### PR TITLE
feat(image-download-service): add GET /domains/unsynced endpoint

### DIFF
--- a/apps-microservices/image-download-service/app/core/archiver.py
+++ b/apps-microservices/image-download-service/app/core/archiver.py
@@ -290,6 +290,36 @@ class Archiver:
         # Sort by most recent first
         return sorted(recent_domains, key=lambda x: x["last_updated"], reverse=True)
 
+    async def get_domains_with_unsynced(self) -> List[Dict]:
+        """Get ALL domains that have at least one unsynced product, regardless of last_updated."""
+        if not os.path.exists(self.images_base):
+            return []
+        
+        domains_with_unsynced = []
+        
+        for domain in os.listdir(self.images_base):
+            domain_path = os.path.join(self.images_base, domain)
+            if not os.path.isdir(domain_path):
+                continue
+            
+            manifest = await self.get_manifest(domain)
+            if not manifest:
+                continue
+            
+            products = manifest.get("products", [])
+            unsynced = sum(1 for p in products if not p.get("synced", False))
+            
+            if unsynced > 0:
+                domains_with_unsynced.append({
+                    "domain": domain,
+                    "last_updated": manifest.get("last_updated"),
+                    "total_products": len(products),
+                    "unsynced_products": unsynced,
+                })
+        
+        # Trier par nombre de non-sync décroissant
+        return sorted(domains_with_unsynced, key=lambda x: x["unsynced_products"], reverse=True)
+
     async def list_archives(self) -> List[Dict]:
         """List all archives with metadata."""
         if not os.path.exists(self.archive_base):

--- a/apps-microservices/image-download-service/app/main.py
+++ b/apps-microservices/image-download-service/app/main.py
@@ -185,6 +185,37 @@ async def get_recent_domains(hours: int = 6):
         "hours_checked": hours
     }
 
+@app.get("/domains/unsynced", tags=["Domains"])
+async def get_unsynced_domains():
+    """
+    Get ALL domains that have at least one unsynced product.
+    Unlike /domains/recent, this has no time filter — it catches everything.
+    Use this endpoint for reliable cron synchronization.
+    
+    **Returns:**
+    - List of domains with unsynced products, sorted by unsynced count (highest first)
+    
+    **Example response:**
+    ```json
+    {
+      "domains": [
+        {
+          "domain": "tech-shop.com",
+          "last_updated": "2026-01-26T08:30:00",
+          "total_products": 150,
+          "unsynced_products": 25
+        }
+      ],
+      "count": 1
+    }
+    ```
+    """
+    domains = await archiver.get_domains_with_unsynced()
+    return {
+        "domains": domains,
+        "count": len(domains),
+    }
+
 @app.get("/domains/{domain}/status", tags=["Domains"])
 async def get_domain_sync_status(domain: str):
     """


### PR DESCRIPTION
Add a new endpoint that returns ALL domains with at least one unsynced product, regardless of last_updated timestamp. This eliminates the time-window dependency that caused products to be missed when the sync cron ran outside the download window.

Changes:
- archiver.py: new get_domains_with_unsynced() method
- main.py: new GET /domains/unsynced endpoint