### PR TITLE
feat(opti-moteur-front): endpoint /search/text pour integration front…

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/api_router.py
+++ b/apps-microservices/opti-moteur-front/app/router/api_router.py
@@ -2,10 +2,12 @@
 from fastapi import APIRouter
 
 from .search import router as search_router
+from .search_text import router as search_text_router
 from .ingest import router as ingest_router
 from .admin import router as admin_router
 
 api_router = APIRouter()
 api_router.include_router(search_router)
+api_router.include_router(search_text_router)
 api_router.include_router(ingest_router)
 api_router.include_router(admin_router)

--- a/apps-microservices/opti-moteur-front/app/router/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/router/search_text.py
@@ -1,0 +1,60 @@
+"""
+Route POST /search/text : recherche hybride qui prend du TEXTE en entree
+(pas de vecteur), embed via api-embedding-service, puis lance le pipeline
+/search standard.
+
+Fichier independant - ne modifie pas /app/router/search.py ni ses schemas.
+"""
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.search_text import SearchTextRequest
+from app.schemas.search import SearchResponse  # re-use du schema de reponse existant
+from app.services.embedding_client import embed_text
+from app.services.search_service import search as do_search
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/search", tags=["Search Text"])
+
+
+@router.post(
+    "/text",
+    response_model=SearchResponse,
+    summary="Recherche hybride par texte (embed + search en un seul appel)",
+)
+def search_by_text(req: SearchTextRequest):
+    """
+    Endpoint simplifie pour les clients qui ne gerent pas les embeddings
+    (ex: PHP front www.hellopro.fr).
+
+    Pipeline :
+      1. Appel api-embedding-service pour obtenir le vecteur CamemBERT 1024
+      2. Delegue au pipeline /search existant (detection categorie + hybrid + rerank)
+
+    Retourne la meme structure que /search (SearchResponse).
+    """
+    # 1. Embed
+    try:
+        vector = embed_text(req.query)
+    except Exception as e:
+        logger.error("Embedding failed for query=%r: %s", req.query, e)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Embedding service unavailable: {e}",
+        )
+
+    # 2. Search (reutilise le service existant)
+    try:
+        return do_search(
+            query=req.query,
+            query_vector=vector,
+            collection=req.collection,
+            top_k=req.top_k,
+            candidates=req.candidates,
+            apply_filter_by_category=req.apply_filter_by_category,
+        )
+    except Exception as e:
+        logger.error("Search failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -1,0 +1,21 @@
+"""
+Schemas pydantic pour l'endpoint /search/text.
+Distincts de search.py pour ne PAS toucher aux schemas existants.
+"""
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class SearchTextRequest(BaseModel):
+    """
+    Variante de SearchRequest qui n'exige PAS le vecteur en entree.
+    Le vecteur sera calcule en interne via api-embedding-service.
+
+    Cible : integration depuis PHP front ou tout client qui ne gere pas
+    les embeddings.
+    """
+    query: str = Field(..., description="Requete textuelle", examples=["armoire medicale"])
+    collection: Optional[str] = Field(None, description="Collection Typesense (override settings)")
+    top_k: Optional[int] = Field(10, ge=1, le=100, description="Nombre de resultats a retourner")
+    candidates: Optional[int] = Field(50, ge=10, le=200, description="Candidats pour re-rank")
+    apply_filter_by_category: bool = Field(True, description="Applique filter_by si categorie detectee")

--- a/apps-microservices/opti-moteur-front/app/services/embedding_client.py
+++ b/apps-microservices/opti-moteur-front/app/services/embedding_client.py
@@ -1,0 +1,69 @@
+"""
+Client pour api-embedding-service (CamemBERT-large 1024 dims).
+
+Permet a /search/text d'embedder la query sans dependance sur le front PHP.
+
+Config via env var : EMBEDDING_SERVICE_URL
+  - En Docker prod : http://rag-hp-pub-api-embedding-service-1:8555
+  - En standalone  : http://localhost:8555
+"""
+import logging
+import os
+from typing import List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_SERVICE_URL = os.getenv(
+    "EMBEDDING_SERVICE_URL",
+    "http://rag-hp-pub-api-embedding-service-1:8555",
+)
+EMBEDDING_TIMEOUT = int(os.getenv("EMBEDDING_TIMEOUT", "10"))
+
+
+def _extract_vector(resp) -> List[float]:
+    """
+    Tolere plusieurs formats de reponse :
+      - [0.1, 0.2, ...]
+      - {"embedding": [...]}
+      - {"vector": [...]}
+      - {"data": [...]}
+      - {"embeddings": [[...]]}
+    """
+    if isinstance(resp, list):
+        if resp and isinstance(resp[0], list):
+            return resp[0]
+        return resp
+    if isinstance(resp, dict):
+        for key in ("embedding", "vector", "data", "embeddings"):
+            val = resp.get(key)
+            if val is None:
+                continue
+            if isinstance(val, list) and val and isinstance(val[0], list):
+                return val[0]
+            return val
+    raise ValueError(f"Format reponse embedding inconnu : {type(resp)}")
+
+
+def embed_text(text: str, timeout: int = None) -> List[float]:
+    """Appelle api-embedding-service pour obtenir le vecteur d'une query."""
+    if not text or not text.strip():
+        raise ValueError("Le texte a embedder ne peut pas etre vide")
+
+    url = f"{EMBEDDING_SERVICE_URL.rstrip('/')}/embedding"
+    try:
+        r = requests.post(
+            url,
+            json={"text": text},
+            timeout=timeout or EMBEDDING_TIMEOUT,
+        )
+        r.raise_for_status()
+    except requests.RequestException as e:
+        logger.error("Embedding service unavailable at %s: %s", url, e)
+        raise
+    try:
+        data = r.json()
+    except ValueError:
+        raise ValueError(f"Reponse embedding non-JSON : {r.text[:200]}")
+    return _extract_vector(data)


### PR DESCRIPTION
… PHP

Zero modification de l'existant :
  - 3 nouveaux fichiers isoles
  - 2 lignes ajoutees dans api_router.py (import + include) pour exposer la nouvelle route - pattern canonique du repo (cf api-rest-milvus)

Nouveaux fichiers :
  - app/services/embedding_client.py   : client HTTP api-embedding-service
  - app/schemas/search_text.py         : SearchTextRequest (schema distinct)
  - app/router/search_text.py          : route POST /search/text

Pipeline :
  1. Client POST /search/text avec {"query": "armoire medicale"}
  2. /search/text embed la query via api-embedding-service:8555/embedding
  3. Delegue au pipeline existant app.services.search_service.search()
  4. Retourne SearchResponse (meme format que POST /search)

L'endpoint existant POST /search (avec vecteur fourni) est 100% inchange. Utile pour integrer depuis PHP sans gerer les embeddings cote front.

Config : EMBEDDING_SERVICE_URL (env var, default docker container name).