### PR TITLE
fix(image-download-service): fix OOM crashes and manifest JSON corrup…

### DIFF
--- a/apps-microservices/image-download-service/Dockerfile
+++ b/apps-microservices/image-download-service/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libjpeg-dev \
     zlib1g-dev \
+    libvips-dev \
+    libwebp-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Installer la lib partagée common-utils

--- a/apps-microservices/image-download-service/app/core/downloader.py
+++ b/apps-microservices/image-download-service/app/core/downloader.py
@@ -219,12 +219,17 @@ class Downloader:
         """
         Appends product metadata to the domain's manifest.json file.
         This manifest will be included in the archive for the BO to update the database.
+        
+        Uses fcntl.flock (LOCK_EX) for exclusive cross-replica locking 
+        and atomic write (temp file + os.replace) to prevent corruption.
         """
         import json
-        import aiofiles
+        import fcntl
+        import tempfile
         
         manifest_dir = f"/app/storage/images/{domain}"
         manifest_path = f"{manifest_dir}/manifest.json"
+        lock_path = f"{manifest_path}.lock"
         
         # Create directory if needed
         os.makedirs(manifest_dir, exist_ok=True)
@@ -258,29 +263,44 @@ class Downloader:
                 "filename": img.get("filename", "")
             })
         
-        # Load existing manifest or create new one
-        manifest = {"products": [], "last_updated": ""}
-        
+        # --- Exclusive lock + atomic write to prevent concurrent corruption ---
         try:
-            if os.path.exists(manifest_path):
-                async with aiofiles.open(manifest_path, 'r') as f:
-                    content = await f.read()
-                    manifest = json.loads(content) if content else {"products": [], "last_updated": ""}
+            with open(lock_path, 'w') as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    # Read existing manifest (under lock)
+                    manifest = {"products": [], "last_updated": ""}
+                    if os.path.exists(manifest_path):
+                        try:
+                            with open(manifest_path, 'r') as f:
+                                content = f.read()
+                                if content.strip():
+                                    manifest = json.loads(content)
+                        except (json.JSONDecodeError, ValueError) as e:
+                            logger.warning(f"Corrupted manifest detected for {domain}, starting fresh: {e}")
+                            manifest = {"products": [], "last_updated": ""}
+                    
+                    # Update or add product entry
+                    existing_idx = next((i for i, p in enumerate(manifest.get("products", [])) if p.get("id_produit") == product_id), None)
+                    if existing_idx is not None:
+                        manifest["products"][existing_idx] = product_entry
+                    else:
+                        manifest.setdefault("products", []).append(product_entry)
+                    
+                    manifest["last_updated"] = datetime.now().isoformat()
+                    
+                    # Write to temp file, then atomic rename
+                    fd, tmp_path = tempfile.mkstemp(dir=manifest_dir, suffix='.tmp')
+                    try:
+                        with os.fdopen(fd, 'w') as tmp_f:
+                            tmp_f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
+                        os.replace(tmp_path, manifest_path)
+                    except Exception:
+                        # Clean up temp file on error
+                        if os.path.exists(tmp_path):
+                            os.unlink(tmp_path)
+                        raise
+                finally:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
         except Exception as e:
-            logger.warning(f"Could not read manifest: {e}")
-        
-        # Update or add product entry
-        existing_idx = next((i for i, p in enumerate(manifest["products"]) if p["id_produit"] == product_id), None)
-        if existing_idx is not None:
-            manifest["products"][existing_idx] = product_entry
-        else:
-            manifest["products"].append(product_entry)
-        
-        manifest["last_updated"] = datetime.now().isoformat()
-        
-        # Write manifest
-        try:
-            async with aiofiles.open(manifest_path, 'w') as f:
-                await f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
-        except Exception as e:
-            logger.error(f"Could not write manifest: {e}")
+            logger.error(f"Could not write manifest for {domain}: {e}")

--- a/apps-microservices/image-download-service/app/core/image_processor.py
+++ b/apps-microservices/image-download-service/app/core/image_processor.py
@@ -1,9 +1,13 @@
 import os
 import io
 from PIL import Image
+import pyvips
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Threshold: above this pixel count, delegate to pyvips for shrink-on-load
+LARGE_IMAGE_THRESHOLD = 50_000_000  # 50M pixels
 
 class ImageProcessor:
     def __init__(self):
@@ -38,23 +42,20 @@ class ImageProcessor:
                 
                 image = Image.open(image_stream)
                 
-                # --- SAFETY CHECK: OOM Protection ---
-                # Increased limit to 200 Million pixels (~600MB) since container has 1GB RAM
-                MAX_PIXELS = 200_000_000 
-                
                 width, height = image.size
                 total_pixels = width * height
