### PR TITLE
chore(mcp-gateway): wire Slack env vars into docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2257,6 +2257,8 @@ services:
       # Google Templates runner sidecar (dynamic SA-JSON-backed MCP instances)
       - GOOGLE_TEMPLATES_RUNNER_URL=http://mcp-google-templates-runner:8595
       - GOOGLE_TEMPLATES_RUNNER_ADMIN_TOKEN=${GOOGLE_TEMPLATES_RUNNER_ADMIN_TOKEN}
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+      - SLACK_ENV_LABEL=${SLACK_ENV_LABEL:-dev}
     volumes:
       - /mnt/data/docker/images/mcp_server:/data/uploads
     # depends_on:


### PR DESCRIPTION
Pass SLACK_WEBHOOK_URL through from the host env and default SLACK_ENV_LABEL to "dev" so containers built from this compose file tag their alerts correctly without extra config.

FR: Transmet les variables Slack depuis l'environnement hôte vers le conteneur mcp-gateway-service.