### PR TITLE
feat(opti-moteur-front): param offset pour pagination AJAX

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/router/search_text.py
@@ -57,6 +57,7 @@ def search_by_text(req: SearchTextRequest):
             collection=req.collection,
             top_k=req.top_k,
             candidates=req.candidates,
+            offset=req.offset or 0,
             apply_filter_by_category=req.apply_filter_by_category,
         )
     except Exception as e:

--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -18,6 +18,15 @@ class SearchTextRequest(BaseModel):
     collection: Optional[str] = Field(None, description="Collection Typesense (override settings)")
     top_k: Optional[int] = Field(10, ge=1, le=2000, description="Nombre de resultats a retourner")
     candidates: Optional[int] = Field(50, ge=10, le=2000, description="Candidats pour re-rank")
+    offset: Optional[int] = Field(
+        0,
+        ge=0,
+        le=2000,
+        description=(
+            "Decalage dans les resultats re-ranked, pour la pagination AJAX. "
+            "Ex: offset=40 top_k=40 -> page 2 (produits 41-80)."
+        ),
+    )
     apply_filter_by_category: bool = Field(True, description="Applique filter_by si categorie detectee")
     use_vector: bool = Field(
         True,

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -23,6 +23,7 @@ def search(
     collection: Optional[str] = None,
     top_k: Optional[int] = None,
     candidates: Optional[int] = None,
+    offset: int = 0,
     apply_filter_by_category: bool = True,
 ) -> Dict[str, Any]:
     """
@@ -72,9 +73,10 @@ def search(
     ranked = rerank_candidates(groups, query, use_vector=use_vector)
     rerank_ms = (time.time() - t2) * 1000
 
-    # 5. Shape output
+    # 5. Shape output (applique offset pour pagination AJAX)
     hits_out = []
-    for r in ranked[:top_k]:
+    paged = ranked[offset:offset + top_k] if offset > 0 else ranked[:top_k]
+    for r in paged:
         d = r["doc"]
         hits_out.append({
             "id_produit":   d.get("id_produit"),


### PR DESCRIPTION
## Summary
Ajoute un paramètre **`offset: int = 0`** au endpoint `/search/text` pour permettre la pagination AJAX côté front.

Brique backend du prototype de **pagination AJAX** du moteur de recherche, qui doit diviser par ~2 le temps de rendu de la page 1 (40 produits au lieu de 160) et charger les pages 2/3/4 à la demande via fetch.

## Comportement

| Usage | top_k | offset | Résultat |
|---|---|---|---|
| Page 1 (initiale, rendue par PHP) | 40 | 0 | produits 1-40 |
| Page 2 (AJAX) | 40 | 40 | produits 41-80 |
| Page 3 (AJAX) | 40 | 80 | produits 81-120 |
| Page N (AJAX) | 40 | (N-1)×40 | produits N×40-39 à N×40 |

## Pipeline

1. Détection catégorie (inchangée)
2. `_hybrid_typesense_search` retourne jusqu'à 1000 candidats uniques (multi_search 4 pages × 250, dédup cross-pages)
3. Re-rank Python sur tout le pool
4. **NOUVEAU** : `ranked[offset : offset + top_k]` (au lieu de `[:top_k]`)
5. `total_candidates` reste exposé — le front calcule `nb_pages = ceil(total / 40)`

## Fichiers modifiés
- `app/schemas/search_text.py` — champ `offset: Optional[int] = Field(0, ge=0, le=2000)`
- `app/router/search_text.py` — passe `offset` à `do_search()`
- `app/services/search_service.py` — slicing avec offset

## Intégration front (hors repo, fichiers ecrtel)
- Nouveau endpoint PHP `site/moteur_recherche/search_ajax.php` qui appelle `launch_typesense($kw, 40, $offset)` et retourne un JSON léger
- Nouveau JS `site/design_system/js/moteur_recherche_ajax.js` qui intercepte les clics pagination
- Modif `fonctions_typesense.php` : accepte `$offset`, filtre les produits avec slug vide (évite URLs `/--id-produit.html`), expose `$GLOBALS['typesenseTotalCandidates']`
- Modif `moteur_recherche.php` : nouveau flag `?ajax=1` qui réduit `$nb_prod_max=40` et injecte `window.HP_SEARCH_STATE` + `<script src="...moteur_recherche_ajax.js">`

## Test plan
- [ ] Merger la PR sur `features/poc`
- [ ] VM : `git pull` + `docker compose up -d --build --force-recreate opti-moteur-front`
- [ ] Test API direct :
  - offset=0 top_k=40 → produits 1-40
  - offset=40 top_k=40 → produits 41-80
  - offset=80 top_k=40 → produits 81-120
  - vérifier que les scores décroissent correctement
- [ ] Upload les 4 fichiers PHP+JS sur ecrtel
- [ ] Test navigateur : `?typesense=1&ajax=1` vs `?typesense=1` (sans ajax) pour comparer la latence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
