### PR TITLE
fix(image-download-service): replace fcntl.flock with NFS-safe mkdir …

### DIFF
--- a/apps-microservices/image-download-service/app/core/archiver.py
+++ b/apps-microservices/image-download-service/app/core/archiver.py
@@ -42,12 +42,24 @@ class Archiver:
             return None
 
     async def save_manifest(self, domain: str, manifest: Dict):
-        """Save the manifest for a domain."""
+        """Save the manifest for a domain using NFS-safe locking and atomic write."""
+        import tempfile
+        from image_download_service.core.nfs_lock import nfs_lock
+        
         manifest_path = os.path.join(self.images_base, domain, "manifest.json")
+        manifest_dir = os.path.dirname(manifest_path)
         
         try:
-            async with aiofiles.open(manifest_path, 'w') as f:
-                await f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
+            with nfs_lock(manifest_path):
+                fd, tmp_path = tempfile.mkstemp(dir=manifest_dir, suffix='.tmp')
+                try:
+                    with os.fdopen(fd, 'w') as tmp_f:
+                        tmp_f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
+                    os.replace(tmp_path, manifest_path)
+                except Exception:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
         except Exception as e:
             logger.error(f"Error saving manifest for {domain}: {e}")
 

--- a/apps-microservices/image-download-service/app/core/downloader.py
+++ b/apps-microservices/image-download-service/app/core/downloader.py
@@ -253,19 +253,18 @@ class Downloader:
                          error_reason: str, error_category: str = "unknown", error_severity: str = "error"):
         """
         Save download and processing errors to a dedicated domain errors.json file.
-        Uses fcntl.flock (LOCK_EX) for exclusive cross-replica locking
+        Uses NFS-safe locking (os.mkdir) for exclusive cross-replica locking
         and atomic write (temp file + os.replace) to prevent corruption.
         
         Catégories: no_url, http_client, http_server, timeout, network, processing, dlq
         Sévérités:  warning, error, critical
         """
         import json
-        import fcntl
         import tempfile
+        from image_download_service.core.nfs_lock import nfs_lock
         
         errors_dir = f"/app/storage/images/{domain}"
         errors_path = f"{errors_dir}/errors.json"
-        lock_path = f"{errors_path}.lock"
         
         os.makedirs(errors_dir, exist_ok=True)
         
@@ -280,32 +279,28 @@ class Downloader:
         }
         
         try:
-            with open(lock_path, 'w') as lock_file:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-                try:
-                    errors_list = []
-                    if os.path.exists(errors_path):
-                        try:
-                            with open(errors_path, 'r') as f:
-                                content = f.read()
-                                if content.strip():
-                                    errors_list = json.loads(content)
-                        except (json.JSONDecodeError, ValueError) as e:
-                            logger.warning(f"Corrupted errors file detected for {domain}, starting fresh: {e}")
-                    
-                    errors_list.append(error_entry)
-                    
-                    fd, tmp_path = tempfile.mkstemp(dir=errors_dir, suffix='.tmp')
+            with nfs_lock(errors_path):
+                errors_list = []
+                if os.path.exists(errors_path):
                     try:
-                        with os.fdopen(fd, 'w') as tmp_f:
-                            tmp_f.write(json.dumps(errors_list, indent=2, ensure_ascii=False))
-                        os.replace(tmp_path, errors_path)
-                    except Exception:
-                        if os.path.exists(tmp_path):
-                            os.unlink(tmp_path)
-                        raise
-                finally:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+                        with open(errors_path, 'r') as f:
+                            content = f.read()
+                            if content.strip():
+                                errors_list = json.loads(content)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        logger.warning(f"Corrupted errors file detected for {domain}, starting fresh: {e}")
+                
+                errors_list.append(error_entry)
+                
+                fd, tmp_path = tempfile.mkstemp(dir=errors_dir, suffix='.tmp')
+                try:
+                    with os.fdopen(fd, 'w') as tmp_f:
+                        tmp_f.write(json.dumps(errors_list, indent=2, ensure_ascii=False))
+                    os.replace(tmp_path, errors_path)
+                except Exception:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
         except Exception as e:
             logger.error(f"Could not write error file for {domain}: {e}")
 
@@ -388,16 +383,15 @@ class Downloader:
         Appends product metadata to the domain's manifest.json file.
         This manifest will be included in the archive for the BO to update the database.
         
-        Uses fcntl.flock (LOCK_EX) for exclusive cross-replica locking 
+        Uses NFS-safe locking (os.mkdir) for exclusive cross-replica locking 
         and atomic write (temp file + os.replace) to prevent corruption.
         """
         import json
-        import fcntl
         import tempfile
+        from image_download_service.core.nfs_lock import nfs_lock
         
         manifest_dir = f"/app/storage/images/{domain}"
         manifest_path = f"{manifest_dir}/manifest.json"
-        lock_path = f"{manifest_path}.lock"
         
         # Create directory if needed
         os.makedirs(manifest_dir, exist_ok=True)
@@ -431,44 +425,40 @@ class Downloader:
                 "filename": img.get("filename", "")
             })
         
-        # --- Exclusive lock + atomic write to prevent concurrent corruption ---
+        # --- NFS-safe exclusive lock + atomic write to prevent concurrent corruption ---
         try:
-            with open(lock_path, 'w') as lock_file:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-                try:
-                    # Read existing manifest (under lock)
-                    manifest = {"products": [], "last_updated": ""}
-                    if os.path.exists(manifest_path):
-                        try:
-                            with open(manifest_path, 'r') as f:
-                                content = f.read()
-                                if content.strip():
-                                    manifest = json.loads(content)
-                        except (json.JSONDecodeError, ValueError) as e:
-                            logger.warning(f"Corrupted manifest detected for {domain}, starting fresh: {e}")
-                            manifest = {"products": [], "last_updated": ""}
-                    
-                    # Update or add product entry
-                    existing_idx = next((i for i, p in enumerate(manifest.get("products", [])) if p.get("id_produit") == product_id), None)
-                    if existing_idx is not None:
-                        manifest["products"][existing_idx] = product_entry
-                    else:
-                        manifest.setdefault("products", []).append(product_entry)
-                    
-                    manifest["last_updated"] = datetime.now().isoformat()
-                    
-                    # Write to temp file, then atomic rename
-                    fd, tmp_path = tempfile.mkstemp(dir=manifest_dir, suffix='.tmp')
+            with nfs_lock(manifest_path):
+                # Read existing manifest (under lock)
+                manifest = {"products": [], "last_updated": ""}
+                if os.path.exists(manifest_path):
                     try:
-                        with os.fdopen(fd, 'w') as tmp_f:
-                            tmp_f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
-                        os.replace(tmp_path, manifest_path)
-                    except Exception:
-                        # Clean up temp file on error
-                        if os.path.exists(tmp_path):
-                            os.unlink(tmp_path)
-                        raise
-                finally:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+                        with open(manifest_path, 'r') as f:
+                            content = f.read()
+                            if content.strip():
+                                manifest = json.loads(content)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        logger.warning(f"Corrupted manifest detected for {domain}, starting fresh: {e}")
+                        manifest = {"products": [], "last_updated": ""}
+                
+                # Update or add product entry
+                existing_idx = next((i for i, p in enumerate(manifest.get("products", [])) if p.get("id_produit") == product_id), None)
+                if existing_idx is not None:
+                    manifest["products"][existing_idx] = product_entry
+                else:
+                    manifest.setdefault("products", []).append(product_entry)
+                
+                manifest["last_updated"] = datetime.now().isoformat()
+                
+                # Write to temp file, then atomic rename
+                fd, tmp_path = tempfile.mkstemp(dir=manifest_dir, suffix='.tmp')
+                try:
+                    with os.fdopen(fd, 'w') as tmp_f:
+                        tmp_f.write(json.dumps(manifest, indent=2, ensure_ascii=False))
+                    os.replace(tmp_path, manifest_path)
+                except Exception:
+                    # Clean up temp file on error
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
         except Exception as e:
             logger.error(f"Could not write manifest for {domain}: {e}")

--- a/apps-microservices/image-download-service/app/core/nfs_lock.py
+++ b/apps-microservices/image-download-service/app/core/nfs_lock.py
@@ -1,0 +1,148 @@
+"""
+NFS-safe locking mechanism using os.mkdir() (atomic on NFS).
+
+Unlike fcntl.flock which is process-local and doesn't work across containers
+sharing an NFS volume, os.mkdir() is guaranteed atomic by POSIX — only one
+process succeeds, others get FileExistsError.
+
+Usage:
+    from image_download_service.core.nfs_lock import nfs_lock
+
+    with nfs_lock("/path/to/manifest.json"):
+        # read-modify-write under exclusive lock
+        ...
+"""
+
+import os
+import json
+import time
+import socket
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Lock timeout: if a lock is older than this, consider it stale (seconds)
+STALE_LOCK_TIMEOUT = 60
+
+# Max wait time to acquire lock (seconds)
+MAX_WAIT_TIME = 30
+
+# Retry interval (seconds)
+RETRY_INTERVAL = 0.1
+
+
+class NFSLockError(Exception):
+    """Raised when the lock cannot be acquired within the timeout."""
+    pass
+
+
+class NFSLock:
+    """
+    NFS-safe exclusive lock using os.mkdir().
+    
+    os.mkdir() is atomic on NFS — only one process can create a directory.
+    A stale lock (from a crashed process) is automatically cleaned up
+    after STALE_LOCK_TIMEOUT seconds.
+    """
+    
+    def __init__(self, file_path: str, stale_timeout: int = STALE_LOCK_TIMEOUT, max_wait: int = MAX_WAIT_TIME):
+        self.lock_dir = f"{file_path}.nfslock"
+        self.info_file = os.path.join(self.lock_dir, "info.json")
+        self.stale_timeout = stale_timeout
+        self.max_wait = max_wait
+        self._acquired = False
+    
+    def acquire(self):
+        """Acquire the lock, waiting up to max_wait seconds."""
+        start_time = time.time()
+        
+        while True:
+            try:
+                os.mkdir(self.lock_dir)
+                # Lock acquired — write info for debugging
+                self._write_info()
+                self._acquired = True
+                return
+            except FileExistsError:
+                # Lock exists — check if it's stale
+                if self._is_stale():
+                    logger.warning(f"Removing stale NFS lock: {self.lock_dir}")
+                    self._force_remove()
+                    continue
+                
+                # Check timeout
+                elapsed = time.time() - start_time
+                if elapsed >= self.max_wait:
+                    raise NFSLockError(
+                        f"Could not acquire NFS lock {self.lock_dir} after {self.max_wait}s"
+                    )
+                
+                time.sleep(RETRY_INTERVAL)
+    
+    def release(self):
+        """Release the lock by removing the directory."""
+        if self._acquired:
+            self._force_remove()
+            self._acquired = False
+    
+    def _write_info(self):
+        """Write lock info for debugging and stale detection."""
+        try:
+            info = {
+                "pid": os.getpid(),
+                "hostname": socket.gethostname(),
+                "acquired_at": time.time(),
+                "acquired_at_iso": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            }
+            with open(self.info_file, 'w') as f:
+                json.dump(info, f)
+        except Exception:
+            pass  # Info file is best-effort, don't fail the lock
+    
+    def _is_stale(self) -> bool:
+        """Check if the lock is stale (older than stale_timeout)."""
+        try:
+            # Try reading the info file first
+            if os.path.exists(self.info_file):
+                with open(self.info_file, 'r') as f:
+                    info = json.load(f)
+                acquired_at = info.get("acquired_at", 0)
+                return (time.time() - acquired_at) > self.stale_timeout
+            
+            # No info file — check directory mtime
+            stat = os.stat(self.lock_dir)
+            return (time.time() - stat.st_mtime) > self.stale_timeout
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            # If we can't determine, assume stale to avoid deadlocks
+            return True
+    
+    def _force_remove(self):
+        """Force remove the lock directory and its contents."""
+        try:
+            if os.path.exists(self.info_file):
+                os.unlink(self.info_file)
+            os.rmdir(self.lock_dir)
+        except FileNotFoundError:
+            pass  # Already removed by another process
+        except OSError as e:
+            logger.error(f"Failed to remove NFS lock {self.lock_dir}: {e}")
+    
+    def __enter__(self):
+        self.acquire()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+        return False
+
+
+def nfs_lock(file_path: str, stale_timeout: int = STALE_LOCK_TIMEOUT, max_wait: int = MAX_WAIT_TIME) -> NFSLock:
+    """
+    Convenience function to create an NFSLock context manager.
+    
+    Usage:
+        with nfs_lock("/path/to/manifest.json"):
+            # exclusive access
+            ...
+    """
+    return NFSLock(file_path, stale_timeout, max_wait)


### PR DESCRIPTION
…lock

fcntl.flock is advisory and process-local — it does not work across containers sharing an NFS volume. This caused manifest.json corruption when multiple replicas wrote simultaneously (~80 corrupted domains).

Changes:
- nfs_lock.py: new NFS-safe lock using os.mkdir() (atomic on NFS) with stale lock detection and automatic cleanup
- downloader.py: replace fcntl.flock with nfs_lock in _save_to_manifest() and save_error()
- archiver.py: add nfs_lock + atomic write to save_manifest() (previously had NO lock at all)