### PR TITLE
fix(opti-moteur-front): UTF-8 encoding sur Typesense import

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/ingestion_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/ingestion_service.py
@@ -82,17 +82,32 @@ def _disk_free_gb(path: str = "/") -> float:
 
 
 def _flush_to_typesense(collection: str, batch: List[str]) -> Tuple[int, int]:
+    """
+    Raw HTTP POST avec encodage UTF-8 explicite.
+    Contourne un bug du client typesense-python 0.21.0 qui utilise latin-1
+    et fait planter les produits contenant ', EUR, bullet, TM, oe, etc.
+    """
     if not batch:
         return 0, 0
-    body = "\n".join(batch)
+    import requests
+    body = "\n".join(batch).encode("utf-8")
+    url = f"{typesense_client.base_url()}/collections/{collection}/documents/import?action=upsert"
     try:
-        res = typesense_client.client.collections[collection].documents.import_(
-            body, {"action": "upsert"}
+        r = requests.post(
+            url,
+            headers={
+                "X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY,
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+            data=body,
+            timeout=300,
         )
+        r.raise_for_status()
+        text = r.text
     except Exception as e:
         logger.warning("Typesense flush error: %s", e)
         return 0, len(batch)
-    return res.count('"success":true'), res.count('"success":false')
+    return text.count('"success":true'), text.count('"success":false')
 
 
 async def ingest_by_category(

--- a/apps-microservices/opti-moteur-front/vm/ingest_by_categories.py
+++ b/apps-microservices/opti-moteur-front/vm/ingest_by_categories.py
@@ -189,16 +189,32 @@ def row_to_doc(row):
 
 
 def ts_flush(jsonl_batch):
-    body = "\n".join(jsonl_batch)
+    """
+    Raw HTTP POST avec encodage UTF-8 explicite.
+    Contourne un bug du client typesense-python 0.21.0 qui utilise latin-1
+    et fait planter les produits contenant ', EUR, bullet, TM, oe, etc.
+    """
+    if not jsonl_batch:
+        return 0, 0
+    body = "\n".join(jsonl_batch).encode("utf-8")
+    url = f"http://{TS_HOST}:{TS_PORT}/collections/{TS_COLLECTION}/documents/import?action=upsert"
     try:
-        res = ts_client.collections[TS_COLLECTION].documents.import_(
-            body, {"action": "upsert"}
+        r = requests.post(
+            url,
+            headers={
+                "X-TYPESENSE-API-KEY": TS_KEY,
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+            data=body,
+            timeout=300,
         )
+        r.raise_for_status()
+        text = r.text
     except Exception as e:
         print(f"\n[WARN] flush error: {e}", file=sys.stderr)
         return 0, len(jsonl_batch)
-    ok = res.count('"success":true')
-    err = res.count('"success":false')
+    ok = text.count('"success":true')
+    err = text.count('"success":false')
     return ok, err
 
 


### PR DESCRIPTION
Le client typesense-python 0.21.0 utilise Latin-1 par defaut pour le body POST de /documents/import, ce qui fait planter TOUS les produits contenant des caracteres francais non-latin1 (apostrophe typographique ', EUR, bullet *, TM, oe, guillemets, etc).

Bypass : utiliser requests.post directement avec body.encode('utf-8') et
Content-Type: text/plain; charset=utf-8.

Impacte :
  - vm/ingest_by_categories.py (ts_flush)
  - app/services/ingestion_service.py (_flush_to_typesense)