### PR TITLE
feat(opti-moteur-front): flag use_vector pour A/B BM25 vs hybride

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/router/search_text.py
@@ -30,22 +30,26 @@ def search_by_text(req: SearchTextRequest):
     (ex: PHP front www.hellopro.fr).
 
     Pipeline :
-      1. Appel api-embedding-service pour obtenir le vecteur CamemBERT 1024
-      2. Delegue au pipeline /search existant (detection categorie + hybrid + rerank)
+      1. Si `use_vector=True` (defaut) : appelle api-embedding-service pour
+         obtenir le vecteur CamemBERT 1024 et delegue au pipeline hybride.
+      2. Si `use_vector=False` : skip l'embedding, pipeline pur BM25 +
+         name_match + cat_match (plus rapide, utile pour A/B test).
 
     Retourne la meme structure que /search (SearchResponse).
     """
-    # 1. Embed
-    try:
-        vector = embed_text(req.query)
-    except Exception as e:
-        logger.error("Embedding failed for query=%r: %s", req.query, e)
-        raise HTTPException(
-            status_code=503,
-            detail=f"Embedding service unavailable: {e}",
-        )
+    vector = None
+    if req.use_vector:
+        # 1. Embed
+        try:
+            vector = embed_text(req.query)
+        except Exception as e:
+            logger.error("Embedding failed for query=%r: %s", req.query, e)
+            raise HTTPException(
+                status_code=503,
+                detail=f"Embedding service unavailable: {e}",
+            )
 
-    # 2. Search (reutilise le service existant)
+    # 2. Search (reutilise le service existant, vector=None si use_vector=False)
     try:
         return do_search(
             query=req.query,

--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -19,3 +19,11 @@ class SearchTextRequest(BaseModel):
     top_k: Optional[int] = Field(10, ge=1, le=2000, description="Nombre de resultats a retourner")
     candidates: Optional[int] = Field(50, ge=10, le=2000, description="Candidats pour re-rank")
     apply_filter_by_category: bool = Field(True, description="Applique filter_by si categorie detectee")
+    use_vector: bool = Field(
+        True,
+        description=(
+            "Si True (defaut) : pipeline hybride (BM25 + kNN vecteur CamemBERT + rerank). "
+            "Si False : pur BM25 + name_match + cat_match (pas d'appel a api-embedding-service, "
+            "plus rapide d'environ 300-500 ms, perd la remontee semantique de synonymes)."
+        ),
+    )

--- a/apps-microservices/opti-moteur-front/app/services/reranker.py
+++ b/apps-microservices/opti-moteur-front/app/services/reranker.py
@@ -1,13 +1,21 @@
 """
 Re-rank Python pondere sur les top-N candidats retournes par Typesense.
-Formule :
-    final = W_VECTOR * vec_score
-          + W_BM25   * bm25_score (normalise par batch)
-          + W_NAME   * name_match (tokens query inclus dans nom_produit)
-          + W_CAT    * cat_match  (tokens query inclus dans categorie)
 
-Penalite si vec < 0.20 AND name_match < 0.50 -> multiplication par 0.3
-(elimine les matches BM25 fortuits sans signal semantique ni nom).
+Formule (hybrid, use_vector=True) :
+    final = 0.55 * vec_score
+          + 0.10 * bm25_score (normalise par batch)
+          + 0.25 * name_match (tokens query inclus dans nom_produit)
+          + 0.10 * cat_match  (tokens query inclus dans categorie)
+Penalite si vec < 0.20 AND name_match < 0.50 -> x 0.3
+
+Formule (BM25 only, use_vector=False) :
+    final = 0.00 * vec_score  (pas de signal vecteur disponible)
+          + 0.20 * bm25_score
+          + 0.60 * name_match
+          + 0.20 * cat_match
+Penalite si name_match < 0.20 AND cat_match < 0.50 -> x 0.3
+(sans vecteur, on s'appuie davantage sur le nom qui est le signal le plus
+ robuste pour les queries de type "categorie + adjectif").
 """
 from typing import Dict, List, Any
 
@@ -15,14 +23,41 @@ from app.core.credentials import settings
 from app.utils.text import tokenize
 
 
-def rerank_candidates(groups: List[Dict[str, Any]], query: str) -> List[Dict[str, Any]]:
+# Poids alternatifs quand on n'a pas de signal vecteur (BM25 pur)
+_W_VECTOR_NOVEC = 0.00
+_W_BM25_NOVEC   = 0.20
+_W_NAME_NOVEC   = 0.60
+_W_CAT_NOVEC    = 0.20
+
+
+def rerank_candidates(
+    groups: List[Dict[str, Any]],
+    query: str,
+    use_vector: bool = True,
+) -> List[Dict[str, Any]]:
     """
     groups = Typesense `grouped_hits` (par id_produit).
     Retourne une liste d'objets scored tries par final_score desc.
