### PR TITLE
feat(opti-moteur-front): ingestion batch 2 - 7 sections manquantes

### DIFF
--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -16,6 +16,6 @@ class SearchTextRequest(BaseModel):
     """
     query: str = Field(..., description="Requete textuelle", examples=["armoire medicale"])
     collection: Optional[str] = Field(None, description="Collection Typesense (override settings)")
-    top_k: Optional[int] = Field(10, ge=1, le=500, description="Nombre de resultats a retourner")
-    candidates: Optional[int] = Field(50, ge=10, le=500, description="Candidats pour re-rank")
+    top_k: Optional[int] = Field(10, ge=1, le=2000, description="Nombre de resultats a retourner")
+    candidates: Optional[int] = Field(50, ge=10, le=2000, description="Candidats pour re-rank")
     apply_filter_by_category: bool = Field(True, description="Applique filter_by si categorie detectee")

--- a/rubriques/README_INGESTION_BATCH2.md
+++ b/rubriques/README_INGESTION_BATCH2.md
@@ -1,0 +1,131 @@
+# Ingestion batch 2 — 7 sections restantes
+
+Ce dossier contient les catégories à ingérer pour **compléter la couverture** du
+moteur Typesense avec les 7 sections HelloPro qui manquaient après le POC
+initial (Industrie + Santé, ingérés dans `produits_scale`).
+
+## 📋 Fichiers
+
+| Fichier | Contenu |
+|---|---|
+| `categories_from_roots_2.csv` | **Source** : id, nom, type, depth, parent, nb_produits — 2246 catégories feuilles |
+| `categories_from_roots_2.txt` | **Input pour le script d'ingestion** : 1 nom de catégorie par ligne (déduplique les doublons de noms CSV) |
+
+## 🎯 Couverture ajoutée
+
+7 sections racines (niveau 1) :
+- `1000005` Hydraulique-pneumatique
+- `1000003` Électricité-électronique
+- `1000012` Sécurité
+- `1000013` Logistique
+- `1000011` Génie climatique
+- `9000312` Outillage et fournitures industrielles
+- `1000014` Équipements d'entreprises
+
+**Total estimé : ~317 000 produits** (6× la taille de l'ingestion POC initiale).
+
+## 🚀 Procédure d'ingestion sur la VM
+
+### 1. Pull le repo
+
+```bash
+cd /home/devhp/RAG-HP-PUB
+git pull
+```
+
+### 2. Configurer les variables d'env (Milvus + Typesense)
+
+Le script `vm/ingest_by_categories.py` utilise les mêmes credentials que le
+POC. Charger le `.env` du microservice (ou exporter manuellement) :
+
+```bash
+cd apps-microservices/opti-moteur-front
+
+# Charger les creds depuis le .env du service
+export $(grep -E '^(ZILLIZ_|MILVUS_|TS_)' .env | xargs)
+
+# Renommer pour matcher les noms attendus par le script d'ingestion
+export MILVUS_HOST="$ZILLIZ_URI"
+export MILVUS_PORT="$ZILLIZ_PORT"
+export MILVUS_USER="$ZILLIZ_USER"
+export MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+export MILVUS_COLLECTION="produits_3"
+
+export TS_HOST="localhost"
+export TS_PORT="8108"
+export TS_API_KEY="hp_poc_2026"
+
+# CIBLE : meme collection que l'ingestion POC (= merge additif)
+export TS_COLLECTION="produits_scale"
+```
+
+⚠️ **Important** : cibler la même collection `produits_scale` permet un
+ingest **additif** (les anciens produits Industrie+Santé restent, on ajoute
+les 7 sections par-dessus). L'upsert Typesense dédoublonne naturellement sur
+`id`.
+
+### 3. Lancer l'ingestion (détaché + log)
+
+```bash
+cd /home/devhp/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
+
+# Chemin du fichier texte (depuis la racine du repo)
+export CATEGORIES_FILE=/home/devhp/RAG-HP-PUB/rubriques/categories_from_roots_2.txt
+
+# Lancement detache, log fichier (~70 min estimé pour 317k produits)
+nohup python3 -u ingest_by_categories.py > /tmp/ingest_batch2.log 2>&1 &
+echo "PID: $!"
+```
+
+### 4. Monitoring
+
+```bash
+# Suivre le log en direct
+tail -f /tmp/ingest_batch2.log
+
+# Progression Typesense (nombre total de docs)
+curl -s -H "X-TYPESENSE-API-KEY: hp_poc_2026" \
+  http://localhost:8108/collections/produits_scale \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print("num_documents:", d["num_documents"])'
+
+# Temps CPU/RAM de Typesense
+docker stats --no-stream typesense-opti-moteur
+```
+
+### 5. Validation post-ingest
+
+Une fois terminé, tester quelques queries qui étaient auparavant "ABSENT" :
+
+```bash
+# Armoire de securite (section Securite = 1000012, pas dans POC initial)
+curl -s -X POST http://localhost:8570/search/text \
+  -H "Content-Type: application/json" \
+  -d '{"query":"armoire securite","top_k":5,"candidates":500}' \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print("cat=",d.get("detected_category")," cand=",d.get("total_candidates")); [print(" -",h["nom_produit"][:60]," |",h["categorie"]) for h in d.get("results",[])[:5]]'
+
+# Vestiaire metallique (section Equipements = 1000014)
+curl -s -X POST http://localhost:8570/search/text \
+  -H "Content-Type: application/json" \
+  -d '{"query":"vestiaire metallique","top_k":5,"candidates":500}' \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print("cat=",d.get("detected_category")," cand=",d.get("total_candidates")); [print(" -",h["nom_produit"][:60]," |",h["categorie"]) for h in d.get("results",[])[:5]]'
+
+# Compresseur atelier (section Outillage = 9000312)
+curl -s -X POST http://localhost:8570/search/text \
+  -H "Content-Type: application/json" \
+  -d '{"query":"compresseur air atelier","top_k":5,"candidates":500}' \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print("cat=",d.get("detected_category")," cand=",d.get("total_candidates")); [print(" -",h["nom_produit"][:60]," |",h["categorie"]) for h in d.get("results",[])[:5]]'
+```
+
+Les résultats doivent maintenant être pertinents (catégorie détectée avec
+`conf > 0.8` et produits du bon domaine).
+
+## 🧯 Reprise en cas d'interruption
+
+Si l'ingestion est coupée (Ctrl+C, crash, timeout VM), relance simplement le
+script. L'upsert Typesense re-inscrit les mêmes produits sans effet de bord.
+
+Pour accélérer (ignorer ce qui est déjà ingéré) :
+```bash
+export SKIP_EXISTING=1
+# Relance la meme commande qu'avant
+```

--- a/rubriques/categories_from_roots_2.csv
+++ b/rubriques/categories_from_roots_2.csv
@@ -1,0 +1,2247 @@
+id_rubrique,nom,type,depth,parent,nb_produits
+2016804,"Chaussures de sécurité basses",0,2,9000379,9604
+2015953,"Vêtement réfléchissant",0,2,2007417,7526
+2014864,"Table basse",0,2,9000372,7233
+1001698,"Autres raccords hydrauliques",0,2,1000216,6045
+2016803,"Chaussures de sécurité montantes",0,2,9000379,5784
+1001979,"Vêtements de sécurité basique",0,2,2007417,5427
+2007676,"Canapés lits",0,2,9000372,4404
+2005983,"Verres de table",0,2,9000372,3384
+2015295,"Fauteuil de bureau",0,2,2001558,3363
+2001247,Canapés,0,2,9000372,3221
+1001096,Embrayages,0,2,1000031,3078
+2017183,"Vestes de travail",0,2,2007417,2920
+2014975,"Tee-shirts et polos de travail",0,2,2007417,2707
+2007670,Fauteuils,0,2,9000372,2683
+1001974,"Bottes de sécurité",0,2,9000379,2271
+2000040,"Raccord droit",0,2,1000216,2270
+2008393,"Armoire anti-feu",0,2,2008392,2141
+2005485,"Chaises empilables",0,2,2001558,2128
+2017458,"Rayonnage mi-lourd et lourd",0,2,1000409,1925
+2015734,"Bureau droit",0,2,1000422,1922
+2014730,"Pull et sweat de travail",0,2,2007417,1877
+2008164,"Batterie de démarrage",0,2,1000180,1847
+2015403,"Blousons de travail",0,2,2007417,1774
+2003481,"Abrasifs de ponçage",0,2,1000261,1754
+2004235,"Amortisseurs de choc",0,2,1000033,1716
+1001169,"Pompes centrifuges horizontales",0,2,1000215,1660
+2004041,"Gants de manutention",0,2,9000380,1652
+1001100,"Freins à disque",0,2,1000031,1647
+1001142,Compresseurs,0,2,1000207,1611
+2006034,"Tasses et mugs",0,2,9000372,1600
+2003445,"Chambre froide",0,2,2011825,1581
+2003785,"Servantes d'atelier",0,2,2005495,1562
+2017876,"Panneau routier",0,2,1000384,1561
+2005447,"Tables de réunions",0,2,2001554,1503
+2004047,"Gants de protection",0,2,9000380,1410
+2007221,"Appliques, spots et lampes murales",0,2,2019096,1366
+2014974,"Gilets sans manche",0,2,2007417,1310
+2004042,"Gants anti-coupures",0,2,9000380,1310
+2001021,"Cuves à carburants",0,2,2007627,1277
+2008356,"Ampoules à led",0,2,2019096,1237
+2015802,"Armoire d'atelier",0,2,2005553,1233
+2000908,"Pompes de relevage d'eaux et liquides",0,2,1000215,1232
+1001786,"Ventilateur centrifuge industriel",0,2,1000354,1222
+1001741,"Câbles chauffants",0,2,2010772,1213
+1001783,"Ventilateur hélicoïde industriel",0,2,1000354,1209
+2008035,"Groupe électrogène industriel",0,2,2009366,1205
+2015128,"Pile lithium",0,2,1000180,1204
+2003784,"Caisses et boîtes à outils",0,2,2005495,1176
+2008187,"Batterie industrielle",0,2,1000180,1142
+2007921,"Planches à découper",0,2,9000372,1135
+2005441,"Sièges d'accueil",0,2,2010666,1112
+2002089,Coupleurs,0,2,2002048,1106
+2003706,"Moteurs à courant alternatif",0,2,1000030,1079
+1001990,"Tabliers et chasubles de travail",0,2,2007417,1048
+1001737,"Radiants à infrarouge électriques",0,2,2010744,1038
+2000887,Cadenas,0,2,9000393,1034
+2016190,"Bermuda et short de travail",0,2,2007417,1030
+1002065,"Panneaux de signalisation",0,2,1000384,1020
+2015861,Lit,0,2,9000372,1018
+2003500,Palan,0,2,2007710,992
+2014824,"Bureau d'angle",0,2,1000422,965
+2004134,"Accessoires pour rayonnages",0,2,1000409,944
+1002148,"Diable de manutention",0,2,1000396,944
+2008033,"Groupe électrogène portable",0,2,2009366,922
+2001557,"Banques d'accueil",0,2,2010666,905
+1002172,Crics,0,2,1000401,900
+1001778,"Déshumidificateurs à condensation",0,2,1000360,893
+2001832,"Pompes immergées",0,2,1000215,890
+2006874,"Bac de rétention en plastique rigide",0,2,2018232,866
+2014830,Établis,0,2,2005495,866
+1001706,"Colliers de fixation",0,2,2002048,863
+2005443,"Chaise pliante",0,2,2001558,860
+2015860,Matelas,0,2,9000372,857
+2004126,"Signalisations pour véhicules",0,2,1000384,847
+2014320,"Lunette de chantier",0,2,2007417,845
+2000028,"Scies à ruban",0,2,1000262,836
+2008122,"Onduleurs électriques autonomes",0,2,2007948,830
+2006042,"Étagères de salon",0,2,9000372,817
+9000556,"Roues et roulettes industrielles",0,2,1000397,812
+1002121,"Chariot élévateur",0,2,1000392,810
+2005446,"Tables pliantes",0,2,2001554,793
+2016390,"Cottes de travail",0,2,2007417,790
+2016919,"Table élévatrice",0,2,2007710,790
+2007634,"Cuves à usages divers",0,2,2007627,787
+2014339,"Bureau pour ordinateur",0,2,1000422,781
+1001945,"Coffre-fort de sécurité",0,2,1000375,776
+2009501,"Bureaux de direction",0,2,1000422,773
+2002975,"Poteau de signalisation",0,2,2012827,772
+2017622,"Mobiliers scolaires",0,2,1000422,766
+2007508,"Blouses de travail",0,2,2007417,765
+2007974,"Batteries solaires",0,2,1000180,765
+2017459,"Rayonnage léger",0,2,1000409,761
+2008359,"Plafonniers led",0,2,2019096,734
+1002133,"Gerbeur électrique",0,2,1000395,723
+1001978,"Chaussures de sécurité",0,2,9000379,711
+1001790,"Moteurs de ventilateurs",0,2,2011345,707
+2015805,"Établi avec rangement",0,2,2005495,705
+2008588,"Porte affiche",0,2,2002383,701
+1002002,"Vêtements de sécurité haut risque",0,2,2007417,696
+2007669,Aérotherme,0,2,2007666,684
+2010986,"Générateurs d'air chaud à fioul",0,2,2008685,680
+2013977,"Raccords tournants",0,2,1000216,677
+2015684,"Plancher chauffant",0,2,2010332,677
+2015696,"Huile moteur",0,2,1000032,674
+2015206,"Bouchon de tuyau",0,2,2002048,673
+2005555,"Armoires à portes battantes",0,2,2005553,667
+1001352,"Scies circulaires",0,2,1000262,660
+2002581,"Socles rouleurs",0,2,1000397,654
+1001714,"Vannes et robinets à  papillon",0,2,2011698,650
+2002239,Blocs-tiroirs,0,2,2005198,649
+2007772,"Cartouche filtrante",0,2,2005982,646
+2018630,"Bureau open space",0,2,1000422,641
+1001794,"Clapets anti-retours hydrauliques",0,2,2005982,637
+2003205,"Pinces de levage",0,2,2007710,629
+2016805,"Chaussures de sécurité pour femmes",0,2,9000379,604
+2005721,Mange-debout,0,2,2008987,604
+2005533,"Vestiaires multicases",0,2,9000378,602
+2000869,"Serrure à encastrer",0,2,9000393,602
+2003485,"Sangle d'arrimage",0,2,2005973,601
+2011447,"Lits escamotables",0,2,9000372,600
+2004045,"Gants protection thermique",0,2,9000380,599
+2003498,Treuil,0,2,1000401,592
+2016312,"Lampe torche à led",0,2,2019096,585
+2010672,"Sièges sur poutres",0,2,2010666,581
+2016313,"Spot pour led",0,2,2019096,580
+2004044,"Gants de protection chimique",0,2,9000380,567
+1000656,Multimètres,0,2,9000326,560
+2007207,"Accessoires pour cuves",0,2,2007627,557
+2002848,"Poste à souder professionnel",0,2,1000272,554
+2007630,"Cuves à eau",0,2,2007627,550
+2002151,"Caméras de surveillance",0,2,1000377,546
+2015294,"Siège et chaise d'atelier",0,2,2001558,521
+1002263,"Palette en plastique",0,2,2007619,520
+1002240,"Armoire de sécurité pour produits dangereux",0,2,2008392,517
+1002270,"Caisse-palette en plastique",0,2,2007619,517
+2007946,"Kits panneaux photovoltaïques",0,2,2009368,515
+1001733,"Générateurs d'air chaud à gaz",0,2,2008685,507
+2014230,"Cordon d'alimentation électrique",0,2,1000999,505
+2006838,"Panneaux solaires photovoltaïques",0,2,2009368,504
+2000687,"Poêles à bois",0,2,1000344,501
+1002135,"Transpalette électrique",0,2,1000395,498
+2011286,"Rideaux d'air chaud électriques",0,2,2007666,497
+1002134,"Transpalette manuel",0,2,1000395,497
+1002011,"Casques de chantier",0,2,2007417,491
+2011702,"Vannes et robinetteries à boisseaux",0,2,2011698,487
+2016239,"Pompe électrique",0,2,1000215,487
+2013903,"Joint pour chambre froide",0,2,2011825,486
+2017594,"Ventilateur mobile",0,2,1000354,484
+2014828,"Tabouret de bureau",0,2,2001558,482
+2015057,"Potelets fixes",0,2,2012827,480
+1002142,"Chariots manuels à étagères",0,2,1000396,476
+2016441,"Cuves de transport ",0,2,2007627,475
+2007240,"Pompes hydrauliques auto-amorçantes",0,2,1000215,469
+2006426,"Douchette code-barres",0,2,1000387,468
+2003717,Visseuses,0,2,9000381,467
+2010984,"Générateurs d'air chaud électriques",0,2,2008685,462
+1001704,"Tuyau d'aspiration",0,2,2002048,461
+2014839,"Meuble armoire bas",0,2,2005553,459
+1002072,"Signalisations sécurité travail",0,2,1000384,458
+2007675,"Canapés d'angle",0,2,9000372,457
+2015048,"Batterie pour onduleur",0,2,1000180,452
+2015910,"Lame de scie à ruban",0,2,1000262,449
+2014718,"Connecteur électronique",0,2,1000999,447
+2003517,"Rayonnages et armoires à bacs",0,2,1000409,446
+2016156,"Tampons de bureau",0,2,1000422,446
+2014474,"Accessoire de lampes",0,2,2019096,445
+1001026,"Alimentation à découpage",0,2,2003487,445
+2005185,"Adhésifs de collage",0,2,1000271,439
+2008196,"Chargeurs de batteries industrielles",0,2,1000180,437
+2014796,"Convertisseur de tension",0,2,2007948,437
+2014984,"Chemise de travail",0,2,2007417,430
+2000270,"Scellés de sécurité",0,2,9000393,429
+2005596,"Vannes et robinetteries à boule",0,2,2011698,423
+1001163,"Vérins hydrauliques simple effet",0,2,1000214,413
+1002007,"Matériels antichutes",0,2,2007417,412
+1001730,"Chauffe-eau électriques",0,2,2008684,412
+2007671,"Banquettes de salon",0,2,9000372,410
+2015456,"Tendeur d'arrimage",0,2,2005973,409
+2001946,"Groupe froid",0,2,2011825,407
+2009842,"Sets de tables",0,2,9000372,407
+1001434,"Générateurs de signaux",0,2,2007948,403
+1001113,"Graisses lubrifiantes",0,2,1000032,403
+2001905,"Résistances chauffantes",0,2,2010772,401
+2010725,"Flexibles métalliques",0,2,2002048,398
+1001259,"Ventouses pneumatiques",0,2,2007710,390
+1001727,"Chaudières à gaz",0,2,1000343,387
+2015251,"Scie de table",0,2,1000262,385
+2004150,"Pompe de graissage",0,2,1000032,385
+2016431,"Container aménagé",0,2,1000415,384
+2007382,"Câbles multiconducteurs",0,2,1000999,381
+2003771,"Accessoires de mesures électriques",0,2,9000326,380
+2007885,"Accessoires de masque de protection",0,2,2006800,379
+2009331,Passe-câbles,0,2,1000999,378
+2004378,"Coffrets de distribution",0,2,1000181,377
+2014341,Casier,0,2,2005198,377
+2014601,"Torches de soudage",0,2,1000272,376
+2007949,"Equipements pour panneaux solaires",0,2,2009368,375
+2016434,"Cuve Adblue",0,2,2007627,373
+2011584,"Joints plats",0,2,1000032,372
+2016450,"Bac de rétention pour fût",0,2,2018232,371
+9000270,"Chaîne de levage",0,2,2007710,369
+2012230,"Brides de fixation",0,2,2002048,366
+1001216,"Presses à métaux hydrauliques",0,2,2007887,366
+2007241,"Groupes motopompes",0,2,1000215,361
+1002012,"Casque soudure",0,2,2007417,359
+2001892,"Accessoires pour chaudières",0,2,1000343,352
+2002147,Surpresseur,0,2,9000643,352
+2014712,"Autres types de colle",0,2,1000271,350
+2003464,"Élingues de levage",0,2,2007710,350
+2013867,"Cuves à gasoil rouge (GNR)",0,2,2007627,346
+1001029,"Groupe électrogène pour maison",0,2,2009366,341
+2007568,"Pompes centrifuges verticales",0,2,1000215,340
+2014648,"Climatiseur mobile",0,2,1000351,340
+1001006,Gaines,0,2,1000999,340
+2015632,"Signalisation lumineuse",0,2,9000389,339
+2001395,"Équipements et accessoires pour fibres optiques",0,2,1000999,339
+2003460,"Potence de levage",0,2,2007710,338
+1002156,"Convoyeur à rouleaux",0,2,1000399,334
+2001887,Ventilo-convecteurs,0,2,2010332,334
+2016819,"Vestiaires industrie propre",0,2,9000378,334
+2017365,"Destructeur de papier",0,2,1000422,331
+2008336,"Cloisons de bureaux",0,2,2001553,329
+2019563,"Flexible hydraulique",0,2,2002048,326
+2004561,"Citerne souple",0,2,2007627,322
+2000979,"Cloisons amovibles",0,2,2001553,321
+1001174,"Accessoires pompes hydrauliques",0,2,1000215,321
+2009329,"Colliers serre-câbles",0,2,1000999,319
+2009453,"Container maritime",0,2,1000415,319
+2003491,"Alimentation stabilisée",0,2,2003487,318
+2009283,"Grille de ventilation",0,2,1000356,318
+1002265,"Palette en bois",0,2,2007619,318
+2010667,"Canapés d'accueil",0,2,2010666,318
+2003741,"Balances industrielles",0,2,2000477,318
+1002140,"Roll-containers vertical",0,2,1000396,316
+2002134,"Pompes pneumatiques à membranes",0,2,2001019,316
+2012305,"Cordes de levage",0,2,2007710,315
+2011270,"Armoires à portes coulissantes",0,2,2005553,313
+2003473,"Anneau de levage",0,2,2007710,309
+2016248,"Griffe et crochet de levage",0,2,2007710,307
+2019696,"Projecteur LED portable",0,2,2019096,306
+2016212,"Gobelets en plastique",0,2,2008987,302
+2007753,"Barrière de parking",0,2,2012828,302
+2019450,"Roue à lamelle",0,2,1000261,302
+10607,"Pupitres de conférence",0,2,9000083,301
+2017565,"Eclairage industriel",0,2,2019096,300
+2005232,"Enrouleurs pour tuyaux hydrauliques",0,2,2002048,299
+1001788,"Caisson de ventilation",0,2,1000354,299
+1001362,"Etaux mécaniques",0,2,2012174,292
+1001701,"Gaines flexibles",0,2,2002048,290
+2004621,"Signalisations temporaires",0,2,1000384,288
+2008798,"Pompes à chaleur aérothermiques",0,2,2008795,287
+1001042,"Transformateurs basse tension",0,2,2007948,283
+9000294,"Caisson à roulettes",0,2,2005198,282
+2018794,"Ventilateur Atex",0,2,1000357,282
+1002152,"Convoyeur à bande",0,2,1000399,279
+2002545,Refroidisseurs,0,2,9000320,277
+2015726,Électrovanne,0,2,2011698,276
+2008337,"Cloison acoustique",0,2,2001553,276
+2016429,"Conteneur de stockage",0,2,1000415,276
+2009490,"Régulateur solaire",0,2,1000180,274
+2008367,"Rubans à led",0,2,2019096,274
+1002138,"Chariots manuels conventionnels",0,2,1000396,273
+2004688,"VMC - Ventilation mécanique contrôlée",0,2,1000354,273
+2000481,"Pistolet à colle",0,2,1000271,273
+2018528,"Rampes de chargement pour engins lourds",0,2,2005546,272
+2015986,"Courroie trapézoïdale",0,2,1000031,269
+1002092,"Miroirs de surveillance",0,2,1000072,269
+1002139,"Chariots manuels grillagés",0,2,1000396,266
+1002233,"Rayonnage archive",0,2,1000409,266
+1002097,"Protection d'angle",0,2,9000387,265
+2002137,"Pompes à vide",0,2,2001019,264
+2009024,"Onduleurs photovoltaïques",0,2,2007948,264
+2016065,"Chalumeau & brûleur",0,2,1000272,263
+2016311,"Réglette à led",0,2,2019096,259
+2003371,"Climatiseur professionnel",0,2,1000351,259
+2003021,"Tapis d'accueil",0,2,2010666,257
+2014205,"Fibre optique",0,2,1000999,257
+2015796,"Vanne de régulation",0,2,2011698,256
+1002010,"Bouchons d'oreilles",0,2,2007417,256
+1002130,"Gerbeur manuel",0,2,1000395,255
+2003770,"Marquage au sol pour entrepôt",0,2,2013732,254
+2013904,"Poêles à granulés",0,2,1000344,253
+2014778,Condensateur,0,2,2007948,252
+2005479,"Sièges assis-debouts",0,2,2001558,252
+2019251,"Kit extracteur de roulement",0,2,2012174,251
+2010974,"Vestiaires et porte-manteaux",0,2,2010018,251
+2007736,"Rayonnage de rétention",0,2,1000409,250
+2006873,"Bac de rétention métallique",0,2,2018232,250
+2005561,"Dessertes d'atelier",0,2,2005495,250
+2001890,"Préparateurs d'ecs",0,2,2008684,248
+2004614,"Pistolets à peinture industriels",0,2,2009246,247
+2015730,"Casquette de protection",0,2,2007417,246
+2019216,"Fontaine à eau réseau",0,2,2008987,246
+2017184,"Combinaisons jetables",0,2,2007417,244
+2011287,"Rideaux d'air à eau chaude",0,2,2007666,244
+2014332,"Panneau de chantier",0,2,1000384,242
+2015280,Charnière,0,2,1000033,242
+2018725,"Tuyau de gaz",0,2,2002048,240
+2002885,"Gilets de sécurité",0,2,2007417,239
+2003440,"Destratificateurs d'air",0,2,2010332,239
+2003466,Palonnier,0,2,2007710,238
+2014651,"Climatiseur inverter",0,2,1000351,237
+2017790,"Machine à café de bureau",0,2,2008987,237
+2015983,"Equipement pour armoire",0,2,2005553,237
+2017080,"Tapis d'entrée",0,2,9000372,236
+2015984,"Armoire à rideau pour bureau",0,2,2005553,236
+2009444,"Carte RFID",0,2,2013979,234
+2010212,Motoréducteur,0,2,2010209,232
+2005532,"Vestiaires industrie salissante",0,2,9000378,230
+9000479,"Treuil compact léger",0,2,1000401,226
+2019746,"Destructeur de papier professionnel",0,2,1000422,225
+9000269,"Élingue câble",0,2,1000401,225
+1001164,"Vérins hydrauliques double effet",0,2,1000214,223
+2015450,"Ponceuse à bande",0,2,1000261,223
+2011229,"Thermostats électroniques",0,2,2011225,222
+2013902,"Poignée pour chambre froide",0,2,2011825,222
+1001963,"Dômes de surveillance",0,2,1000377,222
+2007720,"Accessoires pour chariots élévateurs",0,2,1000392,220
+2003027,"Gaines de ventilation",0,2,2010626,220
+2002392,"Terminaux portables",0,2,1000387,219
+2014729,"Scie industrielle",0,2,1000262,215
+2002270,"Générateurs de soudage",0,2,1000272,215
+1002167,Monte-charge,0,2,1000401,215
+2002088,"Autres joints statiques hydrauliques",0,2,1000036,214
+2017457,"Rack à palette",0,2,1000409,213
+2019057,"Extincteur portatif",0,2,1000367,213
+2004713,"Pompes hydrauliques manuelles",0,2,1000215,212
+1000975,"Aimants permanents",0,2,1000174,211
+2010671,"Housse pour roll, chariot, container ou palette",0,2,1000396,211
+2018820,"Chariot porte bac",0,2,1000396,211
+2012694,"Lecteurs RFID",0,2,1000387,210
+2004251,"Radiateurs électriques convecteurs",0,2,2010744,210
+2002577,"Rayonnage cantilever",0,2,1000409,209
+1001005,"Enrouleurs - dérouleurs",0,2,1000999,208
+2019119,"Détendeur de gaz",0,2,2005982,206
+2007780,"Parafoudres - parasurtenseurs",0,2,1000181,206
+2016315,"Projecteur d'extérieur",0,2,2019096,206
+1001872,"Coffres et armoires anti-feu",0,2,2008392,204
+2016440,"Cuve engrais liquide",0,2,2007627,204
+1000659,"Pinces ampèremétriques",0,2,9000326,204
+9000536,"Enrouleur electrique",0,2,1000999,202
+2003423,"Groupes de climatisation & unités extérieures",0,2,1000351,202
+2011700,"Vannes à opercule",0,2,2011698,202
+2013901,"Charnière pour chambre froide",0,2,2011825,201
+2015520,"Accessoires pour passage de câbles",0,2,1000999,201
+2015238,"Meuble classeur",0,2,2005553,200
+1002271,"Caisse-palette métallique",0,2,2007619,198
+2003661,"Lecteurs de badges",0,2,2012829,198
+2003553,"Échangeurs thermiques tubulaires",0,2,2001970,197
+1001887,"Kits d'alarmes",0,2,1000369,195
+2012003,"Turbines de ventilateurs",0,2,2011345,194
+9000586,"Tuyau flexible industriel",0,2,2002048,193
+2015536,Manille,0,2,2007710,193
+2018782,"Pompe atex",0,2,1000215,193
+2016297,"Panneau directionnel",0,2,2002383,192
+2003470,Rafraîchisseur,0,2,9000320,192
+9000049,"Bureau assis debout",0,2,1000422,191
+2016294,"Séparateur d'espace",0,2,2001553,191
+2001909,"Plafond chauffant",0,2,2010332,190
+9000484,"Avertisseur sonore industriel",0,3,9000655,190
+2016483,"Réservoir à vessie",0,2,9000643,189
+2010702,"Siège d'amphithéâtre",0,2,9000083,188
+1001726,"Chaudières à fioul",0,2,1000343,188
+2018102,"Corps de filtre",0,2,2007259,187
+2005285,"Maison connectée ",0,2,2007948,186
+2015068,"Accessoires pour led",0,2,2019096,186
+2018376,"Barrières de sécurité intérieure",0,2,2012828,186
+2009594,"Chariots électriques",0,2,1000396,186
+2019639,"Thermostat d'ambiance",0,2,2011225,185
+2011772,Lève-palette,0,2,1000395,184
+2003316,"Autres chariots",0,2,1000396,184
+2015134,"Équipement du chauffe-eau",0,2,2008684,184
+2014245,"Pied de calage",0,2,1000033,181
+2004330,"Scies à sol",0,2,1000262,181
+2002236,"Chaudière à bois",0,2,1000343,181
+1001170,"Pompes hydrauliques à engrenages",0,2,1000215,181
+2003801,"Armoires de sécurité",0,2,1000375,181
+2005558,"Armoires ouvertes",0,2,2005553,180
+1001376,"Rivets aveugles",0,2,9000381,180
+9000601,"Pièce de tuyauterie",0,2,2002048,180
+2016170,"Boîtier de dérivation",0,2,1000181,179
+1002162,"Bande transporteuse",0,2,1000399,179
+2006429,"Lecteur code-barres fixe",0,2,1000387,178
+1002232,"Entrepôts modulaires de stockage",0,2,1000410,178
+2018814,"Bracelet RFID",0,2,2013979,175
+2010967,"Bac de rétention en plastique souple",0,2,2018232,173
+2018813,"Porte clés et Badge RFID",0,2,2013979,172
+2015832,"Détecteur de tension",0,2,9000326,171
+2007549,"Pompes solaires",0,2,2009368,171
+2001907,Thermoplongeurs,0,2,2011728,171
+2019354,"Palonnier à ventouse",0,2,2007710,171
+2019714,"Ventilateur industriel plafond ",0,2,1000354,170
+2000480,"Plates-formes et bascules de pesage",0,2,2000477,170
+2007261,"Filtres d'eau potable",0,2,2007259,170
+1002572,"Mezzanine industrielle",0,2,1000409,169
+1001119,"Galets de guidage",0,2,1000033,168
+2018915,"Scie à format",0,2,1000262,168
+2017910,"Rafraîchisseur d'air adiabatique",0,2,9000320,168
+2007721,"Aimant de levage",0,2,1000401,167
+2016221,"Chauffage infrarouge à fioul",0,2,2010744,166
+2003325,"Chariots modulables",0,2,1000396,164
+1001040,"Transformateurs de puissance",0,2,2007948,164
+2003390,"Climatiseur multisplit réversible",0,2,1000351,164
+2014143,"Détecteur - capteur de présence",0,2,1000369,164
+2011092,"Radiants à gaz",0,2,2010744,163
+2005540,"Bancs vestiaires",0,2,9000378,163
+9000216,"Cuve IBC",0,2,2007627,163
+2014319,Harnais,0,2,2007417,163
+2005355,"Silo de stockage",0,2,9000637,161
+2010230,"Inserts pour cheminées",0,2,2006083,160
+2004376,"Coffrets de protection",0,2,1000181,160
+2009578,"Interphonie ip",0,2,2012829,160
+2019283,"Alimentation secourue",0,2,2003487,160
+2015202,"Chemin de table",0,2,9000372,160
+2007636,"Cuves à huiles et lubrifiants",0,2,1000032,159
+2008946,"Ballons tampons",0,2,2008684,159
+1002175,"Palettiseurs et dépalettiseurs",0,2,2013732,158
+2002544,"Sécheurs air frigorifiques",0,2,9000385,158
+2017477,"Rayonnages fixes ",0,2,1000409,158
+1002137,"Transpalette peseur",0,2,1000395,158
+2014661,"Chandelle de levage et de calage",0,2,1000401,157
+2016249,"Grue d'atelier",0,2,1000401,157
+2010024,"Émetteurs-récepteurs radio",0,2,2007948,157
+2004137,"Huile hydraulique",0,2,2005982,156
+1001729,"Chauffe-eau solaires",0,2,2008684,155
+2010654,"Télécommande radio industrielle",0,2,2007948,155
+1001808,"Prises d'air - extracteurs d'intérieurs",0,2,1000357,155
+2007751,"Conteneurs de stockage pour produits dangereux",0,2,2008392,154
+2016350,"Barrières mobiles de sécurité",0,2,2012828,154
+2010864,"Rangements pour crèches",0,2,2010018,154
+2018565,"Fauteuil salle de conférence",0,2,9000083,153
+2008397,"Armoires et cages pour bouteilles de gaz",0,2,2008392,153
+2004289,"Chariot porte-palan",0,2,2007710,153
+2002020,"Tourelles de ventilation",0,2,1000357,153
+2011528,"Plaques chauffantes industrielles",0,2,2010332,150
+2001028,"Filtres à tamis",0,2,2005982,150
+2016485,"Trémie de stockage",0,2,9000637,149
+2008941,"Ballons thermodynamiques",0,2,2008684,149
+2014802,"Tableau de planning",0,2,1000422,148
+2015351,"Armoire à outils",0,2,2005553,148
+2008036,"Groupe électrogène en container",0,2,2009366,147
+2016234,"Moteur courant continu",0,2,1000030,147
+9000532,"Radiateur seche-serviettes",0,2,2010744,147
+2001464,"Postes de travail",0,2,1000422,146
+2016328,"Composant de filtre à eau",0,2,2007259,146
+9000096,"Machine à boisson chaude",0,2,2008987,145
+2012328,"Ponceuses industrielles",0,2,1000261,145
+2018489,"Armoire à clé simple ",0,2,1000375,145
+2002013,Brumisateurs,0,2,1000360,143
+2013911,"Matériel de secourisme",0,2,9000392,143
+2003323,"Chariots manuels porte-panneaux",0,2,1000396,142
+2005808,"Compresseur frigorifique",0,2,9000320,142
+1002146,"Tracteur logistique",0,2,1000395,141
+2004248,"Patins rouleurs",0,2,1000397,141
+1001694,"Soupapes de sécurité",0,2,2005982,141
+9000531,"Radiateur électrique à inertie",0,2,2010744,140
+2008861,"Armoires électriques de chantier",0,2,1000181,139
+2007455,"Médias de filtration d'eau",0,2,2007259,139
+2012869,"Réservoir de stockage industriel",0,2,9000637,139
+2019636,"Pompe de transvasement",0,2,1000215,138
+9000272,"Pompe à membrane électrique",0,2,1000215,138
+2007998,"Cloisons mobiles",0,2,2001553,138
+2008482,"Ventouses électro-magnétiques",0,2,1000174,137
+2008596,"Box de rétention",0,2,2018232,136
+2009430,"Tapis antidérapants",0,2,1000386,136
+2004276,"Climatiseurs monoblocs réversibles",0,2,1000351,136
+2014537,"Pompe à piston",0,2,1000215,135
+2009500,"Caillebotis antidérapants",0,2,1000386,135
+2005098,"Convertisseurs dc-dc",0,2,2007948,134
+2009412,"Cordons et lacets pour badges",0,2,1000387,133
+2001016,"Rideaux d'air froid électriques",0,2,2007666,133
+2018527,"Rampe de chargement pliable",0,2,2005546,132
+1001957,"Enregistreur NVR",0,2,1000377,132
+1002136,"Transpalette haute levée",0,2,1000395,131
+2005128,"Régulateurs de tension",0,2,2007948,131
+1002259,"Autres racks de stockage",0,2,1000409,130
+1001731,"Brûleurs pour chaudières",0,2,1000343,130
+2002908,"Positionneur de soudure",0,2,1000272,129
+2003551,"Échangeurs thermiques à plaques",0,2,2001970,128
+2006867,"Filtres à sable",0,2,2007259,127
+2003802,"Armoire électronique de gestion des clefs",0,2,1000375,127
+2017630,"Rayonnages tubulaires",0,2,1000409,127
+2018626,"Robot éducatif",0,2,9000373,127
+2018124,"Radiateurs soufflants",0,2,2010744,127
+2013635,"Équilibreurs de charges",0,2,1000401,127
+2011297,"Portique de levage",0,2,2007710,126
+1001847,"Détecteurs de fumée",0,2,1000364,126
+1002143,"Chariots manuels 2 dossiers",0,2,1000396,126
+1001902,"Lecteurs à claviers",0,2,2012829,125
+1001377,"Inserts mécaniques",0,2,9000381,124
+1002254,"Rehausse palette",0,2,2007619,124
+2002944,"Barrières anti-inondation",0,2,9000390,123
+2014690,"Accessoire pour alarme",0,2,1000369,123
+2018727,"Filtre anti-calcaire",0,2,2007259,123
+1001905,"Terminaux de contrôle d'accès",0,2,2012829,123
+1001779,"Humidificateurs à évaporation",0,2,1000360,122
+2004165,Ohmmètres,0,2,9000326,122
+1001172,"Pompes à lobes",0,2,1000215,122
+2019755,"Groupe d'eau glacée",0,2,9000320,121
+2018248,"Profilé pour chambre froide",0,2,2011825,121
+2018628,"Robot de service",0,2,9000373,121
+2012562,"Accessoires de manipulation",0,2,1000079,121
+2008408,"Plateforme de rétention",0,2,2018232,121
+2003443,"Colles cyanoacrylates",0,2,1000271,120
+2003614,"Hangars de stockage",0,2,1000410,120
+2003525,"Kit camera de surveillance",0,2,1000377,120
+2014585,"Compteur d'eau",0,2,2002048,119
+2018243,"Panneau pour chambre froide",0,2,2011825,119
+2011075,"Pompes doseuses péristaltiques",0,2,2011072,119
+2003322,"Chariots pour charges lourdes",0,2,1000396,118
+2008182,"Batterie pour chariot élévateur",0,2,1000180,118
+2003652,Électro-aimants,0,2,1000174,118
+2019619,"Raccord pour air comprimé",0,2,2002048,118
+2019131,"Potelet à mémoire de forme",0,2,2012827,117
+2003392,"Climatiseurs monoblocs",0,2,1000351,117
+2013941,"Machines pour palettes",0,2,2007619,117
+2015741,"Bracelet d'évènementiel",0,2,2013979,116
+2016466,"Valises de transport matériel et outillage",0,2,2005495,116
+1001158,"Raccords pneumatiques en ligne",0,2,2002048,116
+1001003,"Compteurs électriques",0,2,1000181,116
+2014336,"Autres accessoires pour convoyeur",0,2,1000399,115
+9000501,"Armoire de stockage batterie lithium",0,2,2008392,115
+2003056,"Tracteur pousseur",0,2,1000395,115
+2003412,"Climatiseur split simple",0,2,1000351,114
+2015721,"Bloc autonome d'éclairage de sécurité",0,2,9000389,114
+1002021,"Masque à gaz",0,2,2006800,114
+2014318,"Chaussette de travail",0,2,2007417,114
+2018728,"Chapeau de cheminée",0,2,2006083,114
+2014741,"Outil de graissage",0,2,1000032,113
+2007743,"Tentes et chapiteaux de stockage",0,2,1000410,113
+1002169,"Pont roulant",0,2,2007710,113
+2018564,"Fauteuil de cinéma",0,2,9000083,112
+2016744,"Barrière levante",0,2,2012828,112
+2008223,"Bornes anti-intrusion",0,2,2012827,112
+2005549,"Rampe de quai",0,2,2005546,112
+2015406,"Diffuseur et vaporisateur de parfum professionnel",0,2,9000372,111
+2008217,"Bornes amovibles",0,2,2012827,111
+2008965,"Cloueurs pneumatiques",0,2,9000381,110
+2005942,"Pointeuses - badgeuses",0,2,2010666,110
+2014247,"Vanne hydraulique",0,2,1000036,109
+2012815,"Chaîne de convoyage",0,2,1000399,109
+2014696,"Équipements du radiateur",0,2,2010744,109
+2016082,"Meubles de change",0,2,2010018,109
+2016224,"Buse et aiguille d'application de colle",0,2,1000271,109
+2002026,"Hélices de ventilateurs",0,2,2011345,109
+2002525,"Rayonnages à pneus",0,2,1000409,108
+2017587,"Tourniquets d'accès piétons",0,2,2012830,108
+1001153,"Sécheurs par adsorption",0,2,9000385,107
+2015573,"Écarteurs et ajusteurs de fourche",0,2,1000392,107
+2017027,"Chaudières à granulés",0,2,1000343,107
+2017186,"Combinaisons de protection chimique",0,2,2007417,106
+2007260,"Filtres d'eau de pluie",0,2,2007259,106
+2008220,"Bornes escamotables automatiques",0,2,2012827,105
+2012586,"Basculeurs / retourneurs de bacs et caisses",0,2,9000359,105
+2001779,"Chariots manuels à caisse et bac",0,2,1000396,105
+2000469,"Pompes hydropneumatiques",0,2,1000215,105
+2016746,"Barrière pivotante",0,2,2012828,105
+2002143,"Analyseurs d'énergie et puissance",0,2,9000326,105
+2014328,"Panneau consignes de sécurité",0,2,1000384,104
+2003808,"Transformateurs d'isolement",0,2,2007948,104
+2018990,"Poche filtrante",0,2,2005982,103
+2003896,"Vérins mécaniques",0,2,1000031,103
+1001929,"Logiciels gestion d'accès",0,2,1000373,103
+2003529,"Récepteurs radios",0,2,2007948,103
+2016183,"Équipement de barrière de sécurité",0,2,2012828,103
+2005550,"Niveleur de quai",0,2,2005546,102
+2002493,"Réservoirs d'air comprimé",0,2,1000035,102
+2016050,"Masque à ventilation assistée ",0,2,2006800,102
+2011073,"Pompes doseuses électromagnétiques",0,2,2011072,102
+2018749,"Pompes à peinture",0,2,2009246,102
+2014491,"Brasseur d'air",0,2,1000354,102
+1002289,"Postes informatiques",0,2,1000422,101
+2005238,"Panneau d'information d'entreprise et publicitaire",0,2,2002383,100
+2010841,"Sertisseuses hydrauliques",0,2,9000381,100
+1001685,"Doseur proportionnel",0,2,2011072,100
+2010842,"Sertisseuses électriques",0,2,9000381,100
+2005522,"Élévateur de charge",0,2,1000401,99
+1001089,"Accouplements flexibles",0,2,1000031,98
+2015292,"Manette logistique",0,2,2010578,98
+1001159,"Distributeurs hydrauliques",0,2,1000036,98
+2007750,Urinoirs,0,2,9000374,97
+2003236,"Cartes et badges plastiques pour impression",0,2,2013979,97
+2008231,"Lecteurs biométriques",0,2,2012829,96
+1001858,"Portes coupe-feu",0,2,1000365,96
+2014973,"Toque et charlotte à cheveux",0,2,2007417,96
+2017734,"Déshumidificateurs à adsorption",0,2,1000360,95
+1002141,"Chariots manuels pour bidons et fûts",0,2,1000396,95
+1001121,"Rails de guidage",0,2,1000033,95
+2001792,Telluromètres,0,2,9000326,95
+2006117,"Foyers pour cheminées",0,2,2006083,94
+1001095,Cardans,0,2,1000031,94
+2003351,"Barres anti-panique",0,2,2012828,94
+9000406,"Système de conférence",0,2,9000083,94
+2009431,"Revêtements de sol antidérapants",0,2,1000386,94
+2005274,"Cartes géographiques",0,2,1000422,94
+2009889,"Appareil Respiratoire Isolant ",0,2,2006800,93
+2016367,"Pompes vide-fûts",0,2,9000382,93
+1001686,"Vannes guillotines",0,2,2011698,92
+2008565,"Manchon électrique",0,2,1000999,92
+2014642,"Panneaux rayonnants",0,2,2010332,92
+2003185,Plénums,0,2,1000356,92
+1002531,"Barrière Vauban",0,2,2012828,91
+2010677,"Accessoires et pièces pour chariot de manutention",0,2,1000396,91
+2018482,"Station de désinfection des mains",0,2,2010666,91
+2006461,"Rayonnage polyvalent",0,2,1000409,91
+2014613,Dégrippant,0,2,1000032,90
+2002312,"Mesures de fréquence",0,2,9000326,90
+1002224,"Rayonnages dynamiques",0,2,1000409,90
+2003229,"Engrenages à denture droite",0,2,1000031,90
+2006057,"Scieries mobiles",0,2,1000262,90
+1002157,"Convoyeur aérien",0,2,1000399,90
+2010290,Poêles-cheminées,0,2,2006083,90
+9000453,"Structure métallo-textile",0,2,1000410,89
+2007143,"Lampes à ultra-violets",0,2,2019096,89
+2001061,"Tunnels de stockage",0,2,1000410,89
+1002533,"Portique limiteur de hauteur",0,2,2012828,89
+2000468,"Pompes à vis",0,2,1000215,89
+2007797,"Accessoires pour pompes à chaleur",0,2,2008795,89
+2012583,"Basculeurs / retourneurs de fûts",0,2,9000359,88
+2014576,"Autres pompes hydraulique",0,2,1000215,88
+2016763,"Caillebotis métal",0,2,1000386,88
+2010605,"Filtres pour ventilation",0,2,2010626,88
+1001039,"Transformateurs de courant",0,2,2007948,88
+1002272,"Caisse-palette en bois",0,2,2007619,88
+2018169," Générateurs de vide",0,2,2013732,88
+2002057,Crépines,0,2,2005982,88
+2004113,"Poulies à corde",0,2,1000031,88
+2011284,"Testeurs de batteries",0,2,1000180,88
+2004283,"Chaudières électriques",0,2,1000343,87
+2012382,"Point d'ancrage",0,2,2005973,87
+2005547,"Butoir de quai",0,2,2005546,87
+2015803,"Présentoirs porte-outils",0,2,2005495,86
+2018480,"Borne de distribution de gel intelligente",0,2,2010666,86
+1001785,"Ventilateur tangentiel",0,2,2011345,85
+1001888,"Sirène d'alarme",0,2,1000369,85
+2015535,"Intercalaire pour palettes et caisse-palettes",0,2,2007619,85
+2017423,Thermorégulateurs,0,2,2011641,85
+2009890,"Capteur de courant",0,2,9000326,84
+1001943,"Cloisons grillagées",0,2,1002096,84
+1000849,"Soudeuses fibres optiques",0,2,1000999,84
+2007888,"Presses à métaux manuelles",0,2,2007887,84
+2003444,Évaporateur,0,2,9000320,84
+2001742,"Buses de pulvérisation",0,2,1000216,84
+2014158,"Imprimantes mobiles de reçus",0,2,1000387,84
+2014340,"Table d'atelier",0,2,2001554,84
+2003230,Autotransformateurs,0,2,2007948,83
+2003795,"Chariots pour charges longues",0,2,1000396,83
+2000868,"Serrures électroniques",0,2,9000393,82
+2004333,"Systèmes de mise à la terre",0,2,1000181,82
+1002154,"Convoyeurs / transporteurs à chaînes",0,2,1000399,81
+2016381,"Système de guidage linéaire",0,2,9000590,81
+2018239,"Soufflante d'air",0,2,1000354,81
+2017185,"Combinaisons imperméables",0,2,2007417,81
+2019728,"Tapis anti fatigue",0,2,9000376,80
+2003382,"Climatiseur de cave à vin",0,2,1000351,80
+2007975,"Armoires électriques industrielles",0,2,1000181,80
+2003245,"Rayonnages mobiles",0,2,1000409,80
+2018481,"Borne avec pédale mécanique",0,2,2010666,80
+2010367,"Stations de peinture et de revêtement",0,2,2009246,79
+2009601,"Vérins électriques",0,2,9000590,79
+2016756,"Systèmes d'inspection rayon x pour bagages",0,2,9000391,79
+2015620,"Journal lumineux",0,2,2002383,78
+2002593,"Pompes à entraînement magnétique",0,2,1000215,78
+2002103,"Vannes murales",0,2,2011698,78
+2015265,"Fermeture auto-agrippante",0,2,1000422,77
+2007628,"Cuves à produits chimiques",0,2,2007627,77
+2004758,Dressings,0,2,9000372,77
+1001044,Éolienne,0,2,2009367,77
+2008412,"Armoire phytosanitaire",0,2,2008392,77
+1001061,"Moteurs diesel",0,2,1000030,77
+2004246,"Autres convoyeurs / transporteurs",0,2,1000399,77
+2018394,"Purgeur automatique temporisé",0,2,9000384,76
+2017015,"Porte blindée professionnelle",0,2,2012830,76
+1002264,"Palette en métal",0,2,2007619,76
+2004242,"Ventilateur d'aspiration",0,2,1000354,75
+2018061,"Lève plaque",0,2,2007710,75
+2019008,"Conteneur spécifique",0,2,1000415,75
+2019128,"Chaîne d'arrimage",0,2,2005973,75
+1001837,"Déclencheurs manuels d'alarme",0,2,1000364,74
+2014280,"Colle anaérobie",0,2,1000271,74
+9000674,"Station électrique portable",0,2,2003487,74
+1001386,"Machines de soudure automatique",0,2,1000272,74
+2004019,"Scies à panneaux",0,2,1000262,73
+2018761,"Porte de chambre froide coulissante",0,2,2011825,73
+2003708,Servomoteurs,0,2,1000030,73
+2013828,"Extracteurs pour gaines et conduits",0,2,1000357,73
+1001115,Paliers,0,2,1000033,73
+2010366,"Filtres pour cabines de peinture",0,2,2009246,72
+2017521,"Tambours moteurs ",0,2,1000399,71
+2009325,"Aérateurs d'intérieur",0,2,1000356,71
+2009285,"Grille de reprise",0,2,1000356,71
+2001914,"Thermostats à bulbe",0,2,2011225,71
+2012556,"Manipulateurs pour panneaux et vitres",0,2,1000079,71
+2014753,"Climatiseur split réversible",0,2,1000351,71
+2010987,"Générateurs d'air chaud à bois",0,2,2008685,71
+2008228,"Potelet rabattable",0,2,2012827,71
+2017912,"Abris de stockage",0,2,1000410,71
+2000698,"Centrales de conditionnement d'air",0,2,1000351,71
+2003188,"Pompes doseuses électroniques",0,2,2011072,70
+1001899,"Accessoires d'identification",0,2,2012829,70
+9000535,"Derouleur de cables pour touret",0,2,1000999,70
+2007392,"Pompes de relevage de condensat",0,2,1000215,70
+2019164,"Vérin de fosse",0,2,1000401,69
+2019729,"Tapis antistatique",0,2,2004130,69
+2012557,"Manipulateurs pour fûts",0,2,1000079,69
+2010859,"Lits pour crèches",0,2,2010018,69
+2018409,"Capteur de débit d'air comprimé",0,2,9000383,68
+2003884,"Système de pesage embarqué",0,2,2000477,68
+2007701,"Élévateur à godets",0,2,1000401,68
+2003184,"Pompes hydrauliques péristaltiques",0,2,1000215,67
+2007988,"Téléphones mobiles pti",0,2,1000073,67
+1001856,"Accessoires coupe-feu",0,2,1000365,67
+1002230,"Armoires industrielles de stockage",0,2,1000409,67
+2019697,"Projecteur LED solaire",0,2,2019096,67
+2010823,Ouvre-lettres,0,2,9000377,67
+2015572,"Rallonges de fourche",0,2,1000392,67
+2019527,"Multiplicateur de pression pneumatique",0,2,1000035,67
+2018709,"Serrure connectée",0,2,9000393,66
+2010781,"Enregistreurs paramètres électriques",0,2,9000326,66
+2002719,"Systèmes de filtrations",0,2,1000217,65
+1001796,"Grille de soufflage",0,2,1000356,65
+1002127,"Véhicules à guidage automatique (AGV)",0,2,1000397,65
+1001130,"Ressorts de compression",0,2,1000033,65
+2005316,"Rideau métallique",0,2,2012830,64
+1001767,"Gaz frigorigène et fluide",0,2,9000320,64
+2002133,"Autres pompes pneumatiques",0,2,2001019,64
+2008739,"Afficheurs numériques",0,2,2002383,64
+2019398,Téflon,0,2,1000036,64
+2015555,"Miroir d'inspection",0,2,1000072,64
+2001910,"Cartouches chauffantes",0,2,2010772,64
+2018828,"Pistolet à huile",0,2,1000032,63
+2013423,"Trépied pour palan et tripode de levage",0,2,1000401,63
+1001189,Déshuileurs,0,2,1000036,63
+1001178,"Filtres auto-nettoyants",0,2,1000217,63
+9000196,"Ponceuse de chants",0,2,1000261,63
+2015033,Pupitre,0,2,1000422,63
+1001079,"Pignons et crémaillères",0,2,1000031,63
+9000123,"Fond bombé de cuve",0,2,2007627,63
+2015804,"Chariot de manutention",0,2,2005495,62
+2017925,"Chariots pour tables",0,2,1000396,62
+2003379,"Climatiseurs solaires",0,2,1000351,62
+1002241,"Postes de soutirage",0,2,2018232,62
+9000295,"Chaise et fauteuil pour enfant",0,2,2010018,62
+2018250,"Plinthe pour chambre froide",0,2,2011825,62
+2008222,"Accessoires pour bornes",0,2,2012827,61
+2005110,"Afficheurs lumineux industriels",0,2,2002383,61
+2016242,"Equipement pour rack de stockage",0,2,1000409,61
+2008750,"Housses de chaises",0,2,9000372,61
+1002287,"Logiciels de gestion d'étiquetage",0,2,1000083,61
+1001155,"Vérins pneumatiques double effet",0,2,1000214,61
+2016757,"Butoirs en caoutchouc",0,2,9000387,61
+2018740,"Table de soudure",0,2,1000272,61
+2007158,"Réserves d'eau anti incendie",0,2,1000367,61
+2016969,"Aspirateurs de fumées de soudage",0,2,1000272,60
+2019171,"Ligne d'assemblage",0,2,9000381,60
+2010369,"Agitateurs pour peinture",0,2,2009246,60
+2019509,"Conteneur Frigorifique",0,2,1000415,60
+2018526,"Rampe d'accès pour conteneur",0,2,2005546,60
+2003089,"Générateur de brouillard",0,2,1000369,59
+2014986,"Mannequin de secourisme",0,2,9000392,59
+2003941,"Renvoi d'angle",0,2,2010209,59
+9000273,"Radiateur et chauffage infrarouge lointain",0,2,2010744,59
+2018999,"Rouleau antidérapant",0,2,1000386,59
+9000656,"avertisseur sonore et lumineux",0,3,9000655,59
+2009028,"Mise sous plis",0,2,9000377,59
+2014242,"Additif à essence",0,2,1000032,59
+2011565,"Barrière à chaîne",0,2,2012828,59
+2005604,"Générateur de vapeur",0,2,2008685,58
+2004029,"Rouleaux motorisés",0,2,1000399,58
+1001916,"Barrières infrarouges périmétriques",0,2,1000369,58
+2015173,"Attache pour badges",0,2,1000387,58
+2001859,"Autres moteurs électriques",0,2,1000030,58
+2018742,"Décapeur laser",0,2,2009246,58
+2003156,"Grilles de protection d'entrée",0,2,2012830,58
+2015990,Potentiomètre,0,2,1000181,57
+2005545,"Sas pour quai",0,2,2005546,57
+2011091,"Tubes radiants à gaz",0,2,2010744,57
+2002695,"Butoirs divers",0,2,9000387,57
+2007629,"Citerne à gaz",0,2,2007627,57
+9000160,"Base roulante",0,2,1000396,57
+2013441,"Barrières de rétention d'eaux d'incendie",0,2,1000367,56
+2005186,"Colles époxydes",0,2,1000271,56
+2014315,"Moniteurs de vidéosurveillance",0,2,1000377,56
+1001818,"Filtres à poches",0,2,2005982,56
+2011647,"Coffrets de régulation de température",0,2,2011641,55
+9000017,"Projecteur gobo",0,2,2019096,55
+2015447,"Protège sol",0,2,9000376,55
+1001255,"Autres manipulateurs",0,2,1000079,55
+2018145,"Électroaimant de levage",0,2,1000401,55
+2011791,"Climatiseurs de véhicules",0,2,1000351,54
+1002237,"Stockeur rotatif",0,2,1000411,54
+2007735,"Accessoires pour le stockage de produits dangereux",0,2,2008392,54
+2007553,"Chevalets de manutention",0,2,1000397,54
+2018664,"Engrenage conique",0,2,1000031,54
+9000166,"Bloc béton anti-intrusion",0,2,2012828,54
+1002153,"Convoyeurs / transporteurs élévateurs",0,2,1000399,54
+2008221,"Bornes escamotables manuelles",0,2,2012827,54
+1001200,"Postes de découpe à plasma",0,2,1000272,54
+2018434,"Programmateur de clé voiture",0,2,1000999,54
+2002014,"Plots anti-vibratiles",0,2,1000033,53
+2016696,"Pompes à épreuves",0,2,2001019,53
+2011280,"Armoires pour armes",0,2,1000375,53
+2015756,"Sacs et enveloppes pour transport de fonds",0,1,1000012,52
+9000215,"Spreader pour conteneur",0,2,1000079,52
+2004110,"Poulies dentées ou crantées",0,2,1000031,52
+9000025,"Distributeur d'huile",0,2,1000032,52
+2004168,"Pompes hautes pressions",0,2,1000215,52
+2008181,"Bâches et housses pour palettes",0,2,2007619,52
+1001692,"Disques de rupture",0,2,2005982,52
+2018873,"Barrière de protection piéton",0,2,2012828,51
+2015038,"Accessoire de groupe électrogène",0,2,2009366,51
+2001793,"Vis d'archimède de convoyage",0,2,1000399,51
+2014700,"Chariot pour courrier",0,2,2005198,51
+2014335,"Coin roulant",0,2,1000397,51
+2014609,"Semelle pour chaussure de sécurité",0,2,9000379,51
+2014737,"Station de soudage",0,2,9000381,50
+2006887,"Circulateurs de chauffage",0,2,2011728,50
+1001171,"Pompes à palettes",0,2,1000215,50
+2002114,"Bombe de galvanisation à froid",0,2,2009246,50
+9000429,"Générateur air chaud industriel ",0,2,2008685,50
+2003099,"Trieuses et contrôleuses pondérales",0,2,2000477,49
+2017372,"Citernes plastique fioul",0,2,2007627,49
+2011776,"Machines agrafeuses",0,2,9000381,49
+2016302,"Badge pour événement",0,2,2013979,49
+2005597,"Colliers chauffants",0,2,2010772,48
+2004104,"Carters de sécurité",0,2,1002096,48
+2010796,"Armoires d'entretien",0,2,2005553,48
+2018831,"Rampe électrique",0,2,2005495,48
+2009798,"Presses à métaux pneumatiques",0,2,2007887,48
+2015179,"Bureau d'école",0,2,1000422,48
+2011074,"Pompes doseuses électromécaniques",0,2,2011072,48
+9000561,"Bande antidérapante",0,2,1000386,48
+2005298,"Vestiaires sportifs",0,2,9000378,48
+1002480,"Location de matériels génie climatique",0,1,1000011,48
+2017915,"Porte de chambre froide",0,2,2011825,48
+2017338,"Radiateurs électriques à pierre réfractaire",0,2,2010744,48
+2009901,"Chariot isotherme",0,2,1000396,48
+2011941,"Pont de chargement de quai",0,2,2005546,47
+2018597,"Consigne automatique",0,2,2010666,47
+2003071,"Registres de ventilation",0,2,2010626,47
+2002468,"Soufflets de protection",0,2,1002096,47
+2003693,"Portillon d'accès",0,2,2012828,47
+2011642,"Régulateurs numériques pour chauffage",0,2,2011641,47
+2014137,"Chariots à fond mobile",0,2,1000396,47
+2018614,"Malette de rangement pour drone",0,2,9000388,47
+2016782,"Exutoire de fumée ",0,2,1000365,46
+2007346,Cogénération,0,2,2008685,46
+2014490,"Tableau électrique",0,2,1000181,46
+2003664,"Rangements pour badges",0,2,2005198,46
+9000530,"Boitier électronique",0,2,1000181,46
+2014486,"Chauffe bain",0,2,2008684,45
+2014142,"Cloisons pour sanitaires et vestiaires",0,2,2001553,45
+2014656,"Climatiseur multisplit",0,2,1000351,45
+2018885,"Couloir de passage",0,2,2012828,45
+2010262,"Déshumidificateurs à absorption",0,2,1000360,45
+9000419,"Siège ballon ergonomique de bureau",0,2,2001558,44
+2000297,"Bras de manipulation",0,2,1000079,44
+2018767,"Compteur de jour sans accident",0,2,1000384,44
+2019461,"Chariot porte outil",0,2,1000396,44
+2004408,"Convertisseurs de signaux",0,2,2007948,44
+2018277,"Mallettes d'étude mécanique",0,2,2012174,44
+2003646,"Tables avec guidage",0,2,1000033,44
+2010057,"Mobiliers de call-centers",0,2,1000422,44
+2008797,"Pompes à chaleur géothermiques",0,2,2008795,43
+2010246,"Humidificateurs à vapeur",0,2,1000360,43
+2008799,"Pompes à chaleur réversibles",0,2,2008795,43
+2002045,"Ponts bascules",0,2,2000477,43
+2005401,"Chaudières à vapeur",0,2,1000343,43
+1001264,"Machines enrouleuses et dérouleuses",0,2,1000999,42
+2008995,"Fontaine à eau bonbonne",0,2,2008987,42
+2006839,"Panneaux solaires thermiques à fluide",0,2,2009084,42
+1001734,"Ballons solaires",0,2,2008684,42
+1001268,"Systèmes de transport pneumatique",0,2,1000399,42
+2018007,"Rack mobile",0,2,1000409,41
+2017979,"Pieuvres électriques",0,2,1000181,41
+2014159,Désemboueurs,0,2,2011728,41
+1001800,"Diffuseurs d'air linéaires",0,2,1000356,41
+2011181,"Presses à métaux électriques",0,2,2007887,41
+2017645,"Potelets amovibles",0,2,2012827,41
+2019207,"Automatisme marche-arrêt pour pompe",0,2,1000036,41
+1001769,"Tour de refroidissement",0,2,9000320,41
+2018397,"Purgeurs à flotteur",0,2,9000384,41
+2018395,"Purgeurs thermostatiques",0,2,9000384,40
+2010858,"Modules de motricité",0,2,2010018,40
+2013888,"Machines pour la fabrication de badges pin's",0,2,1000387,40
+2008779,"Serrures électriques",0,2,9000393,40
+2015742,"Autre matériel pour chauffage",0,2,2008685,40
+2008363,"Afficheurs à led",0,2,2002383,40
+2005583,"Réservoir de stockage d'eau",0,2,2007627,39
+2002985,"Convoyeurs / transporteurs à vis",0,2,1000399,39
+2003374,"Climatiseurs drv ou vrv",0,2,1000351,39
+2003482,"Amplificateurs haute-fréquences",0,2,2007948,39
+9000452,Roulements,0,2,1000031,39
+9000169,"Canon à chaleur diesel",0,2,2008685,39
+2001942,"Générateurs de courant",0,2,2003487,39
+2005172,"Rayonnages pour bobines",0,2,1000409,38
+2001906,"Réchauffeurs de liquide",0,2,2011728,38
+2018425,"Rouleaux pour vrac",0,2,1000399,38
+9000517,"Support panneau photovoltaïque",0,2,2009368,38
+9000301,"Table pour enfant",0,2,2010018,38
+2002037,"Pèse-essieux et pèse-roues",0,2,2000477,38
+2010814,"Imprimantes d'adresses",0,2,9000377,38
+2004287,"Collecteurs de gobelets",0,2,2008987,38
+1002158,"Systèmes et installations sur mesure",0,2,1000399,38
+2007117,"Peseuses multitêtes",0,2,2000477,38
+2008017,"Cabines de poudrage",0,2,2009246,37
+2018057,"Accessoires machine de nettoyage climatisation",0,2,1000351,37
+2008129,Manuracks,0,2,1000409,37
+2017926,"Chariots pour chaises",0,2,1000396,37
+2018781,"Moteur atex",0,2,1000030,37
+2008314,"Collecteurs tournants électriques",0,2,1000031,37
+2016758,"Butoirs  en acier",0,2,9000387,37
+2007367,"Groupes hydrauliques",0,2,1000036,37
+2002069,"Pompes d'épuisement",0,2,1000215,37
+9000600,"Distributeur pneumatique",0,2,2002048,37
+1001926,"Contrôleur de ronde",0,2,1000369,37
+9000471,"Protection auditive",0,2,2007417,37
+2018962,"Sabot de denver",0,2,1000072,37
+2013691,"Équipements et accessoires de grues de levage",0,2,2007710,37
+2010686,"Manivelles de manoeuvre",0,2,2010578,37
+2002573,"Pèse palette",0,2,2000477,36
+1001931,"Logiciels de vidéosurveillance",0,2,1000373,36
+2007990,"Dispositif DATI",0,2,1000073,36
+2011940,"Plaque de chargement de quai",0,2,2005546,36
+2008306,"Filtres magnétiques",0,2,1000174,36
+2003428,"Logiciels de gestion des temps et horaires",0,2,1000083,36
+1001965,"Lecteurs de plaques",0,2,1000377,36
+2010129,"Colonnes de classement rotatives",0,2,2005553,36
+1002101,"Tapis sensible de sécurité",0,2,1000386,36
+1002161,"Table d'accumulation",0,2,1000399,35
+2016911,"Distributeurs automatiques EPI",0,2,2007417,35
+2009323,"Aérateur pour fenêtre",0,2,1000356,35
+2002110,"Actionneurs pour vannes",0,2,1000214,35
+2019529,"Alarme PPMS",0,2,1000369,35
+2010731,"Riveteuses pneumatiques",0,2,9000381,35
+2003922,"Réducteurs à roue et vis",0,2,2010209,35
+2005466,"Fontaines à eau atmosphériques",0,2,2008987,35
+9000265,"Colle pour carrosserie",0,2,1000271,35
+2002550,"Positionneurs pneumatiques",0,2,1000035,34
+2003362,"Armoire de précision",0,2,1000351,34
+2008333,Cloisonnettes,0,2,2001553,34
+1002282,"Logiciels de gestion de stock",0,2,1000083,34
+2007987,"Talkie walkie pti",0,2,1000073,34
+1001812,"Silencieux à baffles",0,2,1000358,34
+2003825,"Postes de soudure par ultrasons",0,2,1000272,34
+2007369,"Filtres d'eaux usées",0,2,2007259,34
+2009548,"Puits canadiens",0,2,2008685,33
+2018411,"Détecteur de fuite d'air comprimé",0,2,9000383,33
+2007612,"Autres basculeurs / retourneurs",0,2,9000359,33
+1001134,"Ressorts de traction",0,2,1000033,33
+1001383,"Postes de soudure laser",0,2,1000272,33
+2019040,"Racleur pour bande transporteuse",0,2,1000399,33
+9000480,"Hangar photovoltaïque agricole",0,2,1000410,33
+2018833,"Pompe pour cuve ibc",0,2,9000359,33
+2004162,"Graissage centralisé",0,2,1000032,32
+2017315,"Afficheurs et enregistreurs de bruit",0,2,2002383,32
+2012012,"Station de charge et de récupération",0,1,1000011,32
+1002044,"Protecteurs télescopiques",0,2,1002096,32
+2011672,"Régulateurs multifonctions",0,2,2011641,32
+2003372,"Climatiseurs par évaporation ou rae",0,2,1000351,32
+2017794,"Pupitres de conférence amplifiés",0,2,9000083,31
+9000021,"Groupe frigorifique pour utilitaire",0,2,9000320,31
+2017907,"Pelles pour chariots élévateurs",0,2,1000392,31
+2012820,"Butées d'arrêt pour convoyeurs / transporteurs",0,2,1000399,31
+2017513,"Matériels de bureau antistatique ",0,2,2004130,31
+2016826,"Peseuses linéaire ",0,2,2000477,31
+9000293,"Banc pour enfant",0,2,2010018,31
+1002164,"Manipulateurs pour bobines et rouleaux",0,2,1000079,31
+2013465,"Tours de stockage",0,2,1000411,31
+2013626,"Afficheurs lumineux de comptage de parking",0,2,2002383,31
+2007361,"Séparateurs centrifuges",0,2,1000036,31
+2008208,"Cartes de fidélité",0,2,2013979,30
+2009743,"Machines de décapage",0,2,2009246,30
+2018548,"Vernis de tropicalisation",0,2,2009246,30
+2006957,"Herse anti-intrusion",0,2,2012828,30
+2008226,"Bornes escamotables semi-automatiques",0,2,2012827,30
+1001691,"Purgeurs capacitifs à détection de niveau ",0,2,9000384,30
+1001845,"Centrales de détection incendie",0,2,1000364,30
+2014112,"Lecteurs de documents d'identité",0,2,2012829,30
+2008945,"Ballons à gaz",0,2,2008684,30
+1001192,"Applicateurs de revêtement",0,2,2009246,30
+2018435,"Application PTI",0,2,1000073,30
+2018466,"Masque d'évacuation",0,2,2006800,30
+2004327,"Butées de positionnement",0,2,1000033,30
+1002239,"Systèmes de tri pour convoyeurs/transporteurs",0,2,1000399,30
+2003809,"Transformateurs haute tension",0,2,2007948,30
+2002792,"Pré-filtres d'eau",0,2,2007259,29
+2016715,"Télécommandes pour alarmes",0,2,1000369,29
+2001993,"Récupérateurs de chaleur",0,2,2008685,29
+2019704,"Groupe électrogène solaire",0,2,2009366,29
+2018380,"Sécheurs à membrane",0,2,9000385,29
+2019071,"Sac de lestage",0,2,9000673,29
+2007718,"Plateforme élévatrice",0,2,1000401,29
+2014645,"Bille porteuse",0,2,1000399,29
+2011623,Horodateurs,0,2,2010666,29
+2004633,"Systèmes d'inspection rayons x pour cargos",0,2,9000391,29
+2017434,"Réservoirs d'alimentation sous pression",0,2,2009246,29
+2012954,"Rayonnage textile",0,2,1000409,28
+2010730,"Riveteuses électriques",0,2,9000381,28
+2010345,"Câbles chauffants pour planchers",0,2,2010332,28
+1001615,"Pompes à boues",0,2,9000382,28
+2017765,"Bornes de défense",0,2,2012827,28
+2012892,"Traçabilité et géolocalisation par rfid",0,2,1000387,28
+9000574,"Masse beton",0,2,9000673,28
+2004362,"Mesures diélectriques",0,2,9000326,28
+9000179,"Mandrin magnétique à aimant permanent",0,2,1000174,28
+2004618,"Pistolets de poudrage",0,2,2009246,28
+2017917,"Machines à affranchir",0,2,9000377,28
+2017345,"Pompes volumétriques",0,2,2001019,27
+2013015,"Cartes et badges cartonnés pour impression",0,2,2013979,27
+2015043,"Coiffe palette",0,2,2007619,27
+2004715,"Centrales hydroélectriques",0,2,1000036,27
+9000585,"Robot de nettoyage professionnel",0,2,9000373,27
+2018932,"Distributeur de masque",0,2,2007417,27
+2003419,"Climatiseur de fenêtre",0,2,1000351,27
+2014667,"Poste de soudage par flamme",0,2,1000272,27
+2015571,"Balais et brosses pour chariots",0,2,1000392,27
+2019072,Plastobloc,0,2,2012828,27
+2018525,"Rampe pour transpalette",0,2,2005546,26
+1002290,"Tables à dessin",0,2,2001554,26
+2017314,"Refroidisseurs adiabatiques",0,2,9000320,26
+2017539,"Barrière sélective",0,2,2012828,26
+2002283,Echomètres,0,2,9000326,26
+2011559,"Chaudières à eau chaude",0,2,1000343,25
+1001868,"Système d'extinction automatique d'incendie",0,2,1000367,25
+9000283,"Service de création de site internet",0,2,9000375,25
+2001935,"Équipements pour transformateurs",0,2,2007948,25
+2015114,"Drones de surveillance",0,2,9000388,25
+2017852,"Barrière anti-voiture bélier",0,2,2012828,25
+2014605,"Galet de roulement",0,2,1000397,25
+2019472,"Lecteur de carte magnétique",0,2,1000387,25
+2003691,"Sas de sécurité",0,2,2012830,25
+2018827,"Barre de levage",0,2,2007710,25
+2005144,"Afficheurs lcd",0,2,2002383,25
+1001891,"Accessoires de caillebotis",0,2,1000386,25
+2018170,"Système de réservation de salle de réunion",0,2,9000375,25
+2018402,"Séparateurs huile/eau",0,2,1000035,25
+9000544,"Tuyauterie modulaire",0,2,2002048,24
+1001382,"Lampes pour colles photosensibles",0,2,1000271,24
+2002983,"Convoyeurs / transporteurs à galets",0,2,1000399,24
+2004443,"Têtes de soudage automatique",0,2,1000272,24
+2013461,Transstockeurs,0,2,1000411,24
+1002050,"Plan d'évacuation",0,2,1000367,24
+2013777,"Racks de stockage grillagés",0,2,1000409,24
+1001867,"Lances incendie",0,2,1000367,24
+2013759,"Armoires de stockage et de distribution",0,2,1000411,24
+2003251,"Systèmes de stockage par accumulation",0,2,1000409,24
+2017576,"Borne de satisfaction",0,2,2010666,24
+2012555,"Manipulateurs pour cartons",0,2,1000079,24
+2003567,"Racks de stockage pour produits longs",0,2,1000409,24
+1001746,"Batteries de chauffage",0,2,2010772,23
+9000142,"Externalisation de la gestion de paie",0,2,9000375,23
+2011643,"Régulateurs analogiques pour refroidissement",0,2,2011641,23
+9000428,"Analyseur d'antenne",0,2,9000326,23
+9000247,"Concentrateur de données",0,2,1000181,23
+2014338,"Palette en carton",0,2,2007619,23
+2007971,"Télégestion de systèmes solaires",0,2,2009368,23
+2011805,"Tourets, bobines et rouleaux de stockage",0,2,2013732,23
+9000433,"Système de stockage d'énergie par batterie",0,1,1000003,23
+2005130,"Échangeurs thermiques électriques",0,2,2001970,22
+9000153,"Tente militaire",0,2,1000410,22
+2011925,"Poêles polycombustibles",0,2,1000344,22
+1001736,"Panneaux radiants à gaz",0,2,2010744,22
+2008715,"Affichage de production",0,2,2002383,22
+2002971,"Courbes pour convoyeurs / transporteurs",0,2,1000399,22
+2003958,"Convoyeurs / transporteurs magnétiques",0,2,1000399,22
+9000240,"Aménagement de bureau professionnel",0,2,1000422,22
+2019445,"Jambière anti-coupure",0,2,2007417,22
+2019525,"Banquette coworking",0,2,1000422,22
+2017578,"Machines de nettoyage de climatisation",0,2,1000351,22
+2007264,"Installations de filtration d'eau",0,2,2007259,22
+1001848,"Détecteurs de chaleur",0,2,1000364,21
+2005114,"Afficheurs lumineux commerciaux",0,2,2002383,21
+2004670,"Station d'étamage",0,2,1000999,21
+2018447,"Afficheur file d'attente",0,2,2018446,21
+9000129,"Robot d'assistance à la personne",0,2,9000373,21
+2012197,"Appareils d'assèchement de mur",0,2,1000360,21
+2010840,"Sertisseuses pneumatiques",0,2,9000381,21
+2003497,"Émerillons de levage",0,2,2007710,21
+9000519,"Robot de nettoyage de panneaux solaires",0,2,9000373,21
+2019176,"Hublot de visualisation",0,2,1002096,21
+2007371,"Accumulateurs de palettes",0,2,1000409,21
+2019232,"Système automatique de stockage et de déstockage (AS/RS)",0,2,1000411,21
+1001900,"Kits d'identification d'accès",0,2,2012829,20
+9000193,"Sac anti-inondation	",0,2,9000390,20
+1001849,"Services de contrôle d'accès",0,2,2012829,20
+2008759,"Robots de surveillance",0,2,1000377,20
+2010948,Turbocompresseurs,0,2,1000030,20
+2018448,"Borne de gestion de file d'attente",0,2,2018446,20
+2016323,"Alarme radio sans fil",0,2,1000369,20
+2009294,"Accessoires pour pompes pneumatiques",0,2,2001019,20
+2010860,"Parcs pour enfants",0,2,2010018,20
+2013408,"Chargeurs pour transport pneumatique",0,2,2013732,20
+9000588,"Laveur pistolet peinture",0,2,2009246,20
+2019033,"Testeur de borne de recharge",0,2,9000326,20
+2019739,"Lève roue",0,2,1000401,20
+2018819,"Coque pour chaussure",0,2,9000379,20
+2018441,"Bandes modulaires",0,2,1000399,20
+2008225,"Bornes arrêt-minute",0,2,2012827,20
+1001432,"Générateurs de tension",0,2,2003487,20
+1001133,"Ressorts de torsion",0,2,1000033,20
+2018413,"Capteur de vapeur d'huile d'air comprimé",0,2,9000383,19
+2016364,"Bornes incendie",0,2,1000367,19
+2018884,"Portillon de sécurité",0,2,2012828,19
+2014510,"Poste de contrôle",0,2,1000422,19
+9000516,"Pochette anti-téléphone pour la pause numérique",0,2,2005198,19
+9000540,"Cabine de soudage laser",0,2,1000272,19
+2016792,"Accessoires véhicules incendie",0,2,1000367,19
+1001697,"Maintien en pression",0,2,1000343,19
+2012585,"Basculeurs / retourneurs de conteneurs",0,2,9000359,19
+2015831,"Ampèremètres numériques",0,2,9000326,19
+9000591,"Colonne levage telescopique",0,2,9000590,19
+2012584,"Basculeurs / retourneurs de bobines",0,2,9000359,19
+2003417,"Logiciels de gestion et traitements de pesées",0,2,1000083,18
+2017538,"Garnitures mécaniques",0,2,1000036,18
+2015982,"Table de montage",0,2,2005495,18
+2016921,"Salles de bains préfabriquées",0,2,9000374,18
+2001858,Démagnétiseurs,0,2,1000174,18
+9000528,"Robot de pose de vitrage",0,2,2007710,18
+2007365,"Postes de transformation de signaux électriques",0,2,2007948,18
+2016322,"Masque pare-visage",0,2,2006800,18
+2018523,"Robot de peinture ",0,2,2009246,18
+2000082,"Joints tournants haute vitesse",0,2,2002048,18
+9000194,"Tiroir à palette",0,2,2007619,18
+2015066,"Cloison d'atelier",0,2,2001553,18
+9000088,"Barrière écluse",0,2,2013732,18
+2003307,"Turbines hydro-électrique",0,2,1000036,18
+2003681,"Manipulateurs pour sacs",0,2,1000079,18
+2015262,"Pistolet station peinture",0,2,2009246,18
+2018412,"Capteur de pression d'air comprimé",0,2,9000383,18
+9000024,"Chauffe roulement",0,2,1000033,18
+2016809,"Service de désenfumage",0,2,1000367,18
+2018396,"Purgeurs thermodynamique",0,2,9000384,17
+9000111,"Convoyeur à accumulation",0,2,1000399,17
+2005490,"Bornes hydrauliques",0,2,1000036,17
+2017512,"Ioniseur d'air",0,2,2004130,17
+2001916,"Régulateurs analogiques pour chauffage",0,2,2011641,17
+2017378,"Convoyeurs à copeaux",0,2,1000399,17
+2010070,"Pupitres informatiques",0,2,1000422,17
+2009306,"Grille de transfert",0,2,1000356,17
+2019580,"Table de sciage",0,2,1000262,17
+9000510,"Recuperateur de chaleur sur eaux usees",0,2,2008685,17
+2008714,"Afficheurs lumineux de sécurité",0,2,2002383,17
+9000190,"Armoire et casier RFID",0,2,1000387,17
+2002968,"Borne pour pont bascule",0,2,2000477,17
+9000033,"Casier d'école",0,2,1000422,17
+9000497,"Dés de palette",0,2,2007619,17
+2019745,Voltmètre,0,2,9000326,17
+9000221,"Caillebotis en caoutchouc",0,2,1000386,17
+1001857,"Panneaux coupe-feu",0,2,1000365,17
+2017760,"Systèmes de pompage de lentilles d'eau",0,2,1000215,17
+2017612,"Matelas isolant	",0,2,2010772,16
+1002488,"Boîte à coins pour câbles de levage",0,2,2007710,16
+2018937,"Système de dimensionnement et de pesée automatique",0,2,2000477,16
+2016403,Pico-ampèremètres,0,2,9000326,16
+2019597,"Écran de cantonnement",0,2,1000365,16
+2003854,"Pesages sur convoyeurs / transporteurs",0,2,2000477,16
+2019724,"Régulateur pour éolienne",0,2,2009367,16
+2015554,"Relais thermique",0,2,1000181,16
+2018773,"Compresseur haute pression ",0,2,1000207,16
+2018467,"Appareil à adduction d'air",0,2,2006800,16
+1002159,"Embouts et galets pour convoyeurs",0,2,1000399,16
+1001841,"Alarmes incendie électroniques",0,2,1000364,16
+2007941,"Pompes pneumatiques manuelles",0,2,2001019,16
+2012521,"Dalles de plafonds",0,2,2001553,15
+2013991,"Détecteurs de faux documents",0,1,1000012,15
+2007904,"Logiciels de gardiennage",0,2,1000373,15
+2018752,"Chariot de séchage",0,2,2009246,15
+9000300,Repose-pied,0,2,2001558,15
+2019038,"Casier électronique",0,2,1000411,15
+2017363,"Contrôleurs pour engins de manutention",0,2,1000397,15
+1002548,Guide-roue,0,2,2005546,15
+2019718,"Manche de chargement télescopique",0,2,2013732,15
+9000448,"Toile filtrante",0,2,2005982,15
+2007698,"Plates-formes de manutention",0,2,2013732,15
+2017018,"Portes blindées de maisons ",0,2,2012830,15
+2000980,"Cloisons fixes",0,2,2001553,15
+2019193,"Compresseur de segment",0,2,1000030,15
+2009023,"Machines à signer",0,2,9000377,15
+2018414,"Analyseur d'air comprimé",0,2,9000383,14
+1001286,"Machines de brasage",0,2,9000381,14
+2011271,"Armoires à portes pliantes",0,2,2005553,14
+2019473,"Filtre à gaz",0,2,2005982,14
+2018253,"Barrière coulissante",0,2,2012828,14
+2016973,"Roll-containers horizontal",0,2,1000396,14
+9000573,"Tracker solaire",0,2,2009368,14
+9000113,"Lampe de quai",0,2,2005546,14
+2018566,"Fauteuil pour salle de spectacle",0,2,9000083,14
+2015067,"Pied de cloison",0,2,2001553,14
+2016765,"Caillebotis bois",0,2,1000386,13
+2016389," Machine pour fabrication de porte clés personnalisés",0,2,1000387,13
+2009230,"Mousses coupe-feu",0,2,1000365,13
+2012199,"Centrales de chauffage",0,2,2008685,13
+1001118,"Couronnes d'orientation",0,2,1000033,13
+2014736,"Poulie variable",0,2,1000031,13
+9000441,"Crash barrière",0,2,2012828,13
+2019160,"Pochette de clés transportable",0,2,1000370,13
+2003972,"Courroies pour convoyage",0,2,1000031,13
+2000886,"Coffrets de sécurité",0,2,1000375,13
+9000308,"Tresse métallique",0,2,1000999,13
+2018627,"Robot humanoïde",0,2,9000373,13
+2002164,"Protecteurs enrouleurs",0,2,1002096,13
+2014198,Millivoltmètre,0,2,9000326,13
+2018623,"Enregistreur HDCVI",0,2,1000377,13
+9000165,"Convoyeur de carrière",0,2,1000399,13
+2008738,"Pellets ou granulés de bois",0,2,1000343,13
+2001566,"Signalisations de détresse",0,2,1000384,13
+2018062,"Chariot à ventouses",0,2,2007710,13
+2016357,"Nettoyant de matériel de pulvérisation de peinture",0,2,2009246,13
+2003242,"Portes blindées de chambres fortes",0,2,2012830,13
+9000147,"Système de dosage d'émulseur",0,2,1000367,12
+2017570,"Logiciels d'étude et de calcul électriques",0,2,1000029,12
+1001909,"Détecteurs de chocs et vibrations",0,2,1000369,12
+2018456,"Chariot pour grille d'exposition",0,2,2005198,12
+2002588,"Tables / plateaux de transport à billes",0,2,1000399,12
+2002942,"Convoyeurs / transporteurs au sol",0,2,1000399,12
+9000564,"Feu tricolore intelligent",0,2,1000384,12
+9000634,"Vestiaire pompier",0,2,9000378,12
+2002972,"Convoyeurs / transporteurs à raclettes",0,2,1000399,12
+1001907,Caillebotis,0,2,1000386,12
+2016398,"Convoyeurs hélicoïdaux",0,2,1000399,12
+2003298,"Chargeurs, déchargeurs de manutention",0,2,1000399,12
+9000657,"colonne lumineuse",0,3,9000655,12
+9000499,"Entreprise de thermolaquage",0,2,2009246,12
+2000677,"Générateurs d'eau chaude",0,2,2008685,12
+9000152,"Shelter militaire",0,2,1000415,12
+2007839,"Kit éolienne",0,2,2009367,12
+2014666,"Onduleur pour soudure",0,2,1000272,12
+2016319,"Raccord câble",0,2,1000999,12
+2001677,"Basculeurs / retourneurs de palettes",0,2,9000359,12
+2017349,"Cloisons translucides",0,2,2001553,12
+2010815,"Endosseuses de chèques",0,2,9000377,12
+2012203,"Sous-stations de chauffage",0,2,2008685,11
+9000534,"Caisse de remuage",0,2,2007619,11
+2008224,"Bornes à tickets",0,2,2012827,11
+2018841,"Pince à border",0,2,2012174,11
+2002692,"Contrôleurs de pesage",0,2,2000477,11
+9000192,"Table vibrante",0,2,2013732,11
+1002283,"Logiciels de gestion de la supply chain",0,2,1000083,11
+1001851,"Tableaux d'alarmes incendie",0,2,1000364,11
+2001783,"Cabines fumeurs",0,2,2008987,11
+1001961,"Matériels de téléassistance",0,2,1000377,11
+9000599,"Vanne à clapet",0,2,2011698,11
+2016352,Interverrouillage,0,2,1000386,11
+2008218,"Obstacles escamotables",0,2,2012827,11
+2014770,"Palette alimentaire",0,2,2007619,11
+2010946,"Cuves pour pulvérulents et granules",0,2,2007627,10
+2000675,"Colonnes de chauffage",0,2,1000344,10
+2014105,Débiteuses,0,2,1000262,10
+2018113,"Gazomètres & réservoirs à gaz",0,2,2007627,10
+9000191,"Distributeur automatique de vêtements ou D.A.V.",0,2,2007417,10
+2018843,"Pince à rétreindre",0,2,2012174,10
+2008694,"Robinets d'incendie armés",0,2,1000367,10
+2003791,"Détecteurs de flammes",0,2,1000364,10
+2006889,"Enduits coupe-feu",0,2,1000365,10
+2011646,"Thermorégulateurs pid",0,2,2011641,10
+9000082,"Solution de détection de faux documents",0,1,1000012,10
+9000299,"Jeux d'imitation",0,2,2010018,10
+9000266,"Trottinette industrielle",0,2,1000396,10
+2019736,"Traverse de levage",0,2,1000401,10
+2003182,"Mesures d'électricité statique",0,2,9000326,10
+9000052,"Cage à drone filet et gonflable",0,2,9000388,10
+2006199,"Bras de chargement",0,2,1000079,10
+1001049,"Logiciels de schématique électrique",0,2,1000029,9
+2019760,"Coffret électrique pour pompe",0,2,1000215,9
+2018123,"Murs filtrant pour cabines de peinture",0,2,2009246,9
+2019139,"Montre PTI",0,2,2007417,9
+2017445," Cloisons et rideaux souples",0,2,2001553,9
+2018743,"Simulateur de soudage",0,2,1000272,9
+2017741,"Machines à hologrammes",0,1,1000012,9
+2018992,"Filtre conique",0,2,1000217,9
+2019294,"Plaque filtrante",0,2,2005982,9
+2019007,"Colonne à taquet",0,2,2013732,9
+2006891,"Mortiers coupe-feu",0,2,1000365,9
+2007713,"Tube pneumatique",0,2,2013732,9
+2017016,"Portes blindées d'appartement",0,2,2012830,9
+2011253,"Murs et plinthes chauffants",0,2,2010332,9
+1001864,"Canons incendie",0,2,1000367,9
+2018796,"Totem pour bornes escamotables",0,2,2012827,9
+9000405,"Amplificateur de puissance CEM",0,2,9000326,9
+2002186,"Équipements de revêtement de surface",0,2,2009246,8
+2017608,"Sirènes d'alerte à la population",0,3,9000655,8
+9000296,"Chariot à peinture",0,2,2010018,8
+2009086,"Panneaux solaires thermiques à air",0,2,2009084,8
+2017911,"Établis électrifiés",0,2,2005495,8
+2002136,"Pompes pneumatiques à palettes",0,2,2001019,8
+2011889,"Couronneuses de câbles",0,2,1000999,8
+2018858,"Sécheur d'air par absorption",0,2,9000385,8
+2001999,"Poutres froides",0,2,1000351,8
+2016742,"Applications mobiles de gardiennage",0,2,1000373,8
+9000208,"Copieur de badge",0,2,2012829,8
+9000224,"Interphone de sécurité",0,2,2012829,8
+2017898,"Détecteurs d'explosifs et narcotiques",0,2,9000391,8
+2004222,"Solutions automatisées",0,2,2007619,8
+2012819,"Rives de guidage convoyeurs / transporteurs",0,2,1000399,8
+1001952,"Coffres de transfert de fond",0,2,1000375,8
+2006888,"Peintures coupe-feu",0,2,1000365,7
+2007590,"Logiciels de câblage électrique",0,2,1000029,7
+9000579,"climatiseur sans unité extérieure",0,2,1000351,7
+2005548,"Passerelles de quais",0,2,2005546,7
+2003692,"Portes tournantes de sécurité",0,2,2012830,7
+2007464,"Bac à feu",0,2,1000367,7
+9000125,"Porte anti-squat",0,2,2012830,7
+2008522,"Pompes pneumatiques vide-conteneurs",0,2,2001019,7
+9000297,"Chevalet de peinture",0,2,2010018,7
+2002340,"Interfaces de commande pour soudage",0,2,1000272,7
+2008697,"Véhicules anti incendie",0,2,1000367,7
+1002236,"Navettes de stockage automatiques",0,2,1000411,7
+2017629,"Bacs de rétention anti-feu ",0,2,1000367,7
+9000596," chaufferie en container",0,2,1000343,7
+2011644,"Régulateurs numériques pour refroidissement",0,2,2011641,7
+2003767,"Convoyeurs / transporteurs à courroies",0,2,1000399,7
+2018403,"Unités de traitement des condensats",0,2,1000035,7
+2016825,"Sécheur de maillot de bain",0,2,9000374,7
+2017516,"Autres matériels antistatiques ",0,2,2004130,7
+2019384,"Extincteur automatique ",0,2,1000367,7
+2009322,"Distributeurs d'air chaud pour cheminées",0,2,2006083,7
+2003545,"Tabliers et fourches peseurs",0,2,2000477,7
+2003544,"Barres de pesage",0,2,2000477,7
+9000291,"Bac à livres",0,2,2005198,6
+9000400,"Gaz combustible",0,2,2008685,6
+2008132,"Filet pour palette",0,2,2007619,6
+2008942,"Ballons électriques",0,2,2008684,6
+2019311,"Plateforme de travail sur mât",0,2,1000401,6
+2019338,"Doublure de conteneur",0,2,1000415,6
+1001946,"Guichets pare-balles",0,2,2012830,6
+2007165,"Détecteurs pour la sécurité routière",0,2,1000384,6
+9000133,"Chariot porte-container",0,2,1000392,6
+9000631,"Couverture anti-feu",0,2,1000367,6
+2003381,"Autres climatiseurs",0,2,1000351,6
+2017569," Grilles acoustiques de ventilation",0,2,1000358,6
+2009971,"Climatiseurs militaires",0,2,1000351,6
+9000110,"Housse de siège",0,2,9000083,6
+2017514,"Protections individuelles antistatiques",0,2,2004130,6
+2007952,"Kit mixte éolien-solaire",0,2,2009368,6
+2017515,"Protections antistatiques des produits",0,2,2004130,6
+2014014,"Scanners de sûreté",0,2,9000391,5
+2018875,"Basculeur de GRV IBC",0,2,9000359,5
+2018184,"Transpalette thermique",0,2,1000395,5
+2003823,"Scies à câble",0,2,1000262,5
+2007981,"Chauffe-eau aérothermiques",0,2,2008684,5
+1002279,"Pompes hydrauliques vide-conteneurs",0,2,1000215,5
+2009248,"Tunnels de peinture",0,2,2009246,5
+2019766,"Moteur de désenfumage",0,2,1000365,5
+2017308,"Parois et cloisons blindées",0,2,2012830,5
+2018896,"Convoyeur à godet",0,2,1000399,5
+2018255,"Trémie à fond ouvrant",0,2,1000399,5
+9000307,"Jeux de barres",0,2,1000999,5
+9000641,SIRH,0,2,9000375,5
+9000604,"Dématérialisation des documents",0,2,9000375,5
+2003253,"Gicleurs pour chaudières",0,2,1000343,5
+2008349,"Espaces de travail modulables",0,2,1000422,5
+2019427,"Ascenseur à palette",0,2,2013732,5
+2004178,"Tables techniques",0,2,1000999,5
+2019049,"Masque auto sauveteur",0,2,2006800,4
+2011558,"Bras anti-couple de vissage",0,2,9000381,4
+2017017," Portes blindées de caves",0,2,2012830,4
+1001395,"Matériels de clinchage",0,2,9000381,4
+9000456,"Drones de mesures de radioactivité",0,2,9000388,4
+2008669,"Magasins de stockage pour produits dangereux",0,2,2008392,4
+1001942,"Chambres fortes",0,2,1000375,4
+2016790,"Aerosols pour extincteurs",0,2,1000367,4
+9000085,"Gradin modulable",0,2,9000083,4
+2002177,"Pesages aéronautiques portables",0,2,2000477,4
+9000582,"filtration membranaire",0,2,2007259,4
+2019337,Twist-lock,0,2,1000415,4
+2019522,"Levage de container",0,2,1000415,4
+2012818,"Pieds de support convoyeurs / transporteurs",0,2,1000399,4
+9000048,"Chauffage de surface hydronique - Dégeleuse de sol",0,2,2008685,4
+2018468,"Chariot d'air respirable",0,2,2006800,4
+2003424,"Générateurs d'air froid",0,2,1000351,4
+2003145,"Tabliers de recouvrement",0,2,1000386,4
+9000306,"Contacteur sur barreaux",0,2,1000181,4
+2018551,"Produit d'enduction",0,2,2009246,4
+2017601,"Papiers sécurisés",0,2,1000422,4
+9000666,"Chariot preparateur de commande",0,2,1000396,4
+2001889,"Neutraliseurs pour chaudières",0,2,1000343,4
+9000584,"Robot de livraison",0,2,9000373,4
+2018991,"Test d'intégrité des filtres",0,2,1000217,4
+9000475,"Conseil en financement public",0,2,9000375,4
+2011288,"Rideaux d'air à gaz",0,2,2007666,3
+2018754,"Table rotative de vernissage ",0,2,2009246,3
+9000533,"Radiateur hydraulique eau chaude",0,2,2010744,3
+2009441,"Cartes et badges réinscriptibles",0,2,2013979,3
+2016736,"Drones voilure tournante",0,2,9000388,3
+9000594,"Porte conteneur à déchets",0,2,1000397,3
+9000583,"Robot d'accueil",0,2,9000373,3
+2016240,"Pompe à membrane",0,2,1000215,3
+2019327,"Télécommande BAES",0,2,9000389,3
+2017344,"Cloisons extensibles accordéon",0,2,2001553,3
+2017489,Lève-conteneur,0,2,9000359,3
+9000309,"Tresses de masse",0,2,1000999,3
+9000613,"Entreprise de demenagement",0,2,9000375,3
+2019598,"Désenfumage mécanique",0,2,1000365,3
+2011512,"Convoyeurs / transporteurs à taquets",0,2,1000399,3
+2007923,"Portillons relevables pour convoyeurs",0,2,1000399,3
+2017011," Rideaux de scène ",0,2,9000083,3
+2008048,"Groupes électrogènes d'éclairage",0,2,2019096,3
+2017586,"Tours de vidéosurveillance mobile",0,2,1000377,3
+2019463,"Chariot porte-bobine",0,2,1000396,3
+2016733,"Mini chambres fortes",0,2,1000375,3
+9000642,"Chaudière à miscanthus",0,2,1000343,2
+9000568,"Container solaire",0,2,2009368,2
+2007834,"Éolienne de pompage",0,2,2009367,2
+2018381,"Sécheurs hybrides",0,2,9000385,2
+9000571,"Modification d'entreprise en ligne",0,2,9000375,2
+2016358,"Machines de soudure par impulsion",0,2,1000272,2
+9000662,"Réparation de flexible hydraulique",0,2,2002048,2
+9000640,"Facturation électronique",0,2,9000375,2
+2016917,"Systèmes antivol pour engins de travaux publics",0,2,1000072,2
+2018356,"Centrales hydropneumatiques",0,2,1000036,2
+2016404,"Ampèremètres analogiques",0,2,9000326,2
+9000597,"Pochette FOD",0,2,2005495,2
+9000660,"fournisseur de gaz et d'électricité",0,1,1000003,2
+9000570,"Création d'entreprise en ligne",0,2,9000375,2
+9000202,"Vestiaire automatique",0,2,9000378,2
+2007980,"Chauffe-eau géothermiques",0,2,2008684,2
+2008229,"Bornes à jetons",0,2,2012827,2
+2018454,"Chariot présentoir pour posters",0,2,2005198,2
+2015569,"Basculeurs pour chariot",0,2,9000359,2
+2003252,"Systèmes de gestion manuel d'entrepôts",0,2,1000410,2
+2010373,"Postes de peinture",0,2,2009246,2
+9000558,"Bureau d'étude d'éclairage",0,2,2019096,2
+2009214,"Logiciels de création de devis en électricité",0,2,1000029,1
+9000667,"Tableau d'affichage",0,2,2002383,1
+2018272,"Chaudière mixte",0,2,1000343,1
+2016359,"Machines de soudure par haute fréquence",0,2,1000272,1
+9000067,"Bascule de circuit",0,2,2000477,1
+2013971,"Plates-formes de survie en zone inondable",0,2,9000390,1
+9000298,"Fauteuil d'allaitement",0,2,2001558,1
+2013344,"Enrubanneuses de câbles",0,2,1000999,1
+9000606,"Entreprise VPG",0,2,9000673,1
+2013775,"Racks de stockage pour bateaux",0,2,1000409,1
+2004370,"Véhicules électriques",0,2,1000397,1
+2011063,"Fichiers pour cartes de visite",0,3,2011060,0
+2002654,Repose-pieds,0,2,2012468,0
+2012548,"Coffret d'extracteur de pièces mécaniques",0,2,2012174,0
+2003790,"Pinces pour terminaux électriques",0,2,2012174,0
+2012130,"Pinces de serrage",0,2,2012174,0
+2002442,"Coffrets de pinces",0,2,2012174,0
+2002434,"Extracteurs à rotule",0,2,2012174,0
+2002401,"Pinces diverses",0,2,2012174,0
+2004413,"Presses manuelles mécaniques",0,2,2012174,0
+2003219,"Marchepieds de bureaux",0,2,2012468,0
+2011335,"Rails din",0,3,2010792,0
+2011048,"Tubes fluorescents",0,3,2011047,0
+2011147,"Pinces universelles",0,2,2012174,0
+2001586,Dictaphones,0,2,2012688,0
+1002308,"Traducteurs électroniques",0,2,2012692,0
+2002612,Tréteaux,0,2,2012468,0
+2012552,"Accessoires pour extracteurs de pièces",0,2,2012174,0
+2011302,"Placards de bureaux",0,3,2012285,0
+2003751,"Accessoires pour radiateurs",0,2,2010744,0
+2011062,"Distributeurs de cartes de visite",0,3,2011060,0
+2011064,"Pochettes pour cartes de visite",0,3,2011060,0
+2004011,"Pinces à collier",0,2,2012174,0
+2011061,"Classeurs pour cartes de visite",0,3,2011060,0
+2013942,"Extracteurs d'injecteurs, bougies d'allumage",0,2,2012174,0
+2004001,Tenailles,0,2,2012174,0
+2001556,Estrades,0,2,2012468,0
+2010947,"Plafonniers rectilignes",0,3,2010944,0
+2011055,"Indicateurs fluorescents",0,3,2011426,0
+2013212,"Accessoires pour étaux",0,2,2012174,0
+2011146,"Clés mixtes",0,3,1000257,0
+2011053,"Tubes fluo-compacts",0,3,2011047,0
+2011049,"Lampes fluo-compactes",0,3,2011047,0
+2012937,"Accessoires pour pinces",0,2,2012174,0
+1001157,"Raccords pneumatiques coudés",0,2,2002048,0
+1001821,"Logiciels de simulation et de gestion",0,3,1000361,0
+2008235,"Bornes de délimitation",0,2,2012827,0
+2008783,"Correcteurs d'orthographe électroniques",0,2,2012692,0
+2013178,"Boîtes à fiches",0,3,2013176,0
+2010821,"Accessoires pour éléments de manoeuvre",0,2,2010578,0
+2010687,"Manettes de manoeuvre",0,2,2010578,0
+2010579,"Boutons de manoeuvre",0,2,2010578,0
+2012426,"Accessoires pour commutateurs",0,3,2005049,0
+2012515,"Bacs d'archives",0,3,2010161,0
+2012520,"Caisses d'archives",0,3,2010161,0
+2010349,"Accessoires pour planchers chauffants",0,2,2010332,0
+2017821,"Table(s) élévatrice(s) électrique(s)",0,2,2013732,0
+2012523,"Autres matériels d'archivages",0,3,2010161,0
+2013276,"Tiroirs de rangement multimédia",0,3,2013268,0
+2012292,Surmeubles,0,3,2012285,0
+2013278,"Boîtes de rangement multimédia",0,3,2013268,0
+2013881,"Rotors et stators de moteurs électriques",0,3,2011961,0
+2013936,"Accessoires pour meubles de bureaux",0,3,2012285,0
+2007151,"Lampes à énergies fossiles",0,2,2019096,0
+2002947,Baladeuses,0,2,2019096,0
+2003336,"Panneaux chauffants",0,2,2010332,0
+2014007,"Accessoires pour amplificateurs",0,3,1000952,0
+1001740,"Planchers chauffants hydrauliques",0,2,2010332,0
+2007812,"Bracelets d'identification",0,2,2013979,0
+2012293,"Autres mobiliers de rangement",0,3,2012285,0
+2012715,"Accessoires machines à écrire",0,2,2013189,0
+2008788,"Dictionnaires électroniques",0,2,2012692,0
+2011492,"Tubes halogènes",0,3,2011489,0
+2001551,"Ciseaux de bureau",0,2,2012731,0
+2012732,"Rogneuses de bureau",0,2,2012731,0
+2012741,"Accessoires pour outils de découpe",0,2,2012731,0
+2012792,"Cutters de bureau",0,2,2012731,0
+2011374,"Tableaux en verre",0,3,2004199,0
+2010721,"Clés à douille",0,3,1000257,0
+2006958,"Accessoires de barrière de sécurité",0,2,2012828,0
+2011385,"Tableaux d'écriture mixtes",0,3,2004199,0
+2011406,"Indicateurs incandescents",0,3,2011426,0
+2011493,"Ampoules halogènes",0,3,2011489,0
+2010576,"Raccords de ventilation",0,2,2010626,0
+2011517,"Lampes à vapeur de sodium",0,3,2011515,0
+2012068,"Accessoires pour afficheurs",0,3,2011427,0
+2012131,"Accessoires pour clé",0,3,1000257,0
+1001903,"Entrebâilleurs de sécurité",0,2,2012830,0
+2012132,"Clés en croix",0,3,1000257,0
+2012286,"Rangements multi-usages",0,3,2012285,0
+2012287,"Colonnes de rangement",0,3,2012285,0
+2008023,"Machines à écrire",0,2,2013189,0
+2012288,"Crédences de bureau",0,3,2012285,0
+2012289,"Étagères de bureau",0,3,2012285,0
+2010722,"Clés à ergot",0,3,1000257,0
+2010389,"Supports de modules",0,3,2010785,0
+2010403,"Câbles à aiguille",0,3,2008280,0
+2004213,"Accessoires pour tableaux",0,3,2008150,0
+1001037,Minuteries,0,3,2010661,0
+2002429,"Masses et massettes",0,3,1000258,0
+2002440,"Coffrets à  clés",0,3,1000257,0
+2003069,"Marteaux de mécanicien",0,3,1000258,0
+2003169,Appliques,0,3,2010983,0
+2003991,"Marteaux de menuisier",0,3,1000258,0
+1001036,Télérupteurs,0,3,2011317,0
+2004005,"Marteaux divers",0,3,1000258,0
+2004010,"Contacteurs de moteurs électriques",0,3,2011961,0
+2004013,"Balais pour  moteurs",0,3,2011961,0
+2004200,"Ventouses de fixation",0,3,2008150,0
+1000968,"Boutons poussoirs électriques",0,3,2008592,0
+2004295,"Clés de filtre à huile",0,3,1000257,0
+2002415,"Douilles de clé",0,3,1000257,0
+2004611,"Diodes électro-luminescentes",0,3,2008352,0
+2005083,Douilles,0,3,2011499,0
+2005256,"Marteaux à piquer",0,3,1000258,0
+2005435,"Bibliothèques de bureau",0,3,2012285,0
+2012811,Livrets,0,2,2011176,0
+2006120,"Combustibles pour cheminées",0,3,2006109,0
+2006714,"Interrupteurs programmables",0,3,2010661,0
+2011312,"Bustes de marianne",0,2,2011311,0
+2011313,"Médailles et décorations",0,2,2011311,0
+2011177,Répertoires,0,2,2011176,0
+2008776,Protège-cahiers,0,2,2011176,0
+2001530,Cahiers,0,2,2011176,0
+2002428,"Marteaux rivoirs",0,3,1000258,0
+1001038,"Indicateurs lumineux",0,3,2011426,0
+2007153,Plafonniers,0,3,2010944,0
+2001532,"Chemises simples",0,3,2010153,0
+2011182,Registres,0,2,2011176,0
+1001338,"Clés plates",0,3,1000257,0
+1002300,"Boîtes d'archives",0,3,2010161,0
+1001337,"Clés à rochet",0,3,1000257,0
+1001336,"Clés à choc",0,3,1000257,0
+2011183,"Carnets imprimés",0,2,2011176,0
+1002583,"Clés torx",0,3,1000257,0
+2000524,"Projecteurs d'éclairage extérieur",0,3,2010430,0
+1001335,"Clés à sangle",0,3,1000257,0
+2001494,"Lampes halogènes",0,3,2011489,0
+2001531,"Pochettes perforées",0,3,2010153,0
+1001334,"Clés allen",0,3,1000257,0
+2001537,"Fichiers de classement",0,3,2013176,0
+2002409,"Autres clés de serrage",0,3,1000257,0
+1001333,"Clés à cliquet",0,3,1000257,0
+2001704,"Électrovannes pneumatiques",0,3,2002152,0
+2001741,"Équipements pour lampes",0,3,2011499,0
+2001758,Pèse-colis,0,3,2013034,0
+2001862,"Autres systèmes d'éclairage par led",0,3,2008352,0
+2011184,"Carnets vierges",0,2,2011176,0
+2011178,Pense-bêtes,0,2,2011176,0
+1001068,"Démarreurs électromécaniques",0,3,2003782,0
+2002043,Pèse-lettres,0,3,2013034,0
+2002403,"Clés à pipe",0,3,1000257,0
+2002404,"Clés à molette",0,3,1000257,0
+2002407,"Clés polygonales",0,3,1000257,0
+2002408,"Clés grippings",0,3,1000257,0
+2007150,"Lampes à incandescence",0,3,2011489,0
+2007552,"Marteaux piqueurs",0,3,1000258,0
+2002400,"Pinces à dénuder",0,2,2012174,0
+2002097,"Accessoires robinetterie et vannes",0,2,2011698,0
+2008648,"Équipements pour interrupteurs électriques",0,3,2008591,0
+2008700,"Boutons poussoirs muraux",0,3,2008592,0
+2008720,"Interrupteurs inverseurs de polarités",0,3,2008591,0
+2008753,"Commutateurs à clé",0,3,2005049,0
+2008821,"Accessoires pour distributeurs pneumatiques",0,3,1000208,0
+2008889,"Lampes à décharge",0,3,2011515,0
+2009964,"Accessoires pour marteaux",0,3,1000258,0
+2010022,"Accessoires pour vannes et électrovannes",0,3,2002152,0
+2010154,"Chemises à rabats",0,3,2010153,0
+2010155,"Chemises extensibles",0,3,2010153,0
+2010156,Sous-chemises,0,3,2010153,0
+2010158,"Chemises de présentation",0,3,2010153,0
+2010159,Chemises-pochettes,0,3,2010153,0
+2008626,Commutateurs,0,3,2005049,0
+2010163,"Pochettes d'archives",0,3,2010161,0
+2010167,"Pochettes coins",0,3,2010153,0
+2010204,"Accessoires pour fichiers et boîtes à fiches",0,3,2013176,0
+1001728,"Chauffages de piscine",0,2,2011728,0
+2001974,Hygrostats,0,2,2012030,0
+2010299,"Plaques pour modules",0,3,2010785,0
+1001088,"Mors d'étaux",0,2,2012174,0
+2010306,"Kits pour moteurs électriques",0,3,2011961,0
+2011179,Bloc-notes,0,2,2011176,0
+1001346,"Pinces coupantes",0,2,2012174,0
+1001363,"Extracteurs à griffes",0,2,2012174,0
+2002397,"Pinces étaux",0,2,2012174,0
+2002399,"Pinces à bec",0,2,2012174,0
+2008645,"Interrupteurs muraux",0,3,2008591,0
+2002094,"Vannes de régulation",0,2,2011698,0
+2007862,"Commutateurs programmables",0,3,2005049,0
+2008319,"Chevalets d'affichage",0,3,2004214,0
+2008053,"Variateurs électriques d'éclairage",0,3,2008764,0
+2012678,Cocardes,0,2,2011311,0
+2012979,"Coussins d'inauguration",0,2,2011311,0
+2008151,"Blocs effaceurs",0,3,2008150,0
+2013061,"Insignes pour élus",0,2,2011311,0
+2008152,"Éléments d'affichage  magnétique",0,3,2008150,0
+2008216,"Lampes fluorescentes",0,3,2011047,0
+2008315,"Interrupteurs à bascule",0,3,2011115,0
+2008317,"Chevalets de conférence",0,3,2004214,0
+2008318,"Chevalets d'accueil",0,3,2004214,0
+2011007,"Blocs d'alimentation réglables",0,2,2010989,0
+2007578,"Adaptateurs d'alimentation",0,2,2010989,0
+2010936,"Plaques d'essais",0,2,2010934,0
+1001739,"Autres éléments chauffants",0,2,2010772,0
+2003658,"Charges électroniques",0,2,2010934,0
+2008354,"Indicateurs à led",0,3,2011426,0
+2008355,"Equipements pour led",0,3,2008352,0
+2008358,"Eclairage linéaire à led",0,3,2008352,0
+2012361,"Chaufferettes d'armoire",0,2,2010772,0
+2004147,"Grilles de protection de ventilateurs",0,2,2011345,0
+2008368,"Spots d'éclairage à led",0,3,2008352,0
+2008414,"Eclairage portatif à led",0,3,2008352,0
+2008593,"Boutons poussoirs d'urgence",0,3,2008592,0
+2008600,"Equipements pour boutons poussoirs",0,3,2008592,0
+2008604,"Interrupteurs à levier",0,3,2011115,0
+2005158,"Autres accessoires de ventilateurs",0,2,2011345,0
+2008611,"Interrupteurs à détecteurs de présence",0,3,2008591,0
+2002398,"Pinces multiprises",0,2,2012174,0
+2003411,"Climatiseurs monoblocs mobiles réversibles",0,2,1000351,0
+2013288,"Accessoires pour contacteurs",0,2,2010170,0
+1001910,"Détecteurs d'ouverture",0,2,1000072,0
+1002024,"Mousquetons et accessoires antichutes",0,2,1000073,0
+1002016,"Lunettes de protection",0,2,1000073,0
+1002014,"Harnais de sécurité",0,2,1000073,0
+1001977,"Ceintures de protection",0,2,1000073,0
+1001975,Cagoules,0,2,1000073,0
+2002709,"Détecteurs de mouvement",0,2,1000072,0
+1001908,"Détecteurs de bris de verre",0,2,1000072,0
+2002621,Genouillères,0,2,1000073,0
+2014116,"Équipements pour groupes hydrauliques",0,2,1000036,0
+2002720,"Régulateurs et limiteurs de pression",0,2,1000036,0
+1001160,"Électrovannes hydrauliques",0,2,1000036,0
+2010653,"Accessoires pour vérins pneumatiques",0,2,1000035,0
+2005411,"Limitateurs de débit pneumatiques",0,2,1000035,0
+2003208,"Lubrificateurs pneumatiques",0,2,1000035,0
+2001744,"Casquettes anti-heurts",0,2,1000073,0
+2002650,"Casques forestiers",0,2,1000073,0
+1001368,Soufflettes,0,2,1000035,0
+2005956,"Accessoires pour gants",0,2,1000073,0
+2008311,"Barres magnétiques",0,2,1000174,0
+2012490,"Lampes loupes de bureaux",0,2,1000087,0
+2005602,"Lampes d'ateliers",0,2,1000087,0
+2002658,"Lampes de bureaux",0,2,1000087,0
+2006532,"Brassards de sécurité",0,2,1000073,0
+2006015,"Mitaines de protection",0,2,1000073,0
+2005218,"Arceaux anti-bruits",0,2,1000073,0
+2002661,"Vêtements haute visibilité",0,2,1000073,0
+2004046,"Gants électriciens",0,2,1000073,0
+2002973,"Accessoires chaussures de sécurité",0,2,1000073,0
+2002915,"Manchettes de sécurité",0,2,1000073,0
+2002914,Jambières,0,2,1000073,0
+2002688,"Accessoires lampes individuelles",0,2,1000073,0
+2002671,"Accessoires casques",0,2,1000073,0
+2002665,"Lampes frontales",0,2,1000073,0
+2000515,"Outillages pneumatiques",0,2,1000035,0
+2012153,"Bagues de guidage",0,2,1000033,0
+1000995,"Autres batteries",0,2,1000180,0
+2003953,"Courroies rondes",0,2,1000031,0
+2003028,Dégrippants,0,2,1000032,0
+1001114,"Additifs lubrifiants",0,2,1000032,0
+2004290,"Rotules mécaniques pour vérin",0,2,1000031,0
+2004112,"Poulies variables",0,2,1000031,0
+2003973,"Courroies spéciales",0,2,1000031,0
+2003965,"Courroies trapézoïdales",0,2,1000031,0
+2003907,Servo-vérins,0,2,1000031,0
+2004142,"Aérosols lubrifiants",0,2,1000032,0
+2003898,"Vérins rotatifs",0,2,1000031,0
+2003672,"Accessoires pour courroies",0,2,1000031,0
+2003456,Réas,0,2,1000031,0
+2003455,"Poulies à chape et ouvrantes",0,2,1000031,0
+2003454,Moufles,0,2,1000031,0
+1001075,"Courroies plates",0,2,1000031,0
+1001071,"Courroies poly v",0,2,1000031,0
+2004096,"Joints toriques",0,2,1000032,0
+2004149,"Systèmes de graissage",0,2,1000032,0
+2010484,"Charnières de sécurité",0,2,1000033,0
+1001128,"Pieds fixes",0,2,1000033,0
+2009989,"Roulements à aiguilles",0,2,1000033,0
+2009988,"Roulements à rouleaux",0,2,1000033,0
+2004316,"Positionneurs magnétiques",0,2,1000033,0
+2004313,"Accessoires pour roulements",0,2,1000033,0
+2004240,"Plaques anti-vibratoires",0,2,1000033,0
+2003643,"Poussoirs de positionnement",0,2,1000033,0
+1001126,Cales,0,2,1000033,0
+2004189,"Kits de graissage",0,2,1000032,0
+1001124,"Suspensions anti-vibratoires",0,2,1000033,0
+1001116,"Roulements à billes",0,2,1000033,0
+2011965,"Bouchons de vidange",0,2,1000032,0
+2011611,"Huiles pour moteurs",0,2,1000032,0
+2011599,"Joints extrudés",0,2,1000032,0
+2004207,"Récipients pour lubrifiants",0,2,1000032,0
+2004193,"Conduits de lubrification",0,2,1000032,0
+9000178,"Plateau magnétique à aimant permanent",0,2,1000174,0
+1000996,Accumulateurs,0,2,1000180,0
+2007690,"Filtres à carburant",0,2,1000030,0
+2002841,"Scies sabre",0,2,1000262,0
+2010322,"Scies circulaires d'établis",0,2,1000262,0
+2010321,"Accessoires pour scies",0,2,1000262,0
+2005184,"Scies à onglet",0,2,1000262,0
+2004020,"Scies automatiques",0,2,1000262,0
+2004014,"Scies à bois et pvc",0,2,1000262,0
+2003016,"Scies trépans",0,2,1000262,0
+2002840,"Scies sauteuses",0,2,1000262,0
+2010337,"Lames pour scies sauteuses",0,2,1000262,0
+2002416,"Scies à métaux",0,2,1000262,0
+2012511,"Outils de ponçage",0,2,1000261,0
+2012332,"Ponceuses à bandes portatives",0,2,1000261,0
+2005520,"Ponceuses excentriques portatives",0,2,1000261,0
+1001351,"Ponceuses vibrantes portatives",0,2,1000261,0
+1001350,"Accessoires pour ponceuses",0,2,1000261,0
+1001349,"Ponceuses angulaires portatives",0,2,1000261,0
+2010336,"Lames scies à rubans",0,2,1000262,0
+2010339,"Lames pour scies sabres",0,2,1000262,0
+2009904,"Raccords en tés et en y",0,2,1000216,0
+1001388,"Fers à souder",0,2,1000272,0
+2003520,"Accessoires pour fer à souder",0,2,1000272,0
+2003514,"Postes de soudage par flamme",0,2,1000272,0
+2003512,"Onduleurs de soudage",0,2,1000272,0
+2002907,"Torches de soudage",0,2,1000272,0
+2001849,"Matériels de dessoudage",0,2,1000272,0
+1001389,"Chalumeaux de soudage",0,2,1000272,0
+1001387,"Kits de soudage",0,2,1000272,0
+2010340,"Lames pour scies onglets",0,2,1000262,0
+1001385,"Accessoires de soudage à l'arc",0,2,1000272,0
+2008729,"Accessoires pour collage",0,2,1000271,0
+2014098,"Scies à mousse",0,2,1000262,0
+2013900,"Lames pour scies plongeantes",0,2,1000262,0
+2013682,"Scies plongeantes",0,2,1000262,0
+2012231,"Lames pour scies à bois",0,2,1000262,0
+2010342,"Lames pour scies à métaux",0,2,1000262,0
+1001348,"Ponceuses à bandes",0,2,1000261,0
+1001699,"Raccords hydrauliques coudés",0,2,1000216,0
+1000997,"Piles électriques",0,2,1000180,0
+2008195,"Chargeurs de piles",0,2,1000180,0
+2008213,"Chargeurs pour appareils d'outillage électrique",0,2,1000180,0
+2008204,"Chargeurs de téléphones",0,2,1000180,0
+2008201,"Chargeurs d'ordinateurs portables",0,2,1000180,0
+2008200,"Chargeurs pour appareils photos",0,2,1000180,0
+2008199,"Chargeurs multivoies",0,2,1000180,0
+2008197,"Chargeurs usb",0,2,1000180,0
+2008184,"Batteries stationnaires",0,2,1000180,0
+2008256,"Chargeurs pour véhicules",0,2,1000180,0
+2008176,"Batteries pour appareils photos",0,2,1000180,0
+2008174,"Batteries pour outillage électrique",0,2,1000180,0
+2008171,"Equipements pour batteries",0,2,1000180,0
+2008165,"Batteries pour onduleurs",0,2,1000180,0
+2006844,"Chargeurs solaires",0,2,1000180,0
+2001407,"Batteries téléphones",0,2,1000180,0
+1000998,"Autres chargeurs",0,2,1000180,0
+2008238,"Batteries pour appareils vidéos",0,2,1000180,0
+2008851,"Piles au lithium",0,2,1000180,0
+2019442,"Pompe pour perceuse",0,2,1000215,0
+2013290,"Accessoires pour boîtiers de raccordement",0,2,1000181,0
+2002722,"Autres pompes hydrauliques",0,2,1000215,0
+2002484,"Pompes hydrauliques à pistons",0,2,1000215,0
+2002138,"Pompes électriques",0,2,1000215,0
+1001168,"Pompes hydrauliques à membranes",0,2,1000215,0
+2007958,"Accessoires pour vérins hydrauliques",0,2,1000214,0
+2010949,"Compresseurs  autonomes",0,2,1000207,0
+2013280,"Couvercles pour boîtiers de raccordement",0,2,1000181,0
+2008852,"Piles alcalines",0,2,1000180,0
+2010766,"Boîtiers encastrés",0,2,1000181,0
+2009768,"Équipements pour coffrets électriques",0,2,1000181,0
+2008857,"Boîtiers de raccordement",0,2,1000181,0
+2007458,"Coffrets de comptage",0,2,1000181,0
+2001994,"Tableaux de distribution",0,2,1000181,0
+2013910,"Régénérateurs de batterie",0,2,1000180,0
+2009782,"Accessoires de piles",0,2,1000180,0
+2009309,"Liquides de refroidissement",0,2,1000030,0
+2003737,"Moteurs linéaires",0,2,1000030,0
+2003810,"Lampes à souder",0,2,1000272,0
+2016905,"Gerbeur électrique",0,1,1000013,0
+1001292,"Gammes de mobiliers industriels",0,1,1000014,0
+2017971,"Matériel de manutention et logistique",0,1,1000013,0
+2017817,"Stockage avec bac de rétention",0,1,1000013,0
+2017816,"Caisse(s) palette(s) en plastique gerbable(s)",0,1,1000013,0
+2017356,"Rayonnage commercial",0,1,1000013,0
+2016906,"Transpalette électrique",0,1,1000013,0
+2016903,"Chariot élévateur",0,1,1000013,0
+2001526,"Papiers blancs",0,1,1000014,0
+2013783,"Accessoires pour racks de stockage",0,1,1000013,0
+2013773,"Racks de stockage pour panneaux",0,1,1000013,0
+2013334,"Accessoires pour pistolets attacheurs",0,1,1000013,0
+2011071,"Mallettes médicales",0,1,1000013,0
+2010834,"Accessoires pour jerricans",0,1,1000013,0
+2009956,"Consommables pour marquage industriel",0,1,1000013,0
+2001525,"Enveloppes papier",0,1,1000014,0
+2001527,"Papiers couleurs",0,1,1000014,0
+2009137,"Seaux, cuvettes et bassines logistique",0,1,1000013,0
+2002625,Attachés-cases,0,1,1000014,0
+2003294,"Papiers calque",0,1,1000014,0
+2003218,Porte-copies,0,1,1000014,0
+2002762,"Taille crayons",0,1,1000014,0
+2002628,"Valises et sacs de voyage",0,1,1000014,0
+2002627,"Sacoches de livraison",0,1,1000014,0
+2002626,"Cartables et serviettes",0,1,1000014,0
+2002604,"Pots à crayons",0,1,1000014,0
+2001528,"Papiers spéciaux",0,1,1000014,0
+2002596,Agendas,0,1,1000014,0
+2002386,"Postes qualités industriels",0,1,1000014,0
+2002379,"Tampons - dateurs",0,1,1000014,0
+2001581,"Destructeurs de documents",0,1,1000014,0
+2001552,"Gammes de fournitures de bureaux",0,1,1000014,0
+2001548,Colles,0,1,1000014,0
+2001547,"Rubans adhésifs",0,1,1000014,0
+2009854,"Pistolets attacheurs",0,1,1000013,0
+2005164,"Décolleuses d'étiquettes",0,1,1000013,0
+2005174,Plannings,0,1,1000014,0
+2004301,"Relais reed",0,1,1000003,0
+2013526,"Packs outils pour électricité et électronique",0,1,1000003,0
+2012633,"Accessoires pour potentiomètres",0,1,1000003,0
+2009176,"Peignes de raccordement électrique",0,1,1000003,0
+2004307,"Interfaces de connexions de relais électriques",0,1,1000003,0
+2004304,"Relais de puissance",0,1,1000003,0
+2004303,"Relais temporisés",0,1,1000003,0
+2004299,"Relais de contrôle",0,1,1000003,0
+2013963,"Matériels d'enseignement en électricité",0,1,1000003,0
+2004298,"Relais de sécurité",0,1,1000003,0
+2003963,"Connecteurs électriques",0,1,1000003,0
+2001789,"Pinces électriques",0,1,1000003,0
+1001019,"Relais différentiels",0,1,1000003,0
+1000971,Résistances,0,1,1000003,0
+1000967,Potentiomètres,0,1,1000003,0
+1000951,"Accessoires pour circuits imprimés",0,1,1000003,0
+2013909,"Relais thermiques",0,1,1000003,0
+2008109,"Livres hydraulique et pneumatique",0,1,1000005,0
+2003060,"Étuis et pochettes à outils",0,1,1000013,0
+2015579,"Télésurveillance et Vidéoprotection",0,1,1000012,0
+2002946,"Galets de manutention",0,1,1000013,0
+2002850,"Paniers logistiques",0,1,1000013,0
+2002452,"Sacoches et sacs à outils",0,1,1000013,0
+2002237,"Accessoires pour coffres et boîtes",0,1,1000013,0
+1002275,"Réservoirs de stockage petites capacités",0,1,1000013,0
+1002151,"Autres accessoires et pièces de rechange",0,1,1000013,0
+2002523,"Poubelles anti-feu",0,1,1000012,0
+1001775,"Dudgeonnières, manifolds & flexibles",0,1,1000011,0
+1002049,"Consignes de sécurité",0,1,1000012,0
+2011089,"Radiants à fioul",0,1,1000011,0
+2004275,"Commandes et gestions de chauffage",0,1,1000011,0
+2003377,"Chauffage de véhicules",0,1,1000011,0
+2003366,"Vases d'expansion et accessoires",0,1,1000011,0
+2001917,"Autres accessoires de régulation",0,1,1000011,0
+2001898,"Autres équipements de chauffage",0,1,1000011,0
+2004281,Sous-mains,0,1,1000014,0
+2005176,"Fiches t",0,1,1000014,0
+2003705,"Moteurs pas à pas",0,2,1000030,0
+2010812,"Machines à affranchir Quadient",0,1,1000014,0
+2012170,"Équipements éducatifs",0,1,1000014,0
+2011866,"Accessoires pour calculatrices",0,1,1000014,0
+2011624,"Accessoires de gestion du temps",0,1,1000014,0
+2011455,"Huiles pour destructeurs de documents",0,1,1000014,0
+2011188,"Copies scolaires",0,1,1000014,0
+2010816,"Plateaux d'émargements",0,1,1000014,0
+2010705,Porte-blocs,0,1,1000014,0
+2012314,"Tapis en polycarbonate",0,1,1000014,0
+2010379,"Bandes auto-agrippantes",0,1,1000014,0
+2010378,"Pastilles adhésives",0,1,1000014,0
+2010310,"Attaches à relier",0,1,1000014,0
+2010304,"Coins de lettres",0,1,1000014,0
+2010303,Doigtiers,0,1,1000014,0
+2010302,"Attaches parisiennes",0,1,1000014,0
+2010301,"Mécanismes de reliure",0,1,1000014,0
+2012313,"Tapis en pvc",0,1,1000014,0
+2012315,"Tapis en polyéthylène",0,1,1000014,0
+2010294,"Epingles et punaises",0,1,1000014,0
+2017382,"Machine à café professionnelle",0,1,1000014,0
+2003702,"Moteurs à courant continu",0,2,1000030,0
+1001182,"Filtres à air pour moteurs thermiques",0,2,1000030,0
+2017931,"Total Energie : Gaz et électricité",0,1,1000014,0
+2017706,"Solution d'encaissement - Exclu digitale",0,1,1000014,0
+2017541,"Sécurité de domicile personnel",0,1,1000014,0
+2017494,"Carte carburant CCS",0,1,1000014,0
+2017062,"Cloison modulaire",0,1,1000014,0
+2012316,"Autres tapis protège-sols",0,1,1000014,0
+2017061,Cantilever,0,1,1000014,0
+2017060,"Mezzanine et Plate-forme de stockage",0,1,1000014,0
+2017034,"Mobiliers d'entreprise",0,1,1000014,0
+2017032,"Portique anti-vol",0,1,1000014,0
+2015588,"Encres pour machine à affranchir",0,1,1000014,0
+2013965,"Machines à affranchir (+ de 20 plis par jour)",0,1,1000014,0
+2013823,"Accessoires et consommables de timbristes",0,1,1000014,0
+2010295,Attache-lettres,0,1,1000014,0
+2010293,Elastiques,0,1,1000014,0
+2005202,"Pointeurs lasers",0,1,1000014,0
+2005525,"Accessoires pour mobiliers de travail",0,1,1000014,0
+2007678,"Trousses à crayons",0,1,1000014,0
+2006065,Porte-documents,0,1,1000014,0
+2005607,"Plans de travail",0,1,1000014,0
+2005606,"Postes de montage",0,1,1000014,0
+2005595,Marque-pages,0,1,1000014,0
+2005560,"Dessertes et servantes de bureaux",0,1,1000014,0
+2005515,"Autres accessoires pour établis",0,1,1000014,0
+2008002,"Papiers listing",0,1,1000014,0
+2005513,"Blocs tiroirs pour établis",0,1,1000014,0
+2005511,"Plateaux pour établis",0,1,1000014,0
+2005358,"Couvertures pour reliures",0,1,1000014,0
+2005357,"Anneaux et baguettes à relier",0,1,1000014,0
+2005336,Encriers,0,1,1000014,0
+2005275,Serre-livres,0,1,1000014,0
+2005270,"Protèges documents",0,1,1000014,0
+2007897,"Papiers à dessin",0,1,1000014,0
+2008137,"Compléments de servantes et dessertes",0,1,1000014,0
+2010134,Porte-revues,0,1,1000014,0
+2009445,Pique-notes,0,1,1000014,0
+2009969,Portes-timbres,0,1,1000014,0
+2009834,"Relieuses par serrage",0,1,1000014,0
+2009833,Perforelieuses,0,1,1000014,0
+2009558,"Blocs éphémérides",0,1,1000014,0
+2009493,Oeillets,0,1,1000014,0
+2009447,Trombones,0,1,1000014,0
+2009425,Ote-agrafes,0,1,1000014,0
+2008703,"Papiers pré-imprimés",0,1,1000014,0
+2009313,"Accessoires pour perforateurs",0,1,1000014,0
+2009281,"Sacs pour destructeurs de documents",0,1,1000014,0
+2009237,Calendriers,0,1,1000014,0
+2009044,"Fiches bristol",0,1,1000014,0
+2009027,"Arrondisseurs d'angles",0,1,1000014,0
+2008787,"Agrafes de bureau",0,1,1000014,0
+2008770,"Étiquettes à bagages",0,1,1000014,0
+2003807,"Pinces porte-électrodes",0,2,1000272,0
+2003868,"Postes de soudage par effet joule",0,2,1000272,0
+2008619,"Interrupteurs différentiels",0,2,2010170,0
+2005512,"Établis de sciage  fraisage",0,2,2005495,0
+2005559,"Accessoires pour armoires",0,2,2005553,0
+2005557,"Armoires à rideaux",0,2,2005553,0
+2005554,"Armoires basses",0,2,2005553,0
+2004136,"Rehausses d'armoires",0,2,2005553,0
+1002292,"Armoires hautes d'ateliers",0,2,2005553,0
+2005516,"Établis avec étaux",0,2,2005495,0
+2005500,"Établis nus",0,2,2005495,0
+2012377,"Tendeurs d'arrimage",0,2,2005973,0
+2005498,"Établis avec étagères",0,2,2005495,0
+2005496,"Établis avec coffres",0,2,2005495,0
+2014004,"Accessoires pour casiers de rangement",0,2,2005198,0
+2011981,"Cadres porte-outils",0,2,2005198,0
+2011351,"Accessoires pour blocs-tiroirs",0,2,2005198,0
+2011350,"Blocs-tiroirs de bureaux",0,2,2005198,0
+2011278,"Armoires basses d'atelier",0,2,2005553,0
+2012383,"Sandow d'arrimage",0,2,2005973,0
+2011337,"Chariots porte-outils",0,2,2005198,0
+2004031,"Pulls de travail",0,2,2007417,0
+2007512,"Hauts de travail",0,2,2007417,0
+2007510,"Combinaisons et ensembles de travail",0,2,2007417,0
+2007509,"Cottes et salopettes de travail",0,2,2007417,0
+2007421,"Gammes de vêtements de travail",0,2,2007417,0
+2007420,"Gilets de travail",0,2,2007417,0
+2007419,"Coiffes de travail",0,2,2007417,0
+1001985,"Chaussettes de travail",0,2,2007417,0
+2013615,"Chaînes d'arrimage",0,2,2005973,0
+2007276,"Accessoires de filtres d'eau",0,2,2007259,0
+2009861,"Lunettes masques de protection",0,2,2006800,0
+2007886,"Ecrans faciaux de protection",0,2,2006800,0
+2007072,"Masques respiratoires filtrants",0,2,2006800,0
+1002019,"Masques anti chaleur",0,2,2006800,0
+2012347,"Lubrifiants pneumatiques",0,2,2005982,0
+2002093,"Pistolets polyvalents hydro-pneumatiques",0,2,2005982,0
+2011339,"Accessoires pour panneaux",0,2,2005198,0
+2010231,"Classeurs à tiroirs",0,2,2005198,0
+2011858,"Pantalons,jupes et shorts de travail",0,2,2007417,0
+2005468,"Caissons de bureaux mobiles",0,2,2002437,0
+2011668,"Sacoches pour ordinateurs",0,2,2005079,0
+2008605,"Boutons à clé",0,2,2004225,0
+2012514,"Signalétiques adhésives pour rayonnages",0,2,2003288,0
+2003293,"Signalétiques à fixation mécanique d'entrepôts",0,2,2003288,0
+2003284,"Signalétiques magnétiques d'entrepôts",0,2,2003288,0
+2005469,"Caissons de bureaux fixes",0,2,2002437,0
+2013092,"Supports pour livre",0,2,2002383,0
+2011670,"Housses pour ordinateurs",0,2,2005079,0
+2011867,"Étiquettes de portes",0,2,2002383,0
+2011373,"Tableaux rainurés",0,2,2002383,0
+2008883,Porte-noms,0,2,2002383,0
+2008882,"Panneaux directionnels",0,2,2002383,0
+2008170,"Tableaux adhésifs",0,2,2002383,0
+2007966,"Pupitres de tables",0,2,2002383,0
+2005380,"Tableaux mixtes",0,2,2002383,0
+2011669,"Sacs à dos pour ordinateurs",0,2,2005079,0
+1002299,"Casiers de rangement",0,2,2005198,0
+2010201,"Trieurs valisettes",0,2,2005198,0
+2010130,"Modules de tri",0,2,2005198,0
+2010197,Parapheurs,0,2,2005198,0
+2010195,"Meubles pour dossiers suspendus",0,2,2005198,0
+2010191,Intercalaires,0,2,2005198,0
+2010140,"Corbeilles à courrier",0,2,2005198,0
+2010133,"Trieurs verticaux",0,2,2005198,0
+2010131,"Colonnes de classement à clapets",0,2,2005198,0
+2009974,"Chariots à dossier",0,2,2005198,0
+1002301,"Crochets et pinces à outils",0,2,2005198,0
+2009891,"Panneaux perforés",0,2,2005198,0
+2005319,"Compartimentage de tiroirs",0,2,2005198,0
+2003786,"Distribution de courriers",0,2,2005198,0
+2002482,"Porte-outils aimantés",0,2,2005198,0
+2001535,"Dossiers suspendus",0,2,2005198,0
+2001534,Trieurs,0,2,2005198,0
+2001533,Classeurs,0,2,2005198,0
+2011857,"Blousons,vestes et parkas de travail",0,2,2007417,0
+1002262,"Palettes en carton",0,2,2007619,0
+2005229,"Tableaux magnétiques",0,2,2002383,0
+2008038,"Equipements pour groupes électrogènes",0,2,2009366,0
+2007154,"Rails pour prises",0,2,2009837,0
+2005090,"Adaptateurs électriques de voyage",0,2,2009837,0
+2002121,"Embases secteur",0,2,2009837,0
+1001009,"Multiprises à interruption",0,2,2009837,0
+2009403,"Feuilles de plastification",0,2,2009818,0
+2018501,"Installation de panneaux photovoltaïques",0,2,2009368,0
+2012053,"Accessoires pour fax et télécopieurs",0,2,2009341,0
+2009163,"Multiprises de sécurité",0,2,2009837,0
+2009342,Télécopieurs,0,2,2009341,0
+2002842,"Téléphones fax",0,2,2009341,0
+2009338,"Photocopieurs portables",0,2,2009337,0
+2005562,"Accessoires pour copieurs",0,2,2009337,0
+2012119,"Accessoires pour décapeuses",0,2,2009246,0
+2010370,"Accessoires de peinture",0,2,2009246,0
+2010368,"Stations de peinture",0,2,2009246,0
+2009161,"Fiches secteur",0,2,2009837,0
+2009165,"Fiches programmables",0,2,2009837,0
+2004676,"Décapeuses manuelles",0,2,2009246,0
+9000292,"Banc gigogne",0,2,2010018,0
+2004237,Microrupteurs,0,2,2010170,0
+1001031,Contacteurs,0,2,2010170,0
+1001012,Fusibles,0,2,2010170,0
+2011798,"Équipements pour disjoncteurs",0,2,2010166,0
+2010165,"Disjoncteurs magnéto-thermiques",0,2,2010166,0
+1001020,"Disjoncteurs différentiels",0,2,2010166,0
+2009923,"Cordons pour connecteurs de tests",0,2,2009919,0
+2009172,"Protection de prises",0,2,2009837,0
+2009920,Grips-fils,0,2,2009919,0
+2009851,"Borniers électroniques",0,2,2009888,0
+1001022,Porte-fusibles,0,2,2009888,0
+2013356,"Outils pour embases de connecteurs",0,2,2009866,0
+2009869,"Embases de connecteurs",0,2,2009866,0
+2004650,"Connecteurs pour circuits imprimés",0,2,2009866,0
+2004652,"Connecteurs coaxiaux",0,2,2009855,0
+2007790,"Masquages pour peinture",0,2,2009246,0
+2013208,Agitateurs,0,2,2008987,0
+1002269,"Caisses-palettes en carton",0,2,2007619,0
+2004404,"Convertisseurs en fréquence",0,2,2007948,0
+2005102,"Convertisseurs de tension",0,2,2007948,0
+2005099,"Convertisseurs dc-ac",0,2,2007948,0
+2004581,"Condensateurs de puissance",0,2,2007948,0
+2004579,"Condensateurs non-électrolytiques",0,2,2007948,0
+2004578,"Condensateurs électrolytiques",0,2,2007948,0
+2004410,"Convertisseurs de courant",0,2,2007948,0
+2003177,Télécommandes,0,2,2007948,0
+2008128,"Onduleurs électriques non-autonomes",0,2,2007948,0
+1000964,Diodes,0,2,2007948,0
+2012998,Rapporteurs,0,2,2007890,0
+2009508,"Trace-lettres et pistolets à dessin",0,2,2007890,0
+2007895,"Équerres à dessin",0,2,2007890,0
+2017818,"Benne(s) à déchets",0,2,2007627,0
+2008135,"Coiffes et fonds de palettes",0,2,2007619,0
+2004432,"Palettes en polystyrène",0,2,2007619,0
+2006861,"Équipements pour télécommandes",0,2,2007948,0
+2008371,"Autres transformateurs",0,2,2007948,0
+2011662,"Piètements pour mange-debout",0,2,2008987,0
+2008531,"Bidons de sécurité",0,2,2008392,0
+2008991,Gobelets,0,2,2008987,0
+2005467,"Distributeurs de gobelets",0,2,2008987,0
+2005464,"Fontaines à eau",0,2,2008987,0
+2008900,"Chauffe-eau à gaz",0,2,2008684,0
+2008896,"Accessoires pour chauffe-eau",0,2,2008684,0
+2001893,Chauffe-bains,0,2,2008684,0
+2017369,"Logiciel de gestion commerciale",0,2,2008348,0
+2008410,"Equipements pour onduleurs",0,2,2007948,0
+2008328,"Produits anti-corrosion",0,2,2008325,0
+2004293,"Vernis pour cartes électroniques",0,2,2008325,0
+2013347,"Transformateurs à rail din",0,2,2007948,0
+2011942,"Accessoires de conversion signaux électriques",0,2,2007948,0
+2011689,"Équipements pour radiocommandes",0,2,2007948,0
+2010678,"Télécommandes infrarouges",0,2,2007948,0
+2010656,"Émetteurs de commandes infrarouges",0,2,2007948,0
+2005283,"Extensions pour  pupitre",0,2,2002383,0
+2004206,"Tableaux en liège",0,2,2002383,0
+2004174,"Accessoires de soudage par flamme",0,2,1000272,0
+2002889,"Plaques signalétiques",0,2,1000384,0
+2002448,"Écrans de protection",0,2,1000386,0
+2015610,"Blocs autonomes d'éclairage de sécurité",0,2,1000384,0
+2010214,"Rubans de balisage",0,2,1000384,0
+2010213,"Cônes de balisage",0,2,1000384,0
+2006956,"Accessoires de signalisation",0,2,1000384,0
+2003768,"Chaînes de balisage",0,2,1000384,0
+2002686,"Eclairages de signalisation",0,2,1000384,0
+2015575,"Potences pour chariots élévateurs",0,2,1000392,0
+1002073,"Signalisations incendie",0,2,1000384,0
+1002067,"Signalisations de chantier",0,2,1000384,0
+2018393,"Sécurité de domicile - alarme et vidéoprotection",0,2,1000377,0
+2008758,"Drones de surveillance",0,2,1000377,0
+2000035,"Cartes d'acquisition vidéo",0,2,1000377,0
+1001959,"Ecrans de vidéosurveillance",0,2,1000377,0
+1001956,"Systèmes de veille bébé",0,2,1000377,0
+2006427,"Accessoires lecteurs / scanners code-barres",0,2,1000387,0
+2012947,"Accessoires pour transpalettes",0,2,1000395,0
+1001954,"Matériels de consignation",0,2,1000375,0
+2003344,"Billes pour convoyeurs / transporteurs",0,2,1000399,0
+2003496,"Serre-câbles pour câbles de levage",0,2,1000401,0
+2003484,"Mailles et maillons de levage",0,2,1000401,0
+2003467,"Griffes et crochets de levage",0,2,1000401,0
+2003461,"Chandelles de levage et de calage",0,2,1000401,0
+1002174,"Accessoires pour guirlandes d'alimentation",0,2,1000401,0
+2005505,"Convoyeurs / transporteurs à coudes",0,2,1000399,0
+1002163,"Autres composants de convoyeurs",0,2,1000399,0
+2017820,Transpalette(s),0,2,1000395,0
+2017913,"Remorque de vélo",0,2,1000397,0
+2000900,"Accessoires remorques industrielles",0,2,1000397,0
+1002144,"Coins roulants",0,2,1000397,0
+9000132,"Chariot industriel sur-mesure",0,2,1000396,0
+2017822,"Chariot(s) à niveau constant",0,2,1000396,0
+2000915,"Barres et ridelles pour chariots",0,2,1000396,0
+2000901,"Écritoires et porte-documents pour chariots",0,2,1000396,0
+2003513,"Sacs pour transport de fonds",0,2,1000375,0
+1001951,"Matériels de camouflage",0,2,1000375,0
+2013594,"Manilles de levage",0,2,1000401,0
+1000949,"Circuits imprimés",0,1,1000003,0
+2002023,"Brasseurs de ventilation",0,2,1000354,0
+2012204,"Filtres frigorifiques",0,2,1000351,0
+2004277,"Climatiseurs splits réversibles",0,2,1000351,0
+2003451,"Tubes vortex",0,2,1000351,0
+2003434,"Climatiseurs multisplits inverter",0,2,1000351,0
+2003422,"Climatiseurs splits mobiles",0,2,1000351,0
+2003401,"Climatiseurs splits inverter",0,2,1000351,0
+2011341,"Ventilateurs de bureaux et domestiques",0,2,1000354,0
+2003360,"Climatiseurs monoblocs mobiles",0,2,1000351,0
+2001933,"Supports de climatiseurs",0,2,1000351,0
+1001768,"Tubes de liaison et raccords",0,2,1000351,0
+2014005,"Accessoires pour poêles",0,2,1000344,0
+2007164,"Parasols chauffants électriques",0,2,1000344,0
+2005051,"Pinces de masse",0,2,1000272,0
+2004543,"Postes de soudage à air chaud",0,2,1000272,0
+2005157,"Ventilateurs plafonniers",0,2,1000354,0
+2009881,"Accessoires pour la gestion d'humidité",0,2,1000360,0
+2017020,"Contrôle d'Accès",0,2,1000370,0
+2003673,"Accessoires alarmes",0,2,1000369,0
+2008801,"Serrures en applique",0,2,1000370,0
+2008793,"Serrures à crémone",0,2,1000370,0
+2007919,"Serrures à mortaiser",0,2,1000370,0
+2003112,"Clés de serrurerie",0,2,1000370,0
+2003111,"Accessoires serrurerie",0,2,1000370,0
+2000863,"Gâches de serrurerie",0,2,1000370,0
+1001881,"Alarmes de véhicules",0,2,1000369,0
+2010277,"Humidificateurs à ultrasons",0,2,1000360,0
+1001878,"Alarmes à transmission téléphonique",0,2,1000369,0
+1001877,"Alarmes radio",0,2,1000369,0
+2008671,"Housses pour robinets d'incendie armés",0,2,1000367,0
+2002522,"Bacs à sable anti incendie",0,2,1000367,0
+1001944,Émulseurs,0,2,1000367,0
+1001873,"Couvertures anti feu",0,2,1000367,0
+2013921,"Protections souples anti-feux",0,2,1000365,0
+2011298,"Grues d'ateliers",0,2,1000401,0
+2013631,"Accessoires pour treuils",0,2,1000401,0
+2004198,"Plaques de portes",0,2,2002383,0
+2008658,Écritoires,0,2,2001520,0
+2008335,"Cloisons d'ateliers",0,2,2001553,0
+2012630,Portes-marqueurs,0,2,2001520,0
+2011931,"Stylos rapidograph",0,2,2001520,0
+2011233,"Recharges pour stylos rapidograph",0,2,2001520,0
+2010718,Portes-craies,0,2,2001520,0
+2009424,"Recharges d'encre pour stylos",0,2,2001520,0
+2008085,"Mines de crayons",0,2,2001520,0
+2008346,"Séparateurs de bureaux",0,2,2001553,0
+2003769,Craies,0,2,2001520,0
+2002455,"Stylos roller",0,2,2001520,0
+2002454,"Stylos encre gel",0,2,2001520,0
+2002378,Gommes,0,2,2001520,0
+2001545,"Crayons à papier",0,2,2001520,0
+2001544,Correcteurs,0,2,2001520,0
+2001543,"Stylos plume",0,2,2001520,0
+2008345,"Accessoires de séparateurs d'espaces",0,2,2001553,0
+1002291,"Tables d'atelier",0,2,2001554,0
+2001541,"Stylos bille",0,2,2001520,0
+2010181,"Pâtes thermiques",0,2,2001920,0
+2009909,"Bouchons pour tuyauterie",0,2,2002048,0
+2005413,"Raccords pneumatiques en t et y",0,2,2002048,0
+2003888,"Unions males & femelles",0,2,2002048,0
+1001712,"Autres fixations",0,2,2002048,0
+1000950,"Circuits intégrés",0,1,1000003,0
+1000209,"Raccords manchons tuyauterie",0,2,2002048,0
+2010704,"Sièges dactylo",0,2,2001558,0
+2008079,"Tables d'appoint",0,2,2001554,0
+2010701,"Sièges d'atelier",0,2,2001558,0
+2005477,Tabourets,0,2,2001558,0
+2005436,"Accessoires pour sièges",0,2,2001558,0
+2001762,Bancs,0,2,2001558,0
+2011348,"Accessoires pour tables",0,2,2001554,0
+2009503,"Tables ajustables",0,2,2001554,0
+2009497,"Tables de formations",0,2,2001554,0
+2001542,"Stylos feutre",0,2,2001520,0
+2001540,Surligneurs,0,2,2001520,0
+2013638,"Cosses et manchons pour câbles de levage",0,2,1000401,0
+2005453,"Extensions pour bureaux",0,2,1000422,0
+1000839,"Fibres optiques",0,2,1000999,0
+2010764,"Bureaux sur mesures",0,2,1000422,0
+2007060,"Bureaux plans compacts",0,2,1000422,0
+2005458,"Bureaux classiques droits",0,2,1000422,0
+2005457,"Bureaux d'angles",0,2,1000422,0
+2005456,"Bureaux avec caissons",0,2,1000422,0
+2002436,"Accessoires pour bureaux",0,2,1000422,0
+1001011,"Protections de câbles",0,2,1000999,0
+1002288,"Bureaux informatiques",0,2,1000422,0
+2018663,"Rack pour bobine",0,2,1000415,0
+2018838,"Rack à pare brise",0,2,1000409,0
+2018036,"Racks à pneus (pro)",0,2,1000409,0
+2009217,"Rayonnages légers",0,2,1000409,0
+2002524,"Rayonnages mi-lourds et lourds",0,2,1000409,0
+1002222,"Rayonnages et racks à palettes",0,2,1000409,0
+1001004,"Cordons d'alimentation",0,2,1000999,0
+2002935,Plinthes,0,2,1000999,0
+2001539,Portes-mines,0,2,2001520,0
+2012060,"Boîtes cache-câbles",0,2,1000999,0
+2001538,Marqueurs,0,2,2001520,0
+2017873,"Centrales de vide",0,2,2001019,0
+2017872,"Pompes soufflantes",0,2,2001019,0
+2007881,"Grenades à main",0,2,1002017,0
+2013847,"Rangements et distributeurs de gaine",0,2,1000999,0
+2013275,"Accessoires pour goulottes",0,2,1000999,0
+2012007,"Outils pour serre-câbles",0,2,1000999,0
+2003783,"Systèmes de fixation de câbles",0,2,1000999,0
+2010173,"Chevilles à ailettes",0,2,1000999,0
+2009334,"Raccords de guidage de câbles",0,2,1000999,0
+2009330,"Pontets de fixation de câbles",0,2,1000999,0
+2008929,"Jarretières optiques",0,2,1000999,0
+2008766,"Câbles coaxiaux",0,2,1000999,0
+2008284,"Rallonges électriques",0,2,1000999,0
+2004007,Tresses,0,2,1000999,0
+2011158,"Radiateurs à fluide caloporteur",0,2,2010744,0

--- a/rubriques/categories_from_roots_2.txt
+++ b/rubriques/categories_from_roots_2.txt
@@ -1,0 +1,1438 @@
+# Categories leaves (type=0) sous rubriques racines
+# Racines : 1000005, 1000003, 1000012, 1000013, 1000011, 9000312, 1000014
+# Date    : 2026-04-22 13:32:09
+
+Chaussures de sécurité basses
+Vêtement réfléchissant
+Table basse
+Autres raccords hydrauliques
+Chaussures de sécurité montantes
+Vêtements de sécurité basique
+Canapés lits
+Verres de table
+Fauteuil de bureau
+Canapés
+Embrayages
+Vestes de travail
+Tee-shirts et polos de travail
+Fauteuils
+Bottes de sécurité
+Raccord droit
+Armoire anti-feu
+Chaises empilables
+Rayonnage mi-lourd et lourd
+Bureau droit
+Pull et sweat de travail
+Batterie de démarrage
+Blousons de travail
+Abrasifs de ponçage
+Amortisseurs de choc
+Pompes centrifuges horizontales
+Gants de manutention
+Freins à disque
+Compresseurs
+Tasses et mugs
+Chambre froide
+Servantes d'atelier
+Panneau routier
+Tables de réunions
+Gants de protection
+Appliques, spots et lampes murales
+Gilets sans manche
+Gants anti-coupures
+Cuves à carburants
+Ampoules à led
+Armoire d'atelier
+Pompes de relevage d'eaux et liquides
+Ventilateur centrifuge industriel
+Câbles chauffants
+Ventilateur hélicoïde industriel
+Groupe électrogène industriel
+Pile lithium
+Caisses et boîtes à outils
+Batterie industrielle
+Planches à découper
+Sièges d'accueil
+Coupleurs
+Moteurs à courant alternatif
+Tabliers et chasubles de travail
+Radiants à infrarouge électriques
+Cadenas
+Bermuda et short de travail
+Panneaux de signalisation
+Lit
+Palan
+Bureau d'angle
+Accessoires pour rayonnages
+Diable de manutention
+Groupe électrogène portable
+Banques d'accueil
+Crics
+Déshumidificateurs à condensation
+Pompes immergées
+Bac de rétention en plastique rigide
+Établis
+Colliers de fixation
+Chaise pliante
+Matelas
+Signalisations pour véhicules
+Lunette de chantier
+Scies à ruban
+Onduleurs électriques autonomes
+Étagères de salon
+Roues et roulettes industrielles
+Chariot élévateur
+Tables pliantes
+Cottes de travail
+Table élévatrice
+Cuves à usages divers
+Bureau pour ordinateur
+Coffre-fort de sécurité
+Bureaux de direction
+Poteau de signalisation
+Mobiliers scolaires
+Blouses de travail
+Batteries solaires
+Rayonnage léger
+Plafonniers led
+Gerbeur électrique
+Chaussures de sécurité
+Moteurs de ventilateurs
+Établi avec rangement
+Porte affiche
+Vêtements de sécurité haut risque
+Aérotherme
+Générateurs d'air chaud à fioul
+Raccords tournants
+Plancher chauffant
+Huile moteur
+Bouchon de tuyau
+Armoires à portes battantes
+Scies circulaires
+Socles rouleurs
+Vannes et robinets à  papillon
+Blocs-tiroirs
+Cartouche filtrante
+Bureau open space
+Clapets anti-retours hydrauliques
+Pinces de levage
+Chaussures de sécurité pour femmes
+Mange-debout
+Vestiaires multicases
+Serrure à encastrer
+Sangle d'arrimage
+Lits escamotables
+Gants protection thermique
+Treuil
+Lampe torche à led
+Sièges sur poutres
+Spot pour led
+Gants de protection chimique
+Multimètres
+Accessoires pour cuves
+Poste à souder professionnel
+Cuves à eau
+Caméras de surveillance
+Siège et chaise d'atelier
+Palette en plastique
+Armoire de sécurité pour produits dangereux
+Caisse-palette en plastique
+Kits panneaux photovoltaïques
+Générateurs d'air chaud à gaz
+Cordon d'alimentation électrique
+Panneaux solaires photovoltaïques
+Poêles à bois
+Transpalette électrique
+Rideaux d'air chaud électriques
+Transpalette manuel
+Casques de chantier
+Vannes et robinetteries à boisseaux
+Pompe électrique
+Joint pour chambre froide
+Ventilateur mobile
+Tabouret de bureau
+Potelets fixes
+Chariots manuels à étagères
+Cuves de transport 
+Pompes hydrauliques auto-amorçantes
+Douchette code-barres
+Visseuses
+Générateurs d'air chaud électriques
+Tuyau d'aspiration
+Meuble armoire bas
+Signalisations sécurité travail
+Canapés d'angle
+Batterie pour onduleur
+Lame de scie à ruban
+Connecteur électronique
+Rayonnages et armoires à bacs
+Tampons de bureau
+Accessoire de lampes
+Alimentation à découpage
+Adhésifs de collage
+Chargeurs de batteries industrielles
+Convertisseur de tension
+Chemise de travail
+Scellés de sécurité
+Vannes et robinetteries à boule
+Vérins hydrauliques simple effet
+Matériels antichutes
+Chauffe-eau électriques
+Banquettes de salon
+Tendeur d'arrimage
+Groupe froid
+Sets de tables
+Générateurs de signaux
+Graisses lubrifiantes
+Résistances chauffantes
+Flexibles métalliques
+Ventouses pneumatiques
+Chaudières à gaz
+Scie de table
+Pompe de graissage
+Container aménagé
+Câbles multiconducteurs
+Accessoires de mesures électriques
+Accessoires de masque de protection
+Passe-câbles
+Coffrets de distribution
+Casier
+Torches de soudage
+Equipements pour panneaux solaires
+Cuve Adblue
+Joints plats
+Bac de rétention pour fût
+Chaîne de levage
+Brides de fixation
+Presses à métaux hydrauliques
+Groupes motopompes
+Casque soudure
+Accessoires pour chaudières
+Surpresseur
+Autres types de colle
+Élingues de levage
+Cuves à gasoil rouge (GNR)
+Groupe électrogène pour maison
+Pompes centrifuges verticales
+Climatiseur mobile
+Gaines
+Signalisation lumineuse
+Équipements et accessoires pour fibres optiques
+Potence de levage
+Convoyeur à rouleaux
+Ventilo-convecteurs
+Vestiaires industrie propre
+Destructeur de papier
+Cloisons de bureaux
+Flexible hydraulique
+Citerne souple
+Cloisons amovibles
+Accessoires pompes hydrauliques
+Colliers serre-câbles
+Container maritime
+Alimentation stabilisée
+Grille de ventilation
+Palette en bois
+Canapés d'accueil
+Balances industrielles
+Roll-containers vertical
+Pompes pneumatiques à membranes
+Cordes de levage
+Armoires à portes coulissantes
+Anneau de levage
+Griffe et crochet de levage
+Projecteur LED portable
+Gobelets en plastique
+Barrière de parking
+Roue à lamelle
+Pupitres de conférence
+Eclairage industriel
+Enrouleurs pour tuyaux hydrauliques
+Caisson de ventilation
+Etaux mécaniques
+Gaines flexibles
+Signalisations temporaires
+Pompes à chaleur aérothermiques
+Transformateurs basse tension
+Caisson à roulettes
+Ventilateur Atex
+Convoyeur à bande
+Refroidisseurs
+Électrovanne
+Cloison acoustique
+Conteneur de stockage
+Régulateur solaire
+Rubans à led
+Chariots manuels conventionnels
+VMC - Ventilation mécanique contrôlée
+Pistolet à colle
+Rampes de chargement pour engins lourds
+Courroie trapézoïdale
+Miroirs de surveillance
+Chariots manuels grillagés
+Rayonnage archive
+Protection d'angle
+Pompes à vide
+Onduleurs photovoltaïques
+Chalumeau & brûleur
+Réglette à led
+Climatiseur professionnel
+Tapis d'accueil
+Fibre optique
+Vanne de régulation
+Bouchons d'oreilles
+Gerbeur manuel
+Marquage au sol pour entrepôt
+Poêles à granulés
+Condensateur
+Sièges assis-debouts
+Kit extracteur de roulement
+Vestiaires et porte-manteaux
+Rayonnage de rétention
+Bac de rétention métallique
+Dessertes d'atelier
+Préparateurs d'ecs
+Pistolets à peinture industriels
+Casquette de protection
+Fontaine à eau réseau
+Combinaisons jetables
+Rideaux d'air à eau chaude
+Panneau de chantier
+Charnière
+Tuyau de gaz
+Gilets de sécurité
+Destratificateurs d'air
+Palonnier
+Climatiseur inverter
+Machine à café de bureau
+Equipement pour armoire
+Tapis d'entrée
+Armoire à rideau pour bureau
+Carte RFID
+Motoréducteur
+Vestiaires industrie salissante
+Treuil compact léger
+Destructeur de papier professionnel
+Élingue câble
+Vérins hydrauliques double effet
+Ponceuse à bande
+Thermostats électroniques
+Poignée pour chambre froide
+Dômes de surveillance
+Accessoires pour chariots élévateurs
+Gaines de ventilation
+Terminaux portables
+Scie industrielle
+Générateurs de soudage
+Monte-charge
+Autres joints statiques hydrauliques
+Rack à palette
+Extincteur portatif
+Pompes hydrauliques manuelles
+Aimants permanents
+Housse pour roll, chariot, container ou palette
+Chariot porte bac
+Lecteurs RFID
+Radiateurs électriques convecteurs
+Rayonnage cantilever
+Enrouleurs - dérouleurs
+Détendeur de gaz
+Parafoudres - parasurtenseurs
+Projecteur d'extérieur
+Coffres et armoires anti-feu
+Cuve engrais liquide
+Pinces ampèremétriques
+Enrouleur electrique
+Groupes de climatisation & unités extérieures
+Vannes à opercule
+Charnière pour chambre froide
+Accessoires pour passage de câbles
+Meuble classeur
+Caisse-palette métallique
+Lecteurs de badges
+Échangeurs thermiques tubulaires
+Kits d'alarmes
+Turbines de ventilateurs
+Tuyau flexible industriel
+Manille
+Pompe atex
+Panneau directionnel
+Rafraîchisseur
+Bureau assis debout
+Séparateur d'espace
+Plafond chauffant
+Avertisseur sonore industriel
+Réservoir à vessie
+Siège d'amphithéâtre
+Chaudières à fioul
+Corps de filtre
+Maison connectée 
+Accessoires pour led
+Barrières de sécurité intérieure
+Chariots électriques
+Thermostat d'ambiance
+Lève-palette
+Autres chariots
+Équipement du chauffe-eau
+Pied de calage
+Scies à sol
+Chaudière à bois
+Pompes hydrauliques à engrenages
+Armoires de sécurité
+Armoires ouvertes
+Rivets aveugles
+Pièce de tuyauterie
+Boîtier de dérivation
+Bande transporteuse
+Lecteur code-barres fixe
+Entrepôts modulaires de stockage
+Bracelet RFID
+Bac de rétention en plastique souple
+Porte clés et Badge RFID
+Détecteur de tension
+Pompes solaires
+Thermoplongeurs
+Palonnier à ventouse
+Ventilateur industriel plafond 
+Plates-formes et bascules de pesage
+Filtres d'eau potable
+Mezzanine industrielle
+Galets de guidage
+Scie à format
+Rafraîchisseur d'air adiabatique
+Aimant de levage
+Chauffage infrarouge à fioul
+Chariots modulables
+Transformateurs de puissance
+Climatiseur multisplit réversible
+Détecteur - capteur de présence
+Radiants à gaz
+Bancs vestiaires
+Cuve IBC
+Harnais
+Silo de stockage
+Inserts pour cheminées
+Coffrets de protection
+Interphonie ip
+Alimentation secourue
+Chemin de table
+Cuves à huiles et lubrifiants
+Ballons tampons
+Palettiseurs et dépalettiseurs
+Sécheurs air frigorifiques
+Rayonnages fixes 
+Transpalette peseur
+Chandelle de levage et de calage
+Grue d'atelier
+Émetteurs-récepteurs radio
+Huile hydraulique
+Chauffe-eau solaires
+Télécommande radio industrielle
+Prises d'air - extracteurs d'intérieurs
+Conteneurs de stockage pour produits dangereux
+Barrières mobiles de sécurité
+Rangements pour crèches
+Fauteuil salle de conférence
+Armoires et cages pour bouteilles de gaz
+Chariot porte-palan
+Tourelles de ventilation
+Plaques chauffantes industrielles
+Filtres à tamis
+Trémie de stockage
+Ballons thermodynamiques
+Tableau de planning
+Armoire à outils
+Groupe électrogène en container
+Moteur courant continu
+Radiateur seche-serviettes
+Postes de travail
+Composant de filtre à eau
+Machine à boisson chaude
+Ponceuses industrielles
+Armoire à clé simple 
+Brumisateurs
+Matériel de secourisme
+Chariots manuels porte-panneaux
+Compresseur frigorifique
+Tracteur logistique
+Patins rouleurs
+Soupapes de sécurité
+Radiateur électrique à inertie
+Armoires électriques de chantier
+Médias de filtration d'eau
+Réservoir de stockage industriel
+Pompe de transvasement
+Pompe à membrane électrique
+Cloisons mobiles
+Ventouses électro-magnétiques
+Box de rétention
+Tapis antidérapants
+Climatiseurs monoblocs réversibles
+Pompe à piston
+Caillebotis antidérapants
+Convertisseurs dc-dc
+Cordons et lacets pour badges
+Rideaux d'air froid électriques
+Rampe de chargement pliable
+Enregistreur NVR
+Transpalette haute levée
+Régulateurs de tension
+Autres racks de stockage
+Brûleurs pour chaudières
+Positionneur de soudure
+Échangeurs thermiques à plaques
+Filtres à sable
+Armoire électronique de gestion des clefs
+Rayonnages tubulaires
+Robot éducatif
+Radiateurs soufflants
+Équilibreurs de charges
+Portique de levage
+Détecteurs de fumée
+Chariots manuels 2 dossiers
+Lecteurs à claviers
+Inserts mécaniques
+Rehausse palette
+Barrières anti-inondation
+Accessoire pour alarme
+Filtre anti-calcaire
+Terminaux de contrôle d'accès
+Humidificateurs à évaporation
+Ohmmètres
+Pompes à lobes
+Groupe d'eau glacée
+Profilé pour chambre froide
+Robot de service
+Accessoires de manipulation
+Plateforme de rétention
+Colles cyanoacrylates
+Hangars de stockage
+Kit camera de surveillance
+Compteur d'eau
+Panneau pour chambre froide
+Pompes doseuses péristaltiques
+Chariots pour charges lourdes
+Batterie pour chariot élévateur
+Électro-aimants
+Raccord pour air comprimé
+Potelet à mémoire de forme
+Climatiseurs monoblocs
+Machines pour palettes
+Bracelet d'évènementiel
+Valises de transport matériel et outillage
+Raccords pneumatiques en ligne
+Compteurs électriques
+Autres accessoires pour convoyeur
+Armoire de stockage batterie lithium
+Tracteur pousseur
+Climatiseur split simple
+Bloc autonome d'éclairage de sécurité
+Masque à gaz
+Chaussette de travail
+Chapeau de cheminée
+Outil de graissage
+Tentes et chapiteaux de stockage
+Pont roulant
+Fauteuil de cinéma
+Barrière levante
+Bornes anti-intrusion
+Rampe de quai
+Diffuseur et vaporisateur de parfum professionnel
+Bornes amovibles
+Cloueurs pneumatiques
+Pointeuses - badgeuses
+Vanne hydraulique
+Chaîne de convoyage
+Équipements du radiateur
+Meubles de change
+Buse et aiguille d'application de colle
+Hélices de ventilateurs
+Rayonnages à pneus
+Tourniquets d'accès piétons
+Sécheurs par adsorption
+Écarteurs et ajusteurs de fourche
+Chaudières à granulés
+Combinaisons de protection chimique
+Filtres d'eau de pluie
+Bornes escamotables automatiques
+Basculeurs / retourneurs de bacs et caisses
+Chariots manuels à caisse et bac
+Pompes hydropneumatiques
+Barrière pivotante
+Analyseurs d'énergie et puissance
+Panneau consignes de sécurité
+Transformateurs d'isolement
+Poche filtrante
+Vérins mécaniques
+Logiciels gestion d'accès
+Récepteurs radios
+Équipement de barrière de sécurité
+Niveleur de quai
+Réservoirs d'air comprimé
+Masque à ventilation assistée 
+Pompes doseuses électromagnétiques
+Pompes à peinture
+Brasseur d'air
+Postes informatiques
+Panneau d'information d'entreprise et publicitaire
+Sertisseuses hydrauliques
+Doseur proportionnel
+Sertisseuses électriques
+Élévateur de charge
+Accouplements flexibles
+Manette logistique
+Distributeurs hydrauliques
+Urinoirs
+Cartes et badges plastiques pour impression
+Lecteurs biométriques
+Portes coupe-feu
+Toque et charlotte à cheveux
+Déshumidificateurs à adsorption
+Chariots manuels pour bidons et fûts
+Rails de guidage
+Telluromètres
+Foyers pour cheminées
+Cardans
+Barres anti-panique
+Système de conférence
+Revêtements de sol antidérapants
+Cartes géographiques
+Appareil Respiratoire Isolant 
+Pompes vide-fûts
+Vannes guillotines
+Manchon électrique
+Panneaux rayonnants
+Plénums
+Barrière Vauban
+Accessoires et pièces pour chariot de manutention
+Station de désinfection des mains
+Rayonnage polyvalent
+Dégrippant
+Mesures de fréquence
+Rayonnages dynamiques
+Engrenages à denture droite
+Scieries mobiles
+Convoyeur aérien
+Poêles-cheminées
+Structure métallo-textile
+Lampes à ultra-violets
+Tunnels de stockage
+Portique limiteur de hauteur
+Pompes à vis
+Accessoires pour pompes à chaleur
+Basculeurs / retourneurs de fûts
+Autres pompes hydraulique
+Caillebotis métal
+Filtres pour ventilation
+Transformateurs de courant
+Caisse-palette en bois
+ Générateurs de vide
+Crépines
+Poulies à corde
+Testeurs de batteries
+Chaudières électriques
+Point d'ancrage
+Butoir de quai
+Présentoirs porte-outils
+Borne de distribution de gel intelligente
+Ventilateur tangentiel
+Sirène d'alarme
+Intercalaire pour palettes et caisse-palettes
+Thermorégulateurs
+Capteur de courant
+Cloisons grillagées
+Soudeuses fibres optiques
+Presses à métaux manuelles
+Évaporateur
+Buses de pulvérisation
+Imprimantes mobiles de reçus
+Table d'atelier
+Autotransformateurs
+Chariots pour charges longues
+Serrures électroniques
+Systèmes de mise à la terre
+Convoyeurs / transporteurs à chaînes
+Système de guidage linéaire
+Soufflante d'air
+Combinaisons imperméables
+Tapis anti fatigue
+Climatiseur de cave à vin
+Armoires électriques industrielles
+Rayonnages mobiles
+Borne avec pédale mécanique
+Stations de peinture et de revêtement
+Vérins électriques
+Systèmes d'inspection rayon x pour bagages
+Journal lumineux
+Pompes à entraînement magnétique
+Vannes murales
+Fermeture auto-agrippante
+Cuves à produits chimiques
+Dressings
+Éolienne
+Armoire phytosanitaire
+Moteurs diesel
+Autres convoyeurs / transporteurs
+Purgeur automatique temporisé
+Porte blindée professionnelle
+Palette en métal
+Ventilateur d'aspiration
+Lève plaque
+Conteneur spécifique
+Chaîne d'arrimage
+Déclencheurs manuels d'alarme
+Colle anaérobie
+Station électrique portable
+Machines de soudure automatique
+Scies à panneaux
+Porte de chambre froide coulissante
+Servomoteurs
+Extracteurs pour gaines et conduits
+Paliers
+Filtres pour cabines de peinture
+Tambours moteurs 
+Aérateurs d'intérieur
+Grille de reprise
+Thermostats à bulbe
+Manipulateurs pour panneaux et vitres
+Climatiseur split réversible
+Générateurs d'air chaud à bois
+Potelet rabattable
+Abris de stockage
+Centrales de conditionnement d'air
+Pompes doseuses électroniques
+Accessoires d'identification
+Derouleur de cables pour touret
+Pompes de relevage de condensat
+Vérin de fosse
+Tapis antistatique
+Manipulateurs pour fûts
+Lits pour crèches
+Capteur de débit d'air comprimé
+Système de pesage embarqué
+Élévateur à godets
+Pompes hydrauliques péristaltiques
+Téléphones mobiles pti
+Accessoires coupe-feu
+Armoires industrielles de stockage
+Projecteur LED solaire
+Ouvre-lettres
+Rallonges de fourche
+Multiplicateur de pression pneumatique
+Serrure connectée
+Enregistreurs paramètres électriques
+Systèmes de filtrations
+Grille de soufflage
+Véhicules à guidage automatique (AGV)
+Ressorts de compression
+Rideau métallique
+Gaz frigorigène et fluide
+Autres pompes pneumatiques
+Afficheurs numériques
+Téflon
+Miroir d'inspection
+Cartouches chauffantes
+Pistolet à huile
+Trépied pour palan et tripode de levage
+Déshuileurs
+Filtres auto-nettoyants
+Ponceuse de chants
+Pupitre
+Pignons et crémaillères
+Fond bombé de cuve
+Chariot de manutention
+Chariots pour tables
+Climatiseurs solaires
+Postes de soutirage
+Chaise et fauteuil pour enfant
+Plinthe pour chambre froide
+Accessoires pour bornes
+Afficheurs lumineux industriels
+Equipement pour rack de stockage
+Housses de chaises
+Logiciels de gestion d'étiquetage
+Vérins pneumatiques double effet
+Butoirs en caoutchouc
+Table de soudure
+Réserves d'eau anti incendie
+Aspirateurs de fumées de soudage
+Ligne d'assemblage
+Agitateurs pour peinture
+Conteneur Frigorifique
+Rampe d'accès pour conteneur
+Générateur de brouillard
+Mannequin de secourisme
+Renvoi d'angle
+Radiateur et chauffage infrarouge lointain
+Rouleau antidérapant
+avertisseur sonore et lumineux
+Mise sous plis
+Additif à essence
+Barrière à chaîne
+Générateur de vapeur
+Rouleaux motorisés
+Barrières infrarouges périmétriques
+Attache pour badges
+Autres moteurs électriques
+Décapeur laser
+Grilles de protection d'entrée
+Potentiomètre
+Sas pour quai
+Tubes radiants à gaz
+Butoirs divers
+Citerne à gaz
+Base roulante
+Barrières de rétention d'eaux d'incendie
+Colles époxydes
+Moniteurs de vidéosurveillance
+Filtres à poches
+Coffrets de régulation de température
+Projecteur gobo
+Protège sol
+Autres manipulateurs
+Électroaimant de levage
+Climatiseurs de véhicules
+Stockeur rotatif
+Accessoires pour le stockage de produits dangereux
+Chevalets de manutention
+Engrenage conique
+Bloc béton anti-intrusion
+Convoyeurs / transporteurs élévateurs
+Bornes escamotables manuelles
+Postes de découpe à plasma
+Programmateur de clé voiture
+Plots anti-vibratiles
+Pompes à épreuves
+Armoires pour armes
+Sacs et enveloppes pour transport de fonds
+Spreader pour conteneur
+Poulies dentées ou crantées
+Distributeur d'huile
+Pompes hautes pressions
+Bâches et housses pour palettes
+Disques de rupture
+Barrière de protection piéton
+Accessoire de groupe électrogène
+Vis d'archimède de convoyage
+Chariot pour courrier
+Coin roulant
+Semelle pour chaussure de sécurité
+Station de soudage
+Circulateurs de chauffage
+Pompes à palettes
+Bombe de galvanisation à froid
+Générateur air chaud industriel 
+Trieuses et contrôleuses pondérales
+Citernes plastique fioul
+Machines agrafeuses
+Badge pour événement
+Colliers chauffants
+Carters de sécurité
+Armoires d'entretien
+Rampe électrique
+Presses à métaux pneumatiques
+Bureau d'école
+Pompes doseuses électromécaniques
+Bande antidérapante
+Vestiaires sportifs
+Location de matériels génie climatique
+Porte de chambre froide
+Radiateurs électriques à pierre réfractaire
+Chariot isotherme
+Pont de chargement de quai
+Consigne automatique
+Registres de ventilation
+Soufflets de protection
+Portillon d'accès
+Régulateurs numériques pour chauffage
+Chariots à fond mobile
+Malette de rangement pour drone
+Exutoire de fumée 
+Cogénération
+Tableau électrique
+Rangements pour badges
+Boitier électronique
+Chauffe bain
+Cloisons pour sanitaires et vestiaires
+Climatiseur multisplit
+Couloir de passage
+Déshumidificateurs à absorption
+Siège ballon ergonomique de bureau
+Bras de manipulation
+Compteur de jour sans accident
+Chariot porte outil
+Convertisseurs de signaux
+Mallettes d'étude mécanique
+Tables avec guidage
+Mobiliers de call-centers
+Pompes à chaleur géothermiques
+Humidificateurs à vapeur
+Pompes à chaleur réversibles
+Ponts bascules
+Chaudières à vapeur
+Machines enrouleuses et dérouleuses
+Fontaine à eau bonbonne
+Panneaux solaires thermiques à fluide
+Ballons solaires
+Systèmes de transport pneumatique
+Rack mobile
+Pieuvres électriques
+Désemboueurs
+Diffuseurs d'air linéaires
+Presses à métaux électriques
+Potelets amovibles
+Automatisme marche-arrêt pour pompe
+Tour de refroidissement
+Purgeurs à flotteur
+Purgeurs thermostatiques
+Modules de motricité
+Machines pour la fabrication de badges pin's
+Serrures électriques
+Autre matériel pour chauffage
+Afficheurs à led
+Réservoir de stockage d'eau
+Convoyeurs / transporteurs à vis
+Climatiseurs drv ou vrv
+Amplificateurs haute-fréquences
+Roulements
+Canon à chaleur diesel
+Générateurs de courant
+Rayonnages pour bobines
+Réchauffeurs de liquide
+Rouleaux pour vrac
+Support panneau photovoltaïque
+Table pour enfant
+Pèse-essieux et pèse-roues
+Imprimantes d'adresses
+Collecteurs de gobelets
+Systèmes et installations sur mesure
+Peseuses multitêtes
+Cabines de poudrage
+Accessoires machine de nettoyage climatisation
+Manuracks
+Chariots pour chaises
+Moteur atex
+Collecteurs tournants électriques
+Butoirs  en acier
+Groupes hydrauliques
+Pompes d'épuisement
+Distributeur pneumatique
+Contrôleur de ronde
+Protection auditive
+Sabot de denver
+Équipements et accessoires de grues de levage
+Manivelles de manoeuvre
+Pèse palette
+Logiciels de vidéosurveillance
+Dispositif DATI
+Plaque de chargement de quai
+Filtres magnétiques
+Logiciels de gestion des temps et horaires
+Lecteurs de plaques
+Colonnes de classement rotatives
+Tapis sensible de sécurité
+Table d'accumulation
+Distributeurs automatiques EPI
+Aérateur pour fenêtre
+Actionneurs pour vannes
+Alarme PPMS
+Riveteuses pneumatiques
+Réducteurs à roue et vis
+Fontaines à eau atmosphériques
+Colle pour carrosserie
+Positionneurs pneumatiques
+Armoire de précision
+Cloisonnettes
+Logiciels de gestion de stock
+Talkie walkie pti
+Silencieux à baffles
+Postes de soudure par ultrasons
+Filtres d'eaux usées
+Puits canadiens
+Détecteur de fuite d'air comprimé
+Autres basculeurs / retourneurs
+Ressorts de traction
+Postes de soudure laser
+Racleur pour bande transporteuse
+Hangar photovoltaïque agricole
+Pompe pour cuve ibc
+Graissage centralisé
+Afficheurs et enregistreurs de bruit
+Station de charge et de récupération
+Protecteurs télescopiques
+Régulateurs multifonctions
+Climatiseurs par évaporation ou rae
+Pupitres de conférence amplifiés
+Groupe frigorifique pour utilitaire
+Pelles pour chariots élévateurs
+Butées d'arrêt pour convoyeurs / transporteurs
+Matériels de bureau antistatique 
+Peseuses linéaire 
+Banc pour enfant
+Manipulateurs pour bobines et rouleaux
+Tours de stockage
+Afficheurs lumineux de comptage de parking
+Séparateurs centrifuges
+Cartes de fidélité
+Machines de décapage
+Vernis de tropicalisation
+Herse anti-intrusion
+Bornes escamotables semi-automatiques
+Purgeurs capacitifs à détection de niveau 
+Centrales de détection incendie
+Lecteurs de documents d'identité
+Ballons à gaz
+Applicateurs de revêtement
+Application PTI
+Masque d'évacuation
+Butées de positionnement
+Systèmes de tri pour convoyeurs/transporteurs
+Transformateurs haute tension
+Pré-filtres d'eau
+Télécommandes pour alarmes
+Récupérateurs de chaleur
+Groupe électrogène solaire
+Sécheurs à membrane
+Sac de lestage
+Plateforme élévatrice
+Bille porteuse
+Horodateurs
+Systèmes d'inspection rayons x pour cargos
+Réservoirs d'alimentation sous pression
+Rayonnage textile
+Riveteuses électriques
+Câbles chauffants pour planchers
+Pompes à boues
+Bornes de défense
+Traçabilité et géolocalisation par rfid
+Masse beton
+Mesures diélectriques
+Mandrin magnétique à aimant permanent
+Pistolets de poudrage
+Machines à affranchir
+Pompes volumétriques
+Cartes et badges cartonnés pour impression
+Coiffe palette
+Centrales hydroélectriques
+Robot de nettoyage professionnel
+Distributeur de masque
+Climatiseur de fenêtre
+Poste de soudage par flamme
+Balais et brosses pour chariots
+Plastobloc
+Rampe pour transpalette
+Tables à dessin
+Refroidisseurs adiabatiques
+Barrière sélective
+Echomètres
+Chaudières à eau chaude
+Système d'extinction automatique d'incendie
+Service de création de site internet
+Équipements pour transformateurs
+Drones de surveillance
+Barrière anti-voiture bélier
+Galet de roulement
+Lecteur de carte magnétique
+Sas de sécurité
+Barre de levage
+Afficheurs lcd
+Accessoires de caillebotis
+Système de réservation de salle de réunion
+Séparateurs huile/eau
+Tuyauterie modulaire
+Lampes pour colles photosensibles
+Convoyeurs / transporteurs à galets
+Têtes de soudage automatique
+Transstockeurs
+Plan d'évacuation
+Racks de stockage grillagés
+Lances incendie
+Armoires de stockage et de distribution
+Systèmes de stockage par accumulation
+Borne de satisfaction
+Manipulateurs pour cartons
+Racks de stockage pour produits longs
+Batteries de chauffage
+Externalisation de la gestion de paie
+Régulateurs analogiques pour refroidissement
+Analyseur d'antenne
+Concentrateur de données
+Palette en carton
+Télégestion de systèmes solaires
+Tourets, bobines et rouleaux de stockage
+Système de stockage d'énergie par batterie
+Échangeurs thermiques électriques
+Tente militaire
+Poêles polycombustibles
+Panneaux radiants à gaz
+Affichage de production
+Courbes pour convoyeurs / transporteurs
+Convoyeurs / transporteurs magnétiques
+Aménagement de bureau professionnel
+Jambière anti-coupure
+Banquette coworking
+Machines de nettoyage de climatisation
+Installations de filtration d'eau
+Détecteurs de chaleur
+Afficheurs lumineux commerciaux
+Station d'étamage
+Afficheur file d'attente
+Robot d'assistance à la personne
+Appareils d'assèchement de mur
+Sertisseuses pneumatiques
+Émerillons de levage
+Robot de nettoyage de panneaux solaires
+Hublot de visualisation
+Accumulateurs de palettes
+Système automatique de stockage et de déstockage (AS/RS)
+Kits d'identification d'accès
+Sac anti-inondation	
+Services de contrôle d'accès
+Robots de surveillance
+Turbocompresseurs
+Borne de gestion de file d'attente
+Alarme radio sans fil
+Accessoires pour pompes pneumatiques
+Parcs pour enfants
+Chargeurs pour transport pneumatique
+Laveur pistolet peinture
+Testeur de borne de recharge
+Lève roue
+Coque pour chaussure
+Bandes modulaires
+Bornes arrêt-minute
+Générateurs de tension
+Ressorts de torsion
+Capteur de vapeur d'huile d'air comprimé
+Bornes incendie
+Portillon de sécurité
+Poste de contrôle
+Pochette anti-téléphone pour la pause numérique
+Cabine de soudage laser
+Accessoires véhicules incendie
+Maintien en pression
+Basculeurs / retourneurs de conteneurs
+Ampèremètres numériques
+Colonne levage telescopique
+Basculeurs / retourneurs de bobines
+Logiciels de gestion et traitements de pesées
+Garnitures mécaniques
+Table de montage
+Salles de bains préfabriquées
+Démagnétiseurs
+Robot de pose de vitrage
+Postes de transformation de signaux électriques
+Masque pare-visage
+Robot de peinture 
+Joints tournants haute vitesse
+Tiroir à palette
+Cloison d'atelier
+Barrière écluse
+Turbines hydro-électrique
+Manipulateurs pour sacs
+Pistolet station peinture
+Capteur de pression d'air comprimé
+Chauffe roulement
+Service de désenfumage
+Purgeurs thermodynamique
+Convoyeur à accumulation
+Bornes hydrauliques
+Ioniseur d'air
+Régulateurs analogiques pour chauffage
+Convoyeurs à copeaux
+Pupitres informatiques
+Grille de transfert
+Table de sciage
+Recuperateur de chaleur sur eaux usees
+Afficheurs lumineux de sécurité
+Armoire et casier RFID
+Borne pour pont bascule
+Casier d'école
+Dés de palette
+Voltmètre
+Caillebotis en caoutchouc
+Panneaux coupe-feu
+Systèmes de pompage de lentilles d'eau
+Matelas isolant	
+Boîte à coins pour câbles de levage
+Système de dimensionnement et de pesée automatique
+Pico-ampèremètres
+Écran de cantonnement
+Pesages sur convoyeurs / transporteurs
+Régulateur pour éolienne
+Relais thermique
+Compresseur haute pression 
+Appareil à adduction d'air
+Embouts et galets pour convoyeurs
+Alarmes incendie électroniques
+Pompes pneumatiques manuelles
+Dalles de plafonds
+Détecteurs de faux documents
+Logiciels de gardiennage
+Chariot de séchage
+Repose-pied
+Casier électronique
+Contrôleurs pour engins de manutention
+Guide-roue
+Manche de chargement télescopique
+Toile filtrante
+Plates-formes de manutention
+Portes blindées de maisons 
+Cloisons fixes
+Compresseur de segment
+Machines à signer
+Analyseur d'air comprimé
+Machines de brasage
+Armoires à portes pliantes
+Filtre à gaz
+Barrière coulissante
+Roll-containers horizontal
+Tracker solaire
+Lampe de quai
+Fauteuil pour salle de spectacle
+Pied de cloison
+Caillebotis bois
+ Machine pour fabrication de porte clés personnalisés
+Mousses coupe-feu
+Centrales de chauffage
+Couronnes d'orientation
+Poulie variable
+Crash barrière
+Pochette de clés transportable
+Courroies pour convoyage
+Coffrets de sécurité
+Tresse métallique
+Robot humanoïde
+Protecteurs enrouleurs
+Millivoltmètre
+Enregistreur HDCVI
+Convoyeur de carrière
+Pellets ou granulés de bois
+Signalisations de détresse
+Chariot à ventouses
+Nettoyant de matériel de pulvérisation de peinture
+Portes blindées de chambres fortes
+Système de dosage d'émulseur
+Logiciels d'étude et de calcul électriques
+Détecteurs de chocs et vibrations
+Chariot pour grille d'exposition
+Tables / plateaux de transport à billes
+Convoyeurs / transporteurs au sol
+Feu tricolore intelligent
+Vestiaire pompier
+Convoyeurs / transporteurs à raclettes
+Caillebotis
+Convoyeurs hélicoïdaux
+Chargeurs, déchargeurs de manutention
+colonne lumineuse
+Entreprise de thermolaquage
+Générateurs d'eau chaude
+Shelter militaire
+Kit éolienne
+Onduleur pour soudure
+Raccord câble
+Basculeurs / retourneurs de palettes
+Cloisons translucides
+Endosseuses de chèques
+Sous-stations de chauffage
+Caisse de remuage
+Bornes à tickets
+Pince à border
+Contrôleurs de pesage
+Table vibrante
+Logiciels de gestion de la supply chain
+Tableaux d'alarmes incendie
+Cabines fumeurs
+Matériels de téléassistance
+Vanne à clapet
+Interverrouillage
+Obstacles escamotables
+Palette alimentaire
+Cuves pour pulvérulents et granules
+Colonnes de chauffage
+Débiteuses
+Gazomètres & réservoirs à gaz
+Distributeur automatique de vêtements ou D.A.V.
+Pince à rétreindre
+Robinets d'incendie armés
+Détecteurs de flammes
+Enduits coupe-feu
+Thermorégulateurs pid
+Solution de détection de faux documents
+Jeux d'imitation
+Trottinette industrielle
+Traverse de levage
+Mesures d'électricité statique
+Cage à drone filet et gonflable
+Bras de chargement
+Logiciels de schématique électrique
+Coffret électrique pour pompe
+Murs filtrant pour cabines de peinture
+Montre PTI
+ Cloisons et rideaux souples
+Simulateur de soudage
+Machines à hologrammes
+Filtre conique
+Plaque filtrante
+Colonne à taquet
+Mortiers coupe-feu
+Tube pneumatique
+Portes blindées d'appartement
+Murs et plinthes chauffants
+Canons incendie
+Totem pour bornes escamotables
+Amplificateur de puissance CEM
+Équipements de revêtement de surface
+Sirènes d'alerte à la population
+Chariot à peinture
+Panneaux solaires thermiques à air
+Établis électrifiés
+Pompes pneumatiques à palettes
+Couronneuses de câbles
+Sécheur d'air par absorption
+Poutres froides
+Applications mobiles de gardiennage
+Copieur de badge
+Interphone de sécurité
+Détecteurs d'explosifs et narcotiques
+Solutions automatisées
+Rives de guidage convoyeurs / transporteurs
+Coffres de transfert de fond
+Peintures coupe-feu
+Logiciels de câblage électrique
+climatiseur sans unité extérieure
+Passerelles de quais
+Portes tournantes de sécurité
+Bac à feu
+Porte anti-squat
+Pompes pneumatiques vide-conteneurs
+Chevalet de peinture
+Interfaces de commande pour soudage
+Véhicules anti incendie
+Navettes de stockage automatiques
+Bacs de rétention anti-feu 
+ chaufferie en container
+Régulateurs numériques pour refroidissement
+Convoyeurs / transporteurs à courroies
+Unités de traitement des condensats
+Sécheur de maillot de bain
+Autres matériels antistatiques 
+Extincteur automatique 
+Distributeurs d'air chaud pour cheminées
+Tabliers et fourches peseurs
+Barres de pesage
+Bac à livres
+Gaz combustible
+Filet pour palette
+Ballons électriques
+Plateforme de travail sur mât
+Doublure de conteneur
+Guichets pare-balles
+Détecteurs pour la sécurité routière
+Chariot porte-container
+Couverture anti-feu
+Autres climatiseurs
+ Grilles acoustiques de ventilation
+Climatiseurs militaires
+Housse de siège
+Protections individuelles antistatiques
+Kit mixte éolien-solaire
+Protections antistatiques des produits
+Scanners de sûreté
+Basculeur de GRV IBC
+Transpalette thermique
+Scies à câble
+Chauffe-eau aérothermiques
+Pompes hydrauliques vide-conteneurs
+Tunnels de peinture
+Moteur de désenfumage
+Parois et cloisons blindées
+Convoyeur à godet
+Trémie à fond ouvrant
+Jeux de barres
+SIRH
+Dématérialisation des documents
+Gicleurs pour chaudières
+Espaces de travail modulables
+Ascenseur à palette
+Tables techniques
+Masque auto sauveteur
+Bras anti-couple de vissage
+ Portes blindées de caves
+Matériels de clinchage
+Drones de mesures de radioactivité
+Magasins de stockage pour produits dangereux
+Chambres fortes
+Aerosols pour extincteurs
+Gradin modulable
+Pesages aéronautiques portables
+filtration membranaire
+Twist-lock
+Levage de container
+Pieds de support convoyeurs / transporteurs
+Chauffage de surface hydronique - Dégeleuse de sol
+Chariot d'air respirable
+Générateurs d'air froid
+Tabliers de recouvrement
+Contacteur sur barreaux
+Produit d'enduction
+Papiers sécurisés
+Chariot preparateur de commande
+Neutraliseurs pour chaudières
+Robot de livraison
+Test d'intégrité des filtres
+Conseil en financement public
+Rideaux d'air à gaz
+Table rotative de vernissage 
+Radiateur hydraulique eau chaude
+Cartes et badges réinscriptibles
+Drones voilure tournante
+Porte conteneur à déchets
+Robot d'accueil
+Pompe à membrane
+Télécommande BAES
+Cloisons extensibles accordéon
+Lève-conteneur
+Tresses de masse
+Entreprise de demenagement
+Désenfumage mécanique
+Convoyeurs / transporteurs à taquets
+Portillons relevables pour convoyeurs
+ Rideaux de scène 
+Groupes électrogènes d'éclairage
+Tours de vidéosurveillance mobile
+Chariot porte-bobine
+Mini chambres fortes
+Chaudière à miscanthus
+Container solaire
+Éolienne de pompage
+Sécheurs hybrides
+Modification d'entreprise en ligne
+Machines de soudure par impulsion
+Réparation de flexible hydraulique
+Facturation électronique
+Systèmes antivol pour engins de travaux publics
+Centrales hydropneumatiques
+Ampèremètres analogiques
+Pochette FOD
+fournisseur de gaz et d'électricité
+Création d'entreprise en ligne
+Vestiaire automatique
+Chauffe-eau géothermiques
+Bornes à jetons
+Chariot présentoir pour posters
+Basculeurs pour chariot
+Systèmes de gestion manuel d'entrepôts
+Postes de peinture
+Bureau d'étude d'éclairage
+Logiciels de création de devis en électricité
+Tableau d'affichage
+Chaudière mixte
+Machines de soudure par haute fréquence
+Bascule de circuit
+Plates-formes de survie en zone inondable
+Fauteuil d'allaitement
+Enrubanneuses de câbles
+Entreprise VPG
+Racks de stockage pour bateaux
+Véhicules électriques


### PR DESCRIPTION
## Summary
- Ajoute les catégories à ingérer pour les **7 sections HelloPro manquantes** après le POC Industrie+Santé
- Source : `rubriques/categories_from_roots_2.csv` (2246 catégories feuilles, ~317k produits estimés)
- Input script : `rubriques/categories_from_roots_2.txt` (1438 noms uniques)
- Procédure détaillée : `rubriques/README_INGESTION_BATCH2.md` (env vars, lancement nohup, monitoring, validation)
- Cible : collection existante `produits_scale` (ingest additif, les 51k docs du POC restent)

Au passage : bump des limites Pydantic `top_k` / `candidates` de `le=500` à `le=2000` dans `search_text.py` pour absorber les futurs payloads sans 422.

## Sections ajoutées
| Racine | Section |
|---|---|
| 1000005 | Hydraulique-pneumatique |
| 1000003 | Électricité-électronique |
| 1000012 | Sécurité |
| 1000013 | Logistique |
| 1000011 | Génie climatique |
| 9000312 | Outillage et fournitures industrielles |
| 1000014 | Équipements d'entreprises |

## Test plan
- [ ] Merger la PR sur `features/poc`
- [ ] Sur la VM : `git pull`
- [ ] Lancer l'ingestion : `nohup python3 -u ingest_by_categories.py > /tmp/ingest_batch2.log 2>&1 &` (~70 min estimé)
- [ ] Monitoring : `tail -f /tmp/ingest_batch2.log` + `curl .../collections/produits_scale` pour voir le `num_documents` grimper
- [ ] Validation post-ingest : tester queries `armoire securite`, `vestiaire metallique`, `compresseur air atelier` (qui renvoyaient `ABSENT` avant)
- [ ] Re-test navigateur via `?typesense=1` sur URL HelloPro

🤖 Generated with [Claude Code](https://claude.com/claude-code)