### PR TITLE
fix(crawler-monitor): add proper WebSocket support in frontend nginx.…

### DIFF
--- a/apps-microservices/crawler-monitor-frontend/nginx.conf
+++ b/apps-microservices/crawler-monitor-frontend/nginx.conf
@@ -1,4 +1,13 @@
 # nginx.conf
+
+# Map conditionnelle : ne positionne "Connection: upgrade" QUE si le header
+# Upgrade est présent (requête WebSocket). Sinon, laisse vide pour les
+# requêtes HTTP normales.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 8099;
     server_name localhost;
@@ -26,13 +35,22 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Proxy pour les requêtes API et WebSocket
+    # Le bloc unique /api gère à la fois les appels REST classiques et le
+    # handshake WebSocket grâce au map $http_upgrade ci-dessus.
     location /api {
         proxy_pass http://crawler-monitor-backend:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+
+        # Timeouts WebSocket : maintient la connexion ouverte
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
     }
 
     # Pour le routage de la Single Page Application


### PR DESCRIPTION
…conf

- Add map directive for conditional Connection header (WebSocket vs HTTP)
- Replace hardcoded 'upgrade' with  variable
- Add missing proxy headers (X-Real-IP, X-Forwarded-For, X-Forwarded-Proto)
- Add WebSocket keepalive timeouts (86400s)

Root cause: external gateway for cmf.hellopro.eu forwards as HTTP/1.0, stripping WebSocket Upgrade headers. This fix ensures the frontend Nginx correctly handles WebSocket once the gateway is also fixed.