### PR TITLE
fix(opti-moteur-front): augmenter candidat et ajouter pagination

### DIFF
--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -16,6 +16,6 @@ class SearchTextRequest(BaseModel):
     """
     query: str = Field(..., description="Requete textuelle", examples=["armoire medicale"])
     collection: Optional[str] = Field(None, description="Collection Typesense (override settings)")
-    top_k: Optional[int] = Field(10, ge=1, le=100, description="Nombre de resultats a retourner")
-    candidates: Optional[int] = Field(50, ge=10, le=200, description="Candidats pour re-rank")
+    top_k: Optional[int] = Field(10, ge=1, le=500, description="Nombre de resultats a retourner")
+    candidates: Optional[int] = Field(50, ge=10, le=500, description="Candidats pour re-rank")
     apply_filter_by_category: bool = Field(True, description="Applique filter_by si categorie detectee")

--- a/apps-microservices/opti-moteur-front/app/services/embedding_client.py
+++ b/apps-microservices/opti-moteur-front/app/services/embedding_client.py
@@ -25,15 +25,31 @@ EMBEDDING_TIMEOUT = int(os.getenv("EMBEDDING_TIMEOUT", "10"))
 def _extract_vector(resp) -> List[float]:
     """
     Tolere plusieurs formats de reponse :
