### PR TITLE
fix(templates-runner): patch mcp-gsc get_sitemaps + anchor GA creds path

### DIFF
--- a/apps-microservices/mcp-google-templates-runner/Dockerfile
+++ b/apps-microservices/mcp-google-templates-runner/Dockerfile
@@ -10,6 +10,15 @@ WORKDIR /app
 COPY apps-microservices/mcp-google-templates-runner/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Patch pip-installed mcp-gsc with the fork maintained alongside
+# mcp-google-search-console-service. Fixes:
+#  - get_sitemaps str/int comparison ('>' not supported between 'str' and 'int')
+#  - None coverageState in check_indexing_issues
+# Keeps both the PyPI install (for any transitive deps) and the corrected
+# source file, since import-time behaviour reads from the site-packages path.
+COPY apps-microservices/mcp-google-search-console-service/mcp_gsc/__init__.py \
+     /usr/local/lib/python3.11/site-packages/mcp_gsc/__init__.py
+
 COPY apps-microservices/mcp-google-templates-runner/app /app/app
 COPY apps-microservices/mcp-google-templates-runner/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/apps-microservices/mcp-google-templates-runner/app/supervisor.py
+++ b/apps-microservices/mcp-google-templates-runner/app/supervisor.py
@@ -170,11 +170,18 @@ class Supervisor:
             # execvp which consults PATH), then overlay the template's env.
             # Without PATH, execvp fails with FileNotFoundError even when the
             # binary is installed in /usr/local/bin.
+            #
+            # GOOGLE_APPLICATION_CREDENTIALS is anchored to the canonical
+            # per-instance path AFTER the template env so the runner owns the
+            # value regardless of what the gateway's template row says. This
+            # makes the system resilient to stale default_env strings pointing
+            # at the pre-per-instance-dir flat layout.
             proc_env = {
                 "PATH": os.environ.get("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
                 "HOME": os.environ.get("HOME", "/tmp"),
                 "LANG": os.environ.get("LANG", "C.UTF-8"),
                 **inst.spec.env,
+                "GOOGLE_APPLICATION_CREDENTIALS": self._creds.credential_file_for(inst.instance_id),
             }
             try:
                 proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
Two related fixes for live instance testing:

1. mcp-gsc get_sitemaps raised "'>' not supported between 'str' and 'int'" because the Search Console API returns sitemap warnings/errors as strings while the upstream package compared them to ints. The fork at mcp-google-search-console-service/mcp_gsc/ already has the cast fix; copy that __init__.py over pip's install during docker build. This matches how the standalone GSC service patches the same package.

2. analytics-mcp looks up credentials via GOOGLE_APPLICATION_CREDENTIALS. When a template row stored the pre-dir flat path (/tmp/secrets/{id}.json) the rendered env pointed at a file that the dir-based CredentialsStore never creates. Anchor the env var to the canonical per-instance file path in the Supervisor — template config can no longer drift the path out from under the runner.

fix(templates-runner): corrige get_sitemaps + ancre GOOGLE_APPLICATION_CREDENTIALS