### PR TITLE
feat(mcp-gateway): unify template-backed server filter via mcp_server…

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/types/google.ts
+++ b/apps-microservices/mcp-gateway-frontend/src/types/google.ts
@@ -52,6 +52,10 @@ export interface SheetImportRequest {
   fixed_tool_prefix?: string
   fixed_icon?: string
   disable_documentation?: boolean
+  // Non-empty when the import was launched from the templates catalog
+  // (e.g. custom-http). Stamped on every imported mcp_servers row so the
+  // docs / docs-admin lists can filter template-origin rows uniformly.
+  template_slug?: string
 }
 
 export interface SheetImportResultEntry {

--- a/apps-microservices/mcp-gateway-frontend/src/types/server.ts
+++ b/apps-microservices/mcp-gateway-frontend/src/types/server.ts
@@ -60,6 +60,9 @@ export interface Server {
   doc_slug?: string
   doc_description?: string
   doc_config_guide?: { authType: string; steps: { type?: string; title: string; description: string; link?: string; image?: string }[] }
+  // Non-empty when the server originated from a template flow (stdio
+  // instance or http_batch sheet import). Mirrors the Go backend DTO.
+  template_slug?: string
   created_by?: string
   created_at: string
   updated_at: string

--- a/apps-microservices/mcp-gateway-frontend/src/views/GoogleSheetsImportView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/GoogleSheetsImportView.vue
@@ -275,6 +275,15 @@ function goBack() {
   router.push('/servers')
 }
 
+// Pulled from the URL when the import was launched from the templates
+// catalog (TemplatesView sets ?template_slug=<slug> on http_batch cards).
+// Passed through verbatim to the backend so every imported mcp_servers row
+// carries its template origin for the docs / docs-admin filters.
+const templateSlug = computed<string>(() => {
+  const raw = route.query.template_slug
+  return typeof raw === 'string' ? raw : ''
+})
+
 const stepLabels = ['Sélection', 'Mapping', 'Résultats']
 const checkingConnection = ref(true)
 const googleConnected = ref(false)
@@ -420,6 +429,7 @@ async function handleImport() {
       fixed_tool_prefix: fixedToolPrefix.value || undefined,
       fixed_icon: fixedIcon.value || undefined,
       disable_documentation: !enableDocumentation.value || undefined,
+      template_slug: templateSlug.value || undefined,
     })
     currentStep.value = 2
   } catch (err: unknown) {

--- a/apps-microservices/mcp-gateway-frontend/src/views/TemplatesView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/TemplatesView.vue
@@ -167,10 +167,15 @@ onMounted(() => {
 //   - stdio       → the usual per-template detail view (instance list / create)
 //   - http_batch  → the existing generic Google Sheets server-import flow,
 //                   with ?from=templates so the import view's back-link
-//                   returns here rather than to /servers.
+//                   returns here rather than to /servers, and
+//                   ?template_slug=<slug> so the import request stamps every
+//                   created mcp_servers row with the originating template.
 function templateTarget(template: Template): RouteLocationRaw {
   if (template.kind === 'http_batch') {
-    return { name: 'google-sheets-import', query: { from: 'templates' } }
+    return {
+      name: 'google-sheets-import',
+      query: { from: 'templates', template_slug: template.slug },
+    }
   }
   return { name: 'template-detail', params: { slug: template.slug } }
 }

--- a/apps-microservices/mcp-gateway-service/internal/api/dto.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/dto.go
@@ -84,6 +84,10 @@ type ServerResponse struct {
 	DocSlug        string          `json:"doc_slug,omitempty"`
 	DocDescription string          `json:"doc_description,omitempty"`
 	DocConfigGuide json.RawMessage `json:"doc_config_guide,omitempty"`
+	// TemplateSlug is non-empty when the server originated from a template
+	// flow (stdio instance or http_batch sheet import). The frontend uses it
+	// to badge template-origin rows or hide them from admin views.
+	TemplateSlug        string            `json:"template_slug,omitempty"`
 	CreatedBy           string            `json:"created_by,omitempty"`
 	CreatedAt           time.Time         `json:"created_at"`
 	UpdatedAt           time.Time         `json:"updated_at"`

--- a/apps-microservices/mcp-gateway-service/internal/api/google_dto.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/google_dto.go
@@ -57,6 +57,11 @@ type SheetImportRequest struct {
 	FixedToolPrefix string `json:"fixed_tool_prefix,omitempty"` // Tool prefix applied to all servers (overrides sheet column)
 	FixedIcon            string `json:"fixed_icon,omitempty"`             // Icon applied to all servers (overrides sheet column)
 	DisableDocumentation bool   `json:"disable_documentation,omitempty"` // When true, imported servers have no documentation page
+	// TemplateSlug is set when the import was launched from the templates
+	// catalog (e.g. custom-http). Empty for regular server imports from
+	// /servers/import-google. Stamped on every created mcp_servers row so the
+	// docs / docs-admin filters can exclude these rows uniformly.
+	TemplateSlug string `json:"template_slug,omitempty"`
 }
 
 // SheetImportResultEntry represents the import status of a single row.

--- a/apps-microservices/mcp-gateway-service/internal/api/google_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/google_handlers.go
@@ -705,6 +705,11 @@ func (h *Handler) importSheetRow(r *http.Request, rowNum int, row []string, colI
 		MCPTransport:        "http",
 		DocSlug:             generateDocSlug(name, id),
 		CreatedBy:           userEmail,
+		// TemplateSlug is non-empty only when the caller is the templates
+		// catalog (e.g. custom-http). The regular /servers/import-google
+		// flow leaves this empty so the imported rows show up in the docs
+		// and docs-admin lists as normal servers.
+		TemplateSlug: req.TemplateSlug,
 	}
 
 	// Apply optional mapped fields

--- a/apps-microservices/mcp-gateway-service/internal/api/server_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/server_handlers.go
@@ -298,25 +298,20 @@ func (h *Handler) handleListServers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Opt-in filter used by the docs-admin view: hide servers that are backed
-	// by a template instance. Template catalogs manage their own docs flow, so
-	// exposing template-backed servers in the docs admin would be confusing.
-	if r.URL.Query().Get("exclude_templates") == "true" && h.instanceRepo != nil {
-		if instances, ierr := h.instanceRepo.ListAll(); ierr == nil {
-			templateBacked := make(map[string]struct{}, len(instances))
-			for _, inst := range instances {
-				templateBacked[inst.MCPServerID] = struct{}{}
+	// Opt-in filter used by the docs-admin view: hide servers that originated
+	// from a template (stdio instance OR http_batch sheet import). Template
+	// catalogs manage their own docs flow, so exposing template-origin servers
+	// in the docs admin would be confusing. The filter reads the first-class
+	// template_slug column so both template paths are covered uniformly
+	// without a join against template_instances.
+	if r.URL.Query().Get("exclude_templates") == "true" {
+		filtered := servers[:0]
+		for _, s := range servers {
+			if s.TemplateSlug == "" {
+				filtered = append(filtered, s)
 			}
-			filtered := servers[:0]
-			for _, s := range servers {
-				if _, ok := templateBacked[s.ID]; !ok {
-					filtered = append(filtered, s)
-				}
-			}
-			servers = filtered
-		} else {
-			log.Printf("[api] exclude_templates list instances failed (returning unfiltered): %v", ierr)
 		}
+		servers = filtered
 	}
 
 	resp := ListServersResponse{
@@ -815,6 +810,7 @@ func toServerResponse(srv *db.MCPServer) ServerResponse {
 		DocSlug:             srv.DocSlug,
 		DocDescription:      srv.DocDescription,
 		DocConfigGuide:      srv.DocConfigGuide,
+		TemplateSlug:        srv.TemplateSlug,
 		CreatedBy:           srv.CreatedBy,
 		Tags:                tags,
 		CreatedAt:           srv.CreatedAt,

--- a/apps-microservices/mcp-gateway-service/internal/api/template_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/template_handlers.go
@@ -444,6 +444,10 @@ func (h *Handler) createInstanceFromSpec(
 		HealthStatus:        "healthy",
 		ToolPrefix:          firstNonEmpty(toolPrefixOverride, tpl.ToolPrefix),
 		Icon:                firstNonEmpty(icon, tpl.Icon),
+		// TemplateSlug flags this row as template-origin so ListWithDocs,
+		// GetByDocSlug and the docs-admin exclude_templates filter can all
+		// skip it via a single column predicate.
+		TemplateSlug: tpl.Slug,
 		// Generate a unique doc_slug so the UNIQUE index on mcp_servers is
 		// satisfied — empty strings would collide on the second row. The
 		// slug is never surfaced: ServerRepo.ListWithDocs, GetByDocSlug and

--- a/apps-microservices/mcp-gateway-service/internal/db/models.go
+++ b/apps-microservices/mcp-gateway-service/internal/db/models.go
@@ -31,6 +31,12 @@ type MCPServer struct {
 	// Icon is a URL or path to the server's icon image.
 	Icon string `gorm:"type:varchar(512);not null;default:''" json:"icon"`
 
+	// TemplateSlug links this server to a template catalog row when the server
+	// was created via one of the templates flows (stdio instance or http_batch
+	// sheet import). Empty string means "regular server". Used to filter
+	// template-origin rows out of the docs list and the docs-admin list.
+	TemplateSlug string `gorm:"type:varchar(64);not null;default:'';index:idx_template_slug" json:"template_slug,omitempty"`
+
 	// Documentation fields — used by the public /docs pages.
 	DocSlug        string          `gorm:"type:varchar(128);uniqueIndex:uq_doc_slug" json:"doc_slug,omitempty"`
 	DocDescription string          `gorm:"type:text" json:"doc_description,omitempty"`

--- a/apps-microservices/mcp-gateway-service/internal/repository/server_repo.go
+++ b/apps-microservices/mcp-gateway-service/internal/repository/server_repo.go
@@ -283,16 +283,18 @@ func (r *ServerRepo) EncryptAuthHeaders(srv *db.MCPServer) error {
 }
 
 // ListWithDocs returns all active servers that have a doc_slug set AND are
-// not backed by a template instance. Template-backed servers are excluded
-// from the public docs index even if they somehow have a doc_slug (e.g.
-// legacy rows created before docs were off-by-default for templates) —
-// their documentation lives in the template catalog, not the per-instance
-// docs pages.
+// not backed by a template. Template-backed servers are excluded from the
+// public docs index even if they somehow have a doc_slug (e.g. legacy rows
+// created before docs were off-by-default for templates) — their
+// documentation lives in the template catalog, not the per-instance docs
+// pages. Filtering uses the first-class template_slug column on
+// mcp_servers so both stdio-instance and http_batch-imported rows are
+// covered uniformly.
 func (r *ServerRepo) ListWithDocs() ([]db.MCPServer, error) {
 	var servers []db.MCPServer
 	err := r.db.
 		Where("is_active = ? AND doc_slug != '' AND doc_slug IS NOT NULL", true).
-		Where("id NOT IN (SELECT mcp_server_id FROM template_instances)").
+		Where("template_slug = '' OR template_slug IS NULL").
 		Preload("Tools").
 		Find(&servers).Error
 	return servers, err
@@ -301,12 +303,13 @@ func (r *ServerRepo) ListWithDocs() ([]db.MCPServer, error) {
 // GetByDocSlug returns a server by its documentation slug. Template-backed
 // servers are excluded — they always have a slug (required by the UNIQUE
 // index) but they're never meant to surface docs. Returning them here would
-// let /docs/{guessed-slug} bypass the list filters.
+// let /docs/{guessed-slug} bypass the list filters. The filter mirrors
+// ListWithDocs: any row with a non-empty template_slug is template-origin.
 func (r *ServerRepo) GetByDocSlug(slug string) (*db.MCPServer, error) {
 	var srv db.MCPServer
 	err := r.db.
 		Where("doc_slug = ?", slug).
-		Where("id NOT IN (SELECT mcp_server_id FROM template_instances)").
+		Where("template_slug = '' OR template_slug IS NULL").
 		Preload("Tools").
 		First(&srv).Error
 	if err != nil {

--- a/apps-microservices/mcp-gateway-service/internal/repository/template_repo_test.go
+++ b/apps-microservices/mcp-gateway-service/internal/repository/template_repo_test.go
@@ -55,6 +55,8 @@ func newTemplateTestDB(t *testing.T) *gorm.DB {
 			mcp_transport        TEXT NOT NULL DEFAULT 'http',
 			tool_prefix          TEXT NOT NULL DEFAULT '',
 			icon                 TEXT NOT NULL DEFAULT '',
+			template_slug        TEXT NOT NULL DEFAULT '',
+			doc_slug             TEXT,
 			is_active            INTEGER NOT NULL DEFAULT 1,
 			health_status        TEXT NOT NULL DEFAULT 'unknown',
 			created_by           TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
…s.template_slug column

EN:
- Add a first-class `template_slug` column on mcp_servers (varchar(64), indexed, empty by default). AutoMigrate picks it up on next restart.
- ServerRepo.ListWithDocs and GetByDocSlug now filter with `template_slug = '' OR template_slug IS NULL` instead of the `id NOT IN (SELECT mcp_server_id FROM template_instances)` subquery. This covers both stdio-instance rows AND http_batch sheet imports uniformly (the old filter missed http_batch ones).
- handleListServers (`exclude_templates=true`) now filters in-memory on the column — same blast radius as before, no more instanceRepo join.
- createInstanceFromSpec stamps TemplateSlug = tpl.Slug on every stdio-template server. handleImportFromSheet propagates the new SheetImportRequest.template_slug field to every created row, so the custom-http flow correctly tags imported servers as template-origin.
- ServerResponse DTO surfaces `template_slug` for the frontend. The TypeScript Server + SheetImportRequest interfaces mirror the field.
- TemplatesView.vue passes `?template_slug=<slug>` on http_batch card navigation; GoogleSheetsImportView.vue reads the query param and forwards it to the import request verbatim.

FR:
- Ajout de la colonne `template_slug` sur mcp_servers (varchar(64), indexée, vide par défaut). AutoMigrate l'applique au prochain redémarrage.
- ServerRepo.ListWithDocs et GetByDocSlug filtrent désormais via `template_slug = '' OR template_slug IS NULL` au lieu de la sous- requête `id NOT IN (SELECT mcp_server_id FROM template_instances)`. Cela couvre uniformément les instances stdio ET les imports http_batch (l'ancien filtre ratait ces derniers).
- handleListServers (`exclude_templates=true`) filtre désormais en mémoire sur la colonne — même rayon d'impact qu'avant, sans jointure sur instanceRepo.
- createInstanceFromSpec marque TemplateSlug = tpl.Slug sur chaque serveur de template stdio. handleImportFromSheet propage le nouveau champ SheetImportRequest.template_slug vers chaque ligne créée, pour que le flux custom-http tague correctement les serveurs importés comme étant d'origine template.
- Le DTO ServerResponse expose `template_slug` pour le frontend. Les interfaces TypeScript Server + SheetImportRequest reflètent le champ.
- TemplatesView.vue passe `?template_slug=<slug>` lors de la navigation sur les cartes http_batch ; GoogleSheetsImportView.vue lit le paramètre d'URL et le transmet tel quel à la requête d'import.

Post-deployment (run once on the distant server to backfill existing template-backed rows so the new filter picks them up):

    UPDATE mcp_servers m
    JOIN template_instances ti ON ti.mcp_server_id = m.id
    SET m.template_slug = ti.template_slug
    WHERE m.template_slug = '' OR m.template_slug IS NULL;