### PR TITLE
fix(mcp-gateway): unique doc_slug for template servers + block direct…

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/api/template_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/template_handlers.go
@@ -357,10 +357,11 @@ func (h *Handler) handleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		HealthStatus:        "healthy",
 		ToolPrefix:          firstNonEmpty(toolPrefixOverride, tpl.ToolPrefix),
 		Icon:                firstNonEmpty(icon, tpl.Icon),
-		// Docs off by default for template-backed servers — admins opt in per
-		// instance by editing the server later. Avoids publishing a public
-		// docs page with a placeholder description for every uploaded SA JSON.
-		DocSlug:   "",
+		// Generate a unique doc_slug so the UNIQUE index on mcp_servers is
+		// satisfied — empty strings would collide on the second row. The
+		// slug is never surfaced: ServerRepo.ListWithDocs, GetByDocSlug and
+		// the docs-admin filter all exclude template-backed servers.
+		DocSlug:   generateDocSlug(tpl.Name+"-"+name, mcpServerID),
 		CreatedBy: auth.UserEmailFromContext(r.Context()),
 	}
 	if err := h.repo.Create(&mcpSrv); err != nil {

--- a/apps-microservices/mcp-gateway-service/internal/repository/server_repo.go
+++ b/apps-microservices/mcp-gateway-service/internal/repository/server_repo.go
@@ -298,11 +298,15 @@ func (r *ServerRepo) ListWithDocs() ([]db.MCPServer, error) {
 	return servers, err
 }
 
-// GetByDocSlug returns a server by its documentation slug.
+// GetByDocSlug returns a server by its documentation slug. Template-backed
+// servers are excluded — they always have a slug (required by the UNIQUE
+// index) but they're never meant to surface docs. Returning them here would
+// let /docs/{guessed-slug} bypass the list filters.
 func (r *ServerRepo) GetByDocSlug(slug string) (*db.MCPServer, error) {
 	var srv db.MCPServer
 	err := r.db.
 		Where("doc_slug = ?", slug).
+		Where("id NOT IN (SELECT mcp_server_id FROM template_instances)").
 		Preload("Tools").
 		First(&srv).Error
 	if err != nil {


### PR DESCRIPTION
… docs URL

Setting doc_slug='' for every template-backed server collided on the UNIQUE index uq_doc_slug the second time the user created an instance (Error 1062 "Duplicate entry '' for key mcp_servers.uq_doc_slug").

Two-part fix:

1. Generate a unique slug via generateDocSlug for the template path — the index constraint is satisfied and the slug stays invisible: the public /docs list (ListWithDocs) and the admin /docs-admin list (exclude_templates=true) already filter template-backed rows out.

2. Extend GetByDocSlug with the same template-backed exclusion so a direct navigation to /docs/{guessed-slug} can't bypass the list filters and surface a template server's docs page.

Longer-term, doc_slug should be nullable so "no docs" is NULL instead of a placeholder. That's a schema + *string refactor across ~10 call sites, deferred.

fix(mcp-gateway): slug unique pour les serveurs de templates + bloque l'URL docs directe