+
+    Si `use_vector=False`, applique une formule rebalancee (name_match domine)
+    et une penalite adaptee (sans signal vectoriel, le bruit BM25 se detecte
+    via name_match + cat_match).
     """
     q_tokens = tokenize(query)
     if not q_tokens or not groups:
         return []
+
+    # Choix des poids
+    if use_vector:
+        w_vec  = settings.RERANK_W_VECTOR
+        w_bm25 = settings.RERANK_W_BM25
+        w_name = settings.RERANK_W_NAME
+        w_cat  = settings.RERANK_W_CAT
+    else:
+        w_vec  = _W_VECTOR_NOVEC
+        w_bm25 = _W_BM25_NOVEC
+        w_name = _W_NAME_NOVEC
+        w_cat  = _W_CAT_NOVEC
 
     raw = []
     for g in groups:
@@ -33,7 +68,8 @@ def rerank_candidates(groups: List[Dict[str, Any]], query: str) -> List[Dict[str
         doc = hit["document"]
 
         vec_dist = hit.get("vector_distance")
-        vec_score = 1 - min(vec_dist or 1.0, 1.0)
+        # Quand use_vector=False : vector_distance est absent -> score 0.
+        vec_score = 1 - min(vec_dist or 1.0, 1.0) if use_vector else 0.0
         tm_raw = hit.get("text_match", 0) or 0
 
         name_tokens = tokenize(doc.get("nom_produit", ""))
@@ -56,15 +92,20 @@ def rerank_candidates(groups: List[Dict[str, Any]], query: str) -> List[Dict[str
     for r in raw:
         r["bm25_score"] = r["tm_raw"] / max_tm if max_tm > 0 else 0.0
         r["final_score"] = (
-            settings.RERANK_W_VECTOR * r["vec_score"]
-            + settings.RERANK_W_BM25  * r["bm25_score"]
-            + settings.RERANK_W_NAME  * r["name_match"]
-            + settings.RERANK_W_CAT   * r["cat_match"]
+            w_vec  * r["vec_score"]
+            + w_bm25 * r["bm25_score"]
+            + w_name * r["name_match"]
+            + w_cat  * r["cat_match"]
         )
-        # Penalite bruit BM25 pur
-        if r["vec_score"] < 0.20 and r["name_match"] < 0.50:
+        # Penalite bruit (adaptee selon presence du signal vecteur)
+        if use_vector:
+            noise = r["vec_score"] < 0.20 and r["name_match"] < 0.50
+        else:
+            # Sans vecteur : on flag un bruit si aucun signal textuel fort
+            noise = r["name_match"] < 0.20 and r["cat_match"] < 0.50
+        if noise:
             r["final_score"] *= 0.3
-            r["penalty"] = "noise_bm25"
+            r["penalty"] = "noise_bm25" if use_vector else "noise_text"
         else:
             r["penalty"] = ""
 

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -19,22 +19,25 @@ logger = logging.getLogger(__name__)
 
 def search(
     query: str,
-    query_vector: List[float],
+    query_vector: Optional[List[float]] = None,
     collection: Optional[str] = None,
     top_k: Optional[int] = None,
     candidates: Optional[int] = None,
     apply_filter_by_category: bool = True,
 ) -> Dict[str, Any]:
     """
-    Execute une recherche hybride avec fallback sans filter_by si trop restrictif.
-    Retourne un dict {query, results, detected_cat, confidence, filter_cats,
-    latency_ms_ts, latency_ms_rerank}.
+    Execute une recherche hybride (BM25 + kNN vecteur) OU BM25 pur selon la
+    presence de query_vector. Fallback sans filter_by si trop restrictif.
+
+    Si `query_vector` est None -> pipeline BM25 pur (pas d'appel vectoriel a
+    Typesense, reranker sans poids vecteur). Utile pour benchmark sans embedding.
     """
     collection = collection or settings.TYPESENSE_COLLECTION
     top_k = top_k or settings.DEFAULT_TOP_K
     candidates = candidates or settings.CANDIDATES_TOP_K
+    use_vector = query_vector is not None
 
-    # 1. Category detection
+    # 1. Category detection (inchange, text-only)
     t0 = time.time()
     cat_detected, conf, valid_cats = detect_categories(query, collection=collection)
     detect_ms = (time.time() - t0) * 1000
@@ -44,7 +47,7 @@ def search(
     if apply_filter_by_category and conf >= settings.CAT_FILTER_THRESHOLD and valid_cats:
         filter_cats = valid_cats
 
-    # 3. Hybrid search
+    # 3. Hybrid or BM25-only search
     t1 = time.time()
     ts_result = _hybrid_typesense_search(
         query, query_vector, collection, candidates, filter_cats=filter_cats,
@@ -64,9 +67,9 @@ def search(
         filter_cats = None
     ts_ms = (time.time() - t1) * 1000
 
-    # 4. Re-rank
+    # 4. Re-rank (formule adaptee selon use_vector)
     t2 = time.time()
-    ranked = rerank_candidates(groups, query)
+    ranked = rerank_candidates(groups, query, use_vector=use_vector)
     rerank_ms = (time.time() - t2) * 1000
 
     # 5. Shape output
@@ -117,13 +120,16 @@ _MAX_PAGES = 4
 
 def _hybrid_typesense_search(
     query: str,
-    query_vector: List[float],
+    query_vector: Optional[List[float]],
     collection: str,
     candidates: int,
     filter_cats: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
-    Recherche hybride paginee pour couvrir jusqu'a `candidates` documents uniques.
+    Recherche paginee pour couvrir jusqu'a `candidates` documents uniques.
+
+    Si `query_vector` est None -> BM25 pur (pas de vector_query envoye).
+    Sinon -> hybrid BM25 + kNN sur embedding.
 
     Typesense capse `per_page` et `k` (vector kNN) a 250 pour les recherches
     hybrides. Pour remonter plus de candidats (utile pour les grosses
@@ -134,9 +140,7 @@ def _hybrid_typesense_search(
     page, puis client-side a travers les pages (un meme id_produit peut
     apparaitre sur plusieurs pages si ses chunks sont distribues).
     """
