### PR TITLE
feat(mcp-gateway): alert Slack on failed admin-UI login attempts

### DIFF
--- a/apps-microservices/mcp-gateway-service/cmd/server/main.go
+++ b/apps-microservices/mcp-gateway-service/cmd/server/main.go
@@ -150,7 +150,7 @@ func main() {
 
 	// Mount login/logout routes
 	if authCfg.Enabled {
-		auth.RegisterHandlers(mux, authCfg, userRepo)
+		auth.RegisterHandlers(mux, authCfg, userRepo, slackClient)
 		log.Println("[main] authentication enabled — login at /login")
 	}
 

--- a/apps-microservices/mcp-gateway-service/internal/auth/handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/auth/handlers.go
@@ -11,7 +11,29 @@ import (
 	"time"
 
 	"github.com/hellopro/mcp-gateway/internal/repository"
+	"github.com/hellopro/mcp-gateway/internal/slack"
 )
+
+// notifyLoginFailure surfaces a rejected admin-UI login attempt to Slack.
+// Rate-limited per (client_ip, username) via the shared cooldown limiter so
+// brute-force loops don't flood the channel. Safe to call with a nil client.
+func notifyLoginFailure(slackClient *slack.Client, r *http.Request, username, reason string) {
+	if slackClient == nil {
+		return
+	}
+	ip := slack.ClientIP(r)
+	// Key on (ip, username) rather than (ip, endpoint) so a scanner cycling
+	// through different usernames from the same IP still gets one alert per
+	// username-attempt in the cooldown window.
+	if !slackClient.AllowAuthAlert(ip, "login:"+username) {
+		return
+	}
+	slackClient.Notify(slack.UnauthorizedLoginEvent{
+		Username: username,
+		ClientIP: ip,
+		Reason:   reason,
+	})
+}
 
 // hellopro auth API response
 type HelloProAuthResponse struct {
@@ -23,13 +45,15 @@ type HelloProAuthResponse struct {
 
 // RegisterHandlers mounts /login and /logout on the mux.
 // userRepo is optional: when non-nil, each successful login upserts the user record.
-func RegisterHandlers(mux *http.ServeMux, cfg Config, userRepo *repository.UserRepo) {
+// slackClient is optional: when non-nil, failed login attempts fire an
+// UnauthorizedLoginEvent (rate-limited per (ip, username)).
+func RegisterHandlers(mux *http.ServeMux, cfg Config, userRepo *repository.UserRepo, slackClient *slack.Client) {
 	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
 			handleLoginPage(w, r, cfg)
 		case http.MethodPost:
-			handleLoginAction(w, r, cfg, userRepo)
+			handleLoginAction(w, r, cfg, userRepo, slackClient)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -57,7 +81,7 @@ func handleLoginPage(w http.ResponseWriter, r *http.Request, cfg Config) {
 	w.Write([]byte(`{"message":"Login page is served by the Vue SPA frontend"}`))
 }
 
-func handleLoginAction(w http.ResponseWriter, r *http.Request, cfg Config, userRepo *repository.UserRepo) {
+func handleLoginAction(w http.ResponseWriter, r *http.Request, cfg Config, userRepo *repository.UserRepo, slackClient *slack.Client) {
 	// Detect if this is a JSON API request (from Vue frontend) vs form submit (from Go template)
 	isJSON := strings.Contains(r.Header.Get("Content-Type"), "application/json")
 
@@ -114,6 +138,7 @@ func handleLoginAction(w http.ResponseWriter, r *http.Request, cfg Config, userR
 
 	if err != nil {
 		log.Printf("[auth] hellopro auth failed for %s: %v", username, err)
+		notifyLoginFailure(slackClient, r, username, "hellopro auth error: "+err.Error())
 		if isJSON {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -125,6 +150,7 @@ func handleLoginAction(w http.ResponseWriter, r *http.Request, cfg Config, userR
 	}
 
 	if !authResp.Success {
+		notifyLoginFailure(slackClient, r, username, "invalid credentials")
 		if isJSON {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -152,6 +178,7 @@ func handleLoginAction(w http.ResponseWriter, r *http.Request, cfg Config, userR
 	// Check if user is allowed to access the UI (from DB is_allowed field)
 	if !isAllowed {
 		log.Printf("[auth] user %s (%s) is not allowed (is_allowed=false)", authResp.DisplayName, authResp.Email)
+		notifyLoginFailure(slackClient, r, authResp.Email, "valid user but not in allowlist (is_allowed=false)")
 		if isJSON {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)

--- a/apps-microservices/mcp-gateway-service/internal/slack/events.go
+++ b/apps-microservices/mcp-gateway-service/internal/slack/events.go
@@ -110,6 +110,27 @@ func (e GatewayShutdownEvent) ToPayload(envLabel, gatewayURL string) ([]byte, er
 	)
 }
 
+// UnauthorizedLoginEvent fires when someone tries to log into the admin UI
+// and the attempt is rejected: wrong credentials, backend auth error, or
+// (most importantly) a valid user who is not on the allowlist. Distinct from
+// UnauthorizedEvent, which covers MCP-endpoint auth failures.
+type UnauthorizedLoginEvent struct {
+	Username string
+	ClientIP string
+	Reason   string
+}
+
+func (e UnauthorizedLoginEvent) ToPayload(envLabel, gatewayURL string) ([]byte, error) {
+	return buildPayload(
+		fmt.Sprintf(":no_entry: %sUnauthorized admin login attempt", envPrefix(envLabel)),
+		fmt.Sprintf("Username: `%s`", e.Username),
+		fmt.Sprintf("Client IP: `%s`", e.ClientIP),
+		fmt.Sprintf("Reason: `%s`", truncate(e.Reason, 200)),
+		fmt.Sprintf("Detected at: %s", nowUTC()),
+		gatewayFooter(gatewayURL),
+	)
+}
+
 // TestEvent is posted from the admin "try webhook" button so an operator can
 // confirm their Slack setup works end-to-end without waiting for a real
 // incident. Includes the triggering user's email when available.

--- a/apps-microservices/mcp-gateway-service/internal/slack/events_test.go
+++ b/apps-microservices/mcp-gateway-service/internal/slack/events_test.go
@@ -99,6 +99,19 @@ func TestGatewayShutdownPayload(t *testing.T) {
 	}
 }
 
+func TestUnauthorizedLoginPayload(t *testing.T) {
+	m := payloadFor(t,
+		UnauthorizedLoginEvent{Username: "bob@example.com", ClientIP: "1.2.3.4", Reason: "not in allowlist"},
+		"prod", "https://gw",
+	)
+	text := textOf(t, m)
+	for _, want := range []string{"prod", "admin login attempt", "bob@example.com", "1.2.3.4", "not in allowlist"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text missing %q: %q", want, text)
+		}
+	}
+}
+
 func TestTestEventPayload(t *testing.T) {
 	m := payloadFor(t, TestEvent{TriggeredBy: "alice@example.com"}, "staging", "https://gw")
 	text := textOf(t, m)


### PR DESCRIPTION
New UnauthorizedLoginEvent fires from handleLoginAction at all three rejection paths: hellopro auth backend error, invalid credentials, and (most importantly) a valid hellopro user who is not on the allowlist (is_allowed=false). Rate-limited per (ip, username) so brute-force loops produce one alert per attempted username in the cooldown window, not a flood. Distinct from the existing UnauthorizedEvent which covers MCP endpoint auth failures.

FR: Nouvelle notification Slack pour les tentatives de connexion refusées sur l'interface admin — identifiants invalides, erreur backend, ou utilisateur valide mais non autorisé (is_allowed=false).