-      - [0.1, 0.2, ...]
+      - [0.1, 0.2, ...]                            (list de floats)
+      - [[0.1, 0.2, ...]]                          (list de list)
+      - [{"embedding": [...], "text": ..., ...}]   (list de dict chunks, format api-embedding-service HelloPro)
       - {"embedding": [...]}
       - {"vector": [...]}
       - {"data": [...]}
       - {"embeddings": [[...]]}
     """
     if isinstance(resp, list):
-        if resp and isinstance(resp[0], list):
-            return resp[0]
+        if not resp:
+            raise ValueError("Reponse embedding : liste vide")
+        first = resp[0]
+        # list de list -> prendre le premier sous-vecteur
+        if isinstance(first, list):
+            return first
+        # list de dict (format api-embedding-service : [{"embedding": [...], "text": ..., "chunk_id": ...}])
+        if isinstance(first, dict):
+            for key in ("embedding", "vector"):
+                val = first.get(key)
+                if isinstance(val, list):
+                    if val and isinstance(val[0], list):
+                        return val[0]
+                    return val
+            raise ValueError(f"Reponse embedding : dict sans cle embedding/vector. Cles={list(first.keys())}")
+        # list de floats
         return resp
     if isinstance(resp, dict):
         for key in ("embedding", "vector", "data", "embeddings"):
@@ -42,6 +58,12 @@ def _extract_vector(resp) -> List[float]:
                 continue
             if isinstance(val, list) and val and isinstance(val[0], list):
                 return val[0]
+            if isinstance(val, list) and val and isinstance(val[0], dict):
+                # {"data": [{"embedding": [...]}]}
+                for k in ("embedding", "vector"):
+                    v = val[0].get(k)
+                    if isinstance(v, list):
+                        return v
             return val
     raise ValueError(f"Format reponse embedding inconnu : {type(resp)}")
 

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -106,6 +106,15 @@ def search(
     }
 
 
+# Limite Typesense : per_page + k pour hybrid search capped a 250.
+# Au-dela on doit paginer via le parametre `page`.
+_PER_PAGE_CAP = 250
+# Nombre max de pages parallelisees via multi_search (= 4 x 250 = 1000 docs).
+# Couvre les plus grosses categories HelloPro sans exploser la latence
+# (multi_search fait les pages en parallele server-side).
+_MAX_PAGES = 4
+
+
 def _hybrid_typesense_search(
     query: str,
     query_vector: List[float],
@@ -113,14 +122,31 @@ def _hybrid_typesense_search(
     candidates: int,
     filter_cats: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
+    """
+    Recherche hybride paginee pour couvrir jusqu'a `candidates` documents uniques.
+
+    Typesense capse `per_page` et `k` (vector kNN) a 250 pour les recherches
+    hybrides. Pour remonter plus de candidats (utile pour les grosses
+    categories >250 produits, ex. Perceuses a colonne = 587), on envoie
+    plusieurs pages via multi_search (parallelisees server-side).
+
+    Le dedup par id_produit est fait server-side via `group_by` au sein d'une
+    page, puis client-side a travers les pages (un meme id_produit peut
+    apparaitre sur plusieurs pages si ses chunks sont distribues).
+    """
     vec_str = json.dumps(query_vector)
-    params = {
+    per_page = min(max(candidates, 1), _PER_PAGE_CAP)
+    # Nombre de pages necessaires pour couvrir `candidates` docs, cap _MAX_PAGES
+    num_pages = min((candidates + per_page - 1) // per_page, _MAX_PAGES)
+    num_pages = max(num_pages, 1)
+
+    base_params = {
         "collection": collection,
         "q": query,
         "query_by": "nom_produit,categorie,text",
         "query_by_weights": "5,10,1",
-        "vector_query": f"embedding:({vec_str}, k:{candidates})",
-        "per_page": candidates,
+        "vector_query": f"embedding:({vec_str}, k:{per_page})",
+        "per_page": per_page,
         "group_by": "id_produit",
         "group_limit": 1,
         "typo_tokens_threshold": 3,
@@ -128,7 +154,39 @@ def _hybrid_typesense_search(
     }
     if filter_cats:
         escaped = ",".join(f"`{c}`" for c in filter_cats)
-        params["filter_by"] = f"categorie:=[{escaped}]"
+        base_params["filter_by"] = f"categorie:=[{escaped}]"
 
-    res = typesense_client.multi_search({"searches": [params]})
-    return res["results"][0]
+    # Construit N pages, tous en une seule requete multi_search (parallele)
+    searches = []
+    for page in range(1, num_pages + 1):
+        p = dict(base_params)
+        p["page"] = page
+        searches.append(p)
+
+    res = typesense_client.multi_search({"searches": searches})
+    page_results = res.get("results", [])
+
+    # Merge cross-pages avec dedup par id_produit (garde le 1er hit rencontre
+    # = meilleur rang Typesense, car les pages sont ordonnees par pertinence)
+    seen_ids = set()
+    merged_groups = []
+    for page_result in page_results:
+        for g in page_result.get("grouped_hits", []):
+            hits = g.get("hits") or []
+            if not hits:
+                continue
+            id_p = hits[0].get("document", {}).get("id_produit")
+            if not id_p:
+                continue
+            if id_p in seen_ids:
+                continue
+            seen_ids.add(id_p)
+            merged_groups.append(g)
+
+    logger.debug(
+        "_hybrid_typesense_search: %d pages, %d groupes uniques (candidates=%d, filter_cats=%s)",
+        num_pages, len(merged_groups), candidates, filter_cats,
+    )
+
+    # On renvoie la meme structure que l'ancien retour pour ne rien casser en aval
+    return {"grouped_hits": merged_groups}

--- a/apps-microservices/opti-moteur-front/docker-compose.override.yaml
+++ b/apps-microservices/opti-moteur-front/docker-compose.override.yaml
@@ -1,0 +1,20 @@
+# Override local/prod pour opti-moteur-front.
+#
+# Necessaire en prod sur la VM GCP pour que opti-moteur-front puisse resoudre
+# le nom DNS du container api-embedding-service (qui tourne dans le reseau
+# Docker "rag-hp-pub_services-net" du repo principal).
+#
+# - `default` : reseau cree par ce compose (opti-moteur-front_default), ou
+#   tourne typesense-opti-moteur.
+# - `services-net` : reseau externe partage avec les autres microservices du
+#   repo RAG-HP-PUB (api-embedding-service, api-gateway-service, etc.).
+services:
+  opti-moteur-front:
+    networks:
+      - default
+      - services-net
+
+networks:
+  services-net:
+    external: true
+    name: rag-hp-pub_services-net


### PR DESCRIPTION
Limites top_k / candidats (search_text.py)
Le front-end PHP envoie top_k=200 ($nb_prod_max), l'ancienne limite stricte (le=100) générait des erreurs HTTP 422. La limite a été augmentée à le=500 pour top_k et les candidats.

Pagination hybride (search_service.py)
Typesense limite per_page et k (kNN) à 250 pour la recherche hybride.
Les grosses catégories (>250 documents : "Perceuses à colonne" = 587) voyaient leurs produits pertinents tomber hors de la fenêtre de résultats.
Nouveauté : multi_search en parallèle sur un maximum de 4 pages de 250 (soit 1000 candidats uniques max), avec déduplication inter-pages via id_produit.
Latence maîtrisée (les pages sont parallélisées côté serveur).