### PR TITLE
feat(crawler-monitor-frontend): permanent /callbacks header link with…

### DIFF
--- a/apps-microservices/crawler-monitor-frontend/src/App.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Routes, Route, Link, useNavigate, Navigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-  Activity, AlertCircle, RefreshCw, LogOut, FileText, Globe,
+  Activity, RefreshCw, LogOut, FileText, Globe, Mail,
 } from 'lucide-react';
 import { setOnUnauthorized } from './lib/api';
 import { useCallbacksQuery, useWsInvalidator, queryKeys } from './hooks/queries';
@@ -140,23 +140,33 @@ const App = () => {
             <Activity className="w-8 h-8 text-blue-400" />
             <h1 className="text-xl font-bold text-white">Crawler Dashboard Pro</h1>
           </Link>
-          <div className="flex gap-2">
-            {failedCallbackCount > 0 && (
-              <Link
-                to="/callbacks"
-                className="flex items-center gap-2 px-3 py-1 bg-red-900/50 hover:bg-red-900/70 border border-red-500/30 rounded-lg text-sm transition-colors"
-                title="Voir les callbacks en échec"
-              >
-                <AlertCircle className="w-4 h-4 text-red-400" />
-                <span className="text-red-300">{failedCallbackCount} callback{failedCallbackCount > 1 ? 's' : ''} en échec</span>
-              </Link>
-            )}
+          <div className="flex gap-2 items-center">
             <Link
               to="/domains"
               className="p-2 rounded-md hover:bg-gray-700 transition-colors text-gray-400 hover:text-white"
               title="Domains"
             >
               <Globe className="w-5 h-5" />
+            </Link>
+            <Link
+              to="/callbacks"
+              className={
+                failedCallbackCount > 0
+                  ? 'relative p-2 rounded-md bg-red-900/40 hover:bg-red-900/60 border border-red-500/40 transition-colors text-red-300'
+                  : 'relative p-2 rounded-md hover:bg-gray-700 transition-colors text-gray-400 hover:text-white'
+              }
+              title={
+                failedCallbackCount > 0
+                  ? `${failedCallbackCount} callback${failedCallbackCount > 1 ? 's' : ''} en échec`
+                  : 'Callbacks (aucun en échec)'
+              }
+            >
+              <Mail className="w-5 h-5" />
+              {failedCallbackCount > 0 && (
+                <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 flex items-center justify-center text-[10px] font-bold rounded-full bg-red-500 text-white">
+                  {failedCallbackCount > 99 ? '99+' : failedCallbackCount}
+                </span>
+              )}
             </Link>
             <Link
               to="/audit"


### PR DESCRIPTION
… badge

The /callbacks link only appeared in the header when failedCallbackCount > 0, making the page unreachable from the UI when the list was empty (had to type the URL manually).

Now: a permanent Mail icon button next to /domains and /audit. When there are failures, it gets the alert styling (red bg + border) AND a small numeric badge (top-right corner pill, "99+" cap) for at-a-glance count.

Empty state: same gray icon style as the other nav items, tooltip says "Callbacks (aucun en échec)".

Order in header: Domains -> Callbacks -> Audit -> Refresh -> Logout. Removed the now-unused AlertCircle import.