### PR TITLE
feat(dlq-manager): ajouter filtre since_date au check-urls batch

### DIFF
--- a/apps-microservices/dlq-manager-service/backend/app/api.py
+++ b/apps-microservices/dlq-manager-service/backend/app/api.py
@@ -112,24 +112,24 @@ async def check_url_in_dlq(url: str, es_client: ElasticsearchClient = Depends(ge
 async def check_urls_batch_in_dlq(request: CheckUrlsBatchRequest, es_client: ElasticsearchClient = Depends(get_es_client)):
     """
     Vérifie si une liste d'URLs existe dans les DLQ Elasticsearch.
-    
+
     Args:
-        request: CheckUrlsBatchRequest avec une liste d'URLs
-        
+        request: CheckUrlsBatchRequest avec une liste d'URLs et un since_date optionnel
+
     Returns:
         - results: Dict avec le statut de chaque URL
         - summary: Statistiques globales (total, found, missing)
-    
+
     Exemple d'utilisation:
         POST /api/check-urls
-        Body: {"urls": ["https://example.com/page1", "https://example.com/page2"]}
+        Body: {"urls": ["https://example.com/page1"], "since_date": "2026-04-15T00:00:00"}
     """
     if not request.urls:
         return {
             "results": {},
             "summary": {"total": 0, "found": 0, "missing": 0}
         }
-    return await es_client.check_urls_batch_in_dlq(request.urls)
+    return await es_client.check_urls_batch_in_dlq(request.urls, since_date=request.since_date)
 
 @router.post("/dashboard-stats")
 async def get_dashboard_stats(filters: Optional[Dict[str, Any]] = Body(None), es_client: ElasticsearchClient = Depends(get_es_client)):

--- a/apps-microservices/dlq-manager-service/backend/app/es_client.py
+++ b/apps-microservices/dlq-manager-service/backend/app/es_client.py
@@ -184,10 +184,16 @@ class ElasticsearchClient:
         return response['aggregations']['by_service']['buckets']
 
     @staticmethod
-    def _build_url_query(url: str) -> Dict:
-        """Builds the ES query for matching a URL in DLQ payloads."""
+    def _build_url_query(url: str, since_date: str = None) -> Dict:
+        """Builds the ES query for matching a URL in DLQ payloads.
+
+        Args:
+            url: L'URL à rechercher
+            since_date: Date ISO 8601 minimale (ex: 2026-04-15T00:00:00).
+                        Si fourni, seuls les messages DLQ postérieurs à cette date sont considérés.
+        """
         normalized_url = url.rstrip('/')
-        return {
+        url_match = {
             "bool": {
                 "should": [
                     {"term": {"original_payload.data.url.keyword": url}},
@@ -198,6 +204,18 @@ class ElasticsearchClient:
                     {"match_phrase": {"original_payload.url": url}}
                 ],
                 "minimum_should_match": 1
+            }
+        }
+
+        if not since_date:
+            return url_match
+
+        return {
+            "bool": {
+                "must": [
+                    url_match,
+                    {"range": {"@timestamp": {"gte": since_date}}}
+                ]
             }
         }
 
@@ -246,14 +264,16 @@ class ElasticsearchClient:
             print(f"Erreur lors de la vérification DLQ pour URL {url}: {e}")
             return {"exists": False, "count": 0, "error": str(e)}
 
-    async def check_urls_batch_in_dlq(self, urls: List[str]) -> Dict[str, Any]:
+    async def check_urls_batch_in_dlq(self, urls: List[str], since_date: str = None) -> Dict[str, Any]:
         """
         Vérifie si une liste d'URLs existe dans les DLQ Elasticsearch.
         Utilise msearch pour optimiser les performances.
-        
+
         Args:
             urls: Liste d'URLs à vérifier
-            
+            since_date: Date ISO 8601 minimale (ex: 2026-04-15T00:00:00).
+                        Si fourni, seuls les messages DLQ postérieurs à cette date sont considérés.
+
         Returns:
             Dict avec:
             - results: Dict[url, {exists, count, latest}]
@@ -275,7 +295,7 @@ class ElasticsearchClient:
             search_lines.append({"index": ELASTIC_INDEX_NAME})
 
             # Body de la requête
-            query = self._build_url_query(url)
+            query = self._build_url_query(url, since_date)
             search_lines.append({
                 "query": query,
                 "size": 1,

--- a/apps-microservices/dlq-manager-service/backend/app/models.py
+++ b/apps-microservices/dlq-manager-service/backend/app/models.py
@@ -29,6 +29,7 @@ class ArchiveByFilterRequest(BaseModel):
 class CheckUrlsBatchRequest(BaseModel):
     """Modèle pour la vérification batch d'URLs dans les DLQ."""
     urls: List[str] = Field(max_length=500)
+    since_date: Optional[str] = Field(None, description="Date ISO 8601 minimale pour filtrer les messages DLQ (ex: 2026-04-15T00:00:00). Si absent, aucun filtre date.")
 
 class AutoArchiveRuleCreate(BaseModel):
     name: str


### PR DESCRIPTION
Permet de ne considérer que les messages DLQ postérieurs à une date donnée. Paramètre optionnel since_date (ISO 8601) dans POST /api/check-urls. Si absent, comportement identique à l'existant (rétrocompatible).

Utilisé par le script healing Ecritel pour ignorer les faux positifs historiques (erreurs de services corrigés depuis).