-    vec_str = json.dumps(query_vector)
     per_page = min(max(candidates, 1), _PER_PAGE_CAP)
-    # Nombre de pages necessaires pour couvrir `candidates` docs, cap _MAX_PAGES
     num_pages = min((candidates + per_page - 1) // per_page, _MAX_PAGES)
     num_pages = max(num_pages, 1)
 
@@ -145,13 +149,16 @@ def _hybrid_typesense_search(
         "q": query,
         "query_by": "nom_produit,categorie,text",
         "query_by_weights": "5,10,1",
-        "vector_query": f"embedding:({vec_str}, k:{per_page})",
         "per_page": per_page,
         "group_by": "id_produit",
         "group_limit": 1,
         "typo_tokens_threshold": 3,
         "drop_tokens_threshold": 2,
     }
+    # Ajoute le vector_query seulement si un vecteur est fourni (mode hybride)
+    if query_vector is not None:
+        vec_str = json.dumps(query_vector)
+        base_params["vector_query"] = f"embedding:({vec_str}, k:{per_page})"
     if filter_cats:
         escaped = ",".join(f"`{c}`" for c in filter_cats)
         base_params["filter_by"] = f"categorie:=[{escaped}]"


### PR DESCRIPTION
## Summary
Ajoute un flag **`use_vector`** (défaut `true`) au endpoint `/search/text` pour permettre un A/B test entre pipeline hybride et BM25 pur en prod.

## Comportement

| `use_vector` | Pipeline | Latence typique | Remontée sémantique |
|---|---|---|---|
| `true` (défaut) | **Hybride** : CamemBERT + BM25 + re-rank | ~2000 ms | Oui (synonymes, reformulations) |
| `false` | **BM25 pur** + re-rank (skip embedding service) | ~1500 ms | Non (BM25 only) |

## Formules de re-rank

**Hybride (`use_vector=true`)** — inchangée :
```
final = 0.55 * vec_score + 0.10 * bm25 + 0.25 * name_match + 0.10 * cat_match
penalite x0.3 si vec < 0.20 AND name_match < 0.50
```

**BM25 pur (`use_vector=false`)** — nouvelle :
```
final = 0.00 * vec_score + 0.20 * bm25 + 0.60 * name_match + 0.20 * cat_match
penalite x0.3 si name_match < 0.20 AND cat_match < 0.50
```

## Utilisation côté PHP

```
https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?...&typesense=1&use_vector=0
```

Le PHP `fonctions_typesense.php` (non versionné dans le repo, fichier ecrtel) lit `$_GET['use_vector']` et propage dans le payload JSON vers l'API.

## Fichiers modifiés
- `app/schemas/search_text.py` — champ `use_vector: bool = True`
- `app/router/search_text.py` — skip `embed_text()` si `false`
- `app/services/search_service.py` — `query_vector: Optional[List[float]]`, skip `vector_query` Typesense si None
- `app/services/reranker.py` — param `use_vector` avec poids alternatifs

## Test plan
- [ ] Merger la PR sur `features/poc`
- [ ] Sur la VM : `git pull` + `docker compose up -d --build --force-recreate opti-moteur-front`
- [ ] Tester API directement avec `use_vector=false` via curl
- [ ] Upload `fonctions_typesense.php` mis à jour sur ecrtel
- [ ] Tester navigateur : `?typesense=1&use_vector=0` (BM25 pur) vs `?typesense=1&use_vector=1` (hybride)
- [ ] Comparer latence ressentie et qualité visuelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
