### PR TITLE
fix(templates): preserve instance ports across runner restarts

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/api/internal_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/internal_handlers.go
@@ -50,14 +50,24 @@ func (h *Handler) handleRunnerSync(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[templates][WARN] runner/sync: template %s missing for instance %s", inst.TemplateSlug, inst.ID)
 			continue
 		}
-		var stdioArgs []string
+		// Always send an empty slice (not nil) — Pydantic's list[str] on the
+		// runner side rejects null with 422.
+		stdioArgs := []string{}
 		if len(tpl.StdioArgs) > 0 {
 			_ = json.Unmarshal(tpl.StdioArgs, &stdioArgs)
+			if stdioArgs == nil {
+				stdioArgs = []string{}
+			}
 		}
 		var extraEnv map[string]string
 		if len(inst.ExtraEnv) > 0 {
 			_ = json.Unmarshal(inst.ExtraEnv, &extraEnv)
 		}
+		// Preferred port hint — pass the last-known port so the runner can try
+		// to reallocate the same one after restart. Without this, the pool
+		// hands out ports in a different order each boot (asyncio.gather is
+		// non-deterministic), and mcp_servers.url ends up pointing at the
+		// wrong port until the gateway rediscovers.
 		out.DesiredInstances = append(out.DesiredInstances, runnerclient.SpawnRequest{
 			InstanceID:      inst.ID,
 			TemplateSlug:    inst.TemplateSlug,
@@ -66,6 +76,7 @@ func (h *Handler) handleRunnerSync(w http.ResponseWriter, r *http.Request) {
 			Env:             renderEnv(tpl.DefaultEnv, extraEnv, inst.ID),
 			CredentialsJSON: string(plain),
 			CredentialsHash: inst.CredentialsHash,
+			RunnerPort:      inst.RunnerPort,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/apps-microservices/mcp-gateway-service/internal/runnerclient/types.go
+++ b/apps-microservices/mcp-gateway-service/internal/runnerclient/types.go
@@ -12,6 +12,11 @@ type SpawnRequest struct {
 	Env             map[string]string `json:"env"`
 	CredentialsJSON string            `json:"credentials_json"` // raw SA JSON
 	CredentialsHash string            `json:"credentials_hash"` // sha256 hex
+	// RunnerPort, when non-nil, is the last-known port the runner used for
+	// this instance. The runner tries to re-allocate the same port so the
+	// gateway's stored mcp_servers.url stays valid across runner restarts.
+	// Nil for fresh POST /admin/instances calls.
+	RunnerPort *int `json:"runner_port,omitempty"`
 }
 
 type SpawnResponse struct {

--- a/apps-microservices/mcp-google-templates-runner/app/models.py
+++ b/apps-microservices/mcp-google-templates-runner/app/models.py
@@ -9,6 +9,9 @@ class SpawnRequest(BaseModel):
     env: dict[str, str] = Field(default_factory=dict, max_length=64)
     credentials_json: str = Field(..., max_length=65536)
     credentials_hash: str = Field(..., min_length=1, max_length=128)
+    # Optional port hint — gateway sends the last-known port on startup sync
+    # so the runner can keep instances on stable ports across restarts.
+    runner_port: int | None = Field(default=None, ge=1024, le=65535)
 
 
 class SpawnResponse(BaseModel):

--- a/apps-microservices/mcp-google-templates-runner/app/port_pool.py
+++ b/apps-microservices/mcp-google-templates-runner/app/port_pool.py
@@ -41,17 +41,34 @@ class PortPool:
         # both the event-loop thread and executor threads (supervisor callbacks).
         self._lock = threading.Lock()
 
-    def allocate(self, probe: bool = True) -> int:
+    def allocate(self, probe: bool = True, preferred: int | None = None) -> int:
         """Return the lowest port in the range that is:
           1. not already handed out by this pool, AND
           2. not currently accepting connections on 127.0.0.1 (unless
              probe=False).
+
+        If ``preferred`` is supplied AND inside the range AND passes both
+        checks, it wins over the sequential scan. This is how startup sync
+        restores stable per-instance ports across runner restarts (the
+        gateway sends the last-known port; the runner tries to reuse it so
+        the mcp_servers.url stored in the DB stays valid).
 
         Skipping externally-busy ports guards against stale pool state after
         an unclean runner restart, and against a foreign process that happens
         to bind a port inside our range.
         """
         with self._lock:
+            # Preferred-port fast path.
+            if preferred is not None and self._start <= preferred <= self._end:
+                if preferred not in self._used:
+                    if not probe or not _port_is_busy(preferred):
+                        self._used.add(preferred)
+                        return preferred
+                    logger.warning(
+                        "port_pool: preferred %d is busy, falling back to sequential",
+                        preferred,
+                    )
+            # Sequential scan (original behaviour).
             for p in range(self._start, self._end + 1):
                 if p in self._used:
                     continue

--- a/apps-microservices/mcp-google-templates-runner/app/supervisor.py
+++ b/apps-microservices/mcp-google-templates-runner/app/supervisor.py
@@ -24,6 +24,11 @@ class SpawnSpec:
     env: dict[str, str]
     credentials_json: str
     credentials_hash: str
+    # Optional last-known port the gateway wants us to reuse. When set AND
+    # still free, the pool returns this port. When set but busy, the pool
+    # falls back to the next free port (the gateway will have to reconcile
+    # the URL on the next health check or rediscover).
+    runner_port: Optional[int] = None
 
 
 @dataclasses.dataclass
@@ -70,7 +75,7 @@ class Supervisor:
             if spec.instance_id in self._instances:
                 # Spawn-on-existing = restart-with-possibly-new-spec
                 await self._kill_locked(spec.instance_id, release_port=False)
-            port = self._pool.allocate()
+            port = self._pool.allocate(preferred=spec.runner_port)
             try:
                 cred_path = self._creds.write(spec.instance_id, spec.credentials_json)
             except Exception:


### PR DESCRIPTION
Rebuilding the runner produced a window where every template-backed mcp_servers row flipped to unhealthy: asyncio.gather over the startup-sync desired_instances list is non-deterministic, so the port pool handed out different ports on each boot. mcp_servers.url stayed pointed at the previous boot's port, the health checker probed the wrong address, and everything went red.

Fix: pass the last-known port as a hint through the sync payload.

- Gateway /api/v1/internal/runner/sync now includes runner_port (from template_instances.runner_port) on every SpawnRequest entry.
- runnerclient.SpawnRequest gains *int RunnerPort (omitempty).
- Runner Pydantic SpawnRequest accepts runner_port (nullable).
- SpawnSpec carries it through to the Supervisor.
- PortPool.allocate(preferred=N) fast-paths the preferred port if it is inside the range, not already handed out, and passes the connect-probe. Falls back to the existing sequential scan otherwise.

Common case (clean restart): every instance keeps its port exactly. Fallback case (preferred busy): instance gets a fresh port and the gateway's next health check reconciles — same as before this patch.

Also fix a nil-slice bug alongside: stdio_args defaulted to nil → JSON null on the wire → Pydantic 422 (already fixed on the create-instance path, this was the same bug on the sync path).

fix(templates): garde les ports stables apres redemarrage du runner