+                original_format = image.format.upper() if image.format else "JPEG"
                 
-                if total_pixels > MAX_PIXELS:
-                    logger.warning(f"⛔ Skipping image {product_id}: Too large ({width}x{height} = {total_pixels} px). Limit: {MAX_PIXELS} px.")
-                    return None
+                # --- LARGE IMAGE: Delegate to pyvips (shrink-on-load, ~2-5MB RAM) ---
+                if total_pixels > LARGE_IMAGE_THRESHOLD:
+                    logger.info(f"🔄 Large image detected ({width}x{height} = {total_pixels} px, format={original_format}). Using pyvips shrink-on-load.")
+                    image.close()
+                    return self._process_with_vips(content, original_format, domain, product_id, product_name, base_storage_dir, index)
 
                 # OPTIMIZATION: For JPEGs, we can load a draft (thumbnail) directly
                 if total_pixels > 50_000_000 and image.format == 'JPEG':
                      logger.info(f"⚠️ Large JPEG detected ({width}x{height}). Using draft mode to save RAM.")
                      image.draft('RGB', (800, 800))
-                elif total_pixels > 50_000_000:
-                     logger.info(f"⚠️ Large {image.format} detected ({width}x{height}). Processing with caution (High RAM usage).")
 
                 image.load() # Force load (or load draft)
             except Exception as pil_error:
@@ -99,42 +100,12 @@ class ImageProcessor:
             main_image = image.copy()
             main_image.thumbnail(image_max_size, Image.Resampling.LANCZOS)
             
-            # Create sharded path components
-            product_id_str = str(product_id)
-            if len(product_id_str) < 3:
-                product_id_str = product_id_str.zfill(3)
-                
-            rep1 = product_id_str[-1]
-            rep2 = product_id_str[-2]
-            rep3 = product_id_str[-3]
+            # Build paths
+            paths = self._build_paths(domain, product_id, product_name, base_storage_dir, index, extension)
             
-            # Normalize filename
-            normalized_name = self._normalize_name(product_name)
-            
-            # Suffix with index if provided (e.g., product-123-1.jpg)
-            if index > 0:
-                 filename = f"{normalized_name}-{product_id}-{index}{extension}"
-            else:
-                 if index == 0:
-                      filename = f"{normalized_name}-{product_id}{extension}"
-                 else:
-                      filename = f"{normalized_name}-{product_id}-{index}{extension}"
-            
-            # Define paths
-            # /images/{domain}/produit-2/X/Y/Z/ (Main)
-            main_rel_dir = os.path.join("images", domain, "produit-2", rep1, rep2, rep3)
-            main_full_dir = os.path.join(base_storage_dir, main_rel_dir)
-            
-            # /images/{domain}/produit-3/X/Y/Z/ (Thumbnail)
-            thumb_rel_dir = os.path.join("images", domain, "produit-3", rep1, rep2, rep3)
-            thumb_full_dir = os.path.join(base_storage_dir, thumb_rel_dir)
-            
-            # Create directories
-            os.makedirs(main_full_dir, exist_ok=True)
-            os.makedirs(thumb_full_dir, exist_ok=True)
-            
-            main_file_path = os.path.join(main_full_dir, filename)
-            thumb_file_path = os.path.join(thumb_full_dir, filename)
+            main_file_path = paths["main_file_path"]
+            thumb_file_path = paths["thumb_file_path"]
+            filename = paths["filename"]
             
             # Save Main Image
             save_kwargs = {"optimize": True}
@@ -163,6 +134,119 @@ class ImageProcessor:
         except Exception as e:
             logger.error(f"Error processing image for product {product_id}: {e}")
             raise e
+
+    def _process_with_vips(self, content: bytes, original_format: str, domain: str, product_id: str, product_name: str, base_storage_dir: str, index: int = 0):
+        """
+        Processes large images using pyvips (libvips) with shrink-on-load.
+        Uses streaming decode+resize in a single pass, ~2-5MB RAM regardless of input size.
+        
+        This is used as a fallback for images that would OOM with PIL's full decompression.
+        """
+        try:
+            # Determine output format and extension based on PHP logic
+            if original_format == 'GIF':
+                output_format_suffix = '.gif'
+                extension = '.gif'
+            elif original_format in ('JPEG', 'JPG'):
+                output_format_suffix = '.jpg'
+                extension = '.jpg'
+            elif original_format == 'WEBP':
+                # PHP converts WebP to PNG
+                output_format_suffix = '.png'
+                extension = '.png'
+            else:
+                output_format_suffix = '.png'
+                extension = '.png'
+            
+            # Build paths
+            paths = self._build_paths(domain, product_id, product_name, base_storage_dir, index, extension)
+            
+            main_file_path = paths["main_file_path"]
+            thumb_file_path = paths["thumb_file_path"]
+            filename = paths["filename"]
+
+            # --- Main Image (800x800) using shrink-on-load ---
+            main_vips = pyvips.Image.thumbnail_buffer(content, 800, height=800)
+            
+            if output_format_suffix == '.jpg':
+                main_vips.jpegsave(main_file_path, optimize_coding=True)
+            elif output_format_suffix == '.png':
+                main_vips.pngsave(main_file_path)
+            elif output_format_suffix == '.gif':
+                # pyvips gif support: save as png if gif causes issues
+                main_vips.pngsave(main_file_path)
+            
+            logger.info(f"✅ pyvips: Main image saved for {product_id}: {filename}")
+            
+            # --- Thumbnail (110x110) using shrink-on-load ---
+            thumb_vips = pyvips.Image.thumbnail_buffer(content, 110, height=110)
+            
+            if output_format_suffix == '.jpg':
+                thumb_vips.jpegsave(thumb_file_path, optimize_coding=True)
+            elif output_format_suffix == '.png':
+                thumb_vips.pngsave(thumb_file_path)
+            elif output_format_suffix == '.gif':
+                thumb_vips.pngsave(thumb_file_path)
+            
+            logger.info(f"✅ pyvips: Thumbnail saved for {product_id}: {filename}")
+            
+            return {
+                "main_path": main_file_path,
+                "thumb_path": thumb_file_path,
+                "filename": filename
+            }
+            
+        except Exception as e:
+            logger.error(f"Error processing large image with pyvips for product {product_id}: {e}")
+            raise e
+
+    def _build_paths(self, domain: str, product_id: str, product_name: str, base_storage_dir: str, index: int, extension: str):
+        """
+        Builds the sharded directory paths and filename for a product image.
+        Shared between PIL and pyvips processing paths.
+        """
+        # Create sharded path components
+        product_id_str = str(product_id)
+        if len(product_id_str) < 3:
+            product_id_str = product_id_str.zfill(3)
+            
+        rep1 = product_id_str[-1]
+        rep2 = product_id_str[-2]
+        rep3 = product_id_str[-3]
+        
+        # Normalize filename
+        normalized_name = self._normalize_name(product_name)
+        
+        # Suffix with index if provided (e.g., product-123-1.jpg)
+        if index > 0:
+             filename = f"{normalized_name}-{product_id}-{index}{extension}"
+        else:
+             if index == 0:
+                  filename = f"{normalized_name}-{product_id}{extension}"
+             else:
+                  filename = f"{normalized_name}-{product_id}-{index}{extension}"
+        
+        # Define paths
+        # /images/{domain}/produit-2/X/Y/Z/ (Main)
+        main_rel_dir = os.path.join("images", domain, "produit-2", rep1, rep2, rep3)
+        main_full_dir = os.path.join(base_storage_dir, main_rel_dir)
+        
+        # /images/{domain}/produit-3/X/Y/Z/ (Thumbnail)
+        thumb_rel_dir = os.path.join("images", domain, "produit-3", rep1, rep2, rep3)
+        thumb_full_dir = os.path.join(base_storage_dir, thumb_rel_dir)
+        
+        # Create directories
+        os.makedirs(main_full_dir, exist_ok=True)
+        os.makedirs(thumb_full_dir, exist_ok=True)
+        
+        main_file_path = os.path.join(main_full_dir, filename)
+        thumb_file_path = os.path.join(thumb_full_dir, filename)
+        
+        return {
+            "main_file_path": main_file_path,
+            "thumb_file_path": thumb_file_path,
+            "filename": filename
+        }
 
     def _normalize_name(self, name: str) -> str:
         """

--- a/apps-microservices/image-download-service/requirements.txt
+++ b/apps-microservices/image-download-service/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv
 prometheus-client
 aio-pika
 Pillow
+pyvips


### PR DESCRIPTION
…tion

- Add pyvips shrink-on-load for images >50M pixels to avoid OOM (exit 137) Large WEBP/PNG images are now decoded+resized in streaming mode (~2-5MB RAM) instead of full decompression (~520MB+ for a 13000x10000 image)
- Fix manifest.json corruption from concurrent writes across 20 replicas using fcntl.flock (LOCK_EX) + atomic write (tempfile + os.replace)
- Add libvips-dev, libwebp-dev system deps and pyvips Python package