### PR TITLE
fix(crawler-monitor): stop GET /api/jobs/undefined/details 404 fetches

### DIFF
--- a/apps-microservices/crawler-monitor-backend/server.js
+++ b/apps-microservices/crawler-monitor-backend/server.js
@@ -281,8 +281,14 @@ app.get('/api/jobs', async (req, res) => {
 
     const jobsData = await client.mGet(jobKeys);
     const jobs = jobsData
-      .map(str => str ? JSON.parse(str) : null)
+      .map(str => {
+        if (!str) return null;
+        try { return JSON.parse(str); } catch { return null; }
+      })
       .filter(Boolean)
+      // Skip malformed entries without a crawl_id — they would surface as
+      // id: undefined on the front and trigger /api/jobs/undefined/details 404s.
+      .filter(job => job && typeof job.crawl_id === 'string' && job.crawl_id.length > 0)
       .map(job => ({
         ...job,
         id: job.crawl_id,
@@ -1361,7 +1367,11 @@ async function loadAllJobs(client) {
   const raw = await client.mGet(jobKeys);
   return raw
     .map(s => { try { return s ? JSON.parse(s) : null; } catch { return null; } })
-    .filter(Boolean);
+    .filter(Boolean)
+    // Skip malformed entries without a crawl_id (same hardening as /api/jobs).
+    // Also expose .id for downstream aggregators that read job.id.
+    .filter(job => job && typeof job.crawl_id === 'string' && job.crawl_id.length > 0)
+    .map(job => ({ ...job, id: job.crawl_id }));
 }
 
 // Aggregated stats over a time window (1h | 24h | 7d). Used by the dashboard

--- a/apps-microservices/crawler-monitor-frontend/src/hooks/queries.js
+++ b/apps-microservices/crawler-monitor-frontend/src/hooks/queries.js
@@ -37,11 +37,17 @@ export function useJobsQuery(token, options = {}) {
   });
 }
 
+// A route param can come back as the literal string "undefined" / "null" if
+// a Link/navigate was given a falsy id. Treat those as no-id to avoid firing
+// a doomed GET /api/jobs/undefined/details that always 404s.
+const isValidJobId = (id) =>
+  typeof id === 'string' && id.length > 0 && id !== 'undefined' && id !== 'null';
+
 export function useJobDetailsQuery(token, id, options = {}) {
   return useQuery({
     queryKey: queryKeys.jobDetails(id),
     queryFn: () => api.get(`/jobs/${id}/details`, token),
-    enabled: !!token && !!id,
+    enabled: !!token && isValidJobId(id),
     // job details can change as the crawler runs — slightly shorter staleness
     staleTime: 10 * 1000,
     ...options,

--- a/apps-microservices/crawler-monitor-frontend/src/pages/Overview.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/pages/Overview.jsx
@@ -48,6 +48,9 @@ const Overview = ({ token, replicas }) => {
 
   const filteredJobs = useMemo(() => {
     return allJobs.filter(job => {
+      // Skip malformed entries — protects every onClick / Link from emitting
+      // /jobs/undefined navigations.
+      if (!job || !job.id) return false;
       const jobDate = new Date(job.start_time);
       const start = startDate ? new Date(startDate) : null;
       const end = endDate ? new Date(endDate) : null;
@@ -83,7 +86,12 @@ const Overview = ({ token, replicas }) => {
     return { finished, failed, running, archived, total: filteredJobs.length };
   }, [filteredJobs]);
 
-  const handleSelectJob = (id) => navigate(`/jobs/${id}`);
+  const handleSelectJob = (id) => {
+    // Defensive: never navigate to /jobs/undefined or /jobs/null which would
+    // trigger a 404 fetch loop.
+    if (!id || id === 'undefined' || id === 'null') return;
+    navigate(`/jobs/${id}`);
+  };
 
   // Click on a timeline bucket → narrow the date filters to that bucket
   const handleTimelineBucketClick = ({ from, to }) => {


### PR DESCRIPTION
Symptom in prod (front console):
  GET https://cmf.hellopro.eu/api/jobs/undefined/details 404 (Not Found)

Root cause: at least one Redis crawl_job:* entry has no `crawl_id` field. The /api/jobs endpoint mapped it to { id: undefined, ... }, the front clicked it, navigate(`/jobs/${undefined}`) produced the URL /jobs/undefined, useParams() returned the LITERAL string "undefined", and useJobDetailsQuery fired the doomed request because "undefined" is truthy.

Defense in depth (4 layers):

Backend
- /api/jobs: filter out entries without a string crawl_id BEFORE mapping to id. Also wrapped JSON.parse in a try/catch (was throwing on corrupt entries).
- loadAllJobs (used by /api/system/stats, /api/timeline, /api/domains, /api/alerts): same filter + .map(job => ({ ...job, id: job.crawl_id })) so downstream aggregators see the same shape as /api/jobs.

Frontend
- useJobDetailsQuery.enabled = isValidJobId(id), where isValidJobId rejects undefined, empty, "undefined", and "null" strings. The query stays disabled on bad route params instead of firing.
- Overview.handleSelectJob: no-op on falsy / "undefined" / "null" id, so bad clicks never produce navigation.
- Overview.filteredJobs: drop jobs without a truthy id at the top of the filter pipeline, protecting every JobCard onClick downstream.

Tests cumulated still 66/66 ok.