### PR TITLE
feat(opti-moteur-front): expose id_categorie dans /search/text (debloque ajax front)

### DIFF
--- a/apps-microservices/opti-moteur-front/app/schemas/search.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search.py
@@ -24,8 +24,17 @@ class Hit(BaseModel):
     id_produit: str
     nom_produit: str
     categorie: str
+    # id_categorie : requis cote front PHP pour reconstruire l'URL fiche produit
+    # (pattern /<slug>-<id_categorie>-<id_produit>-produit.html). Sans ce champ,
+    # PHP filtre et rejette les hits -> 0 resultat affiche malgre 30 hits API.
+    id_categorie: str = ""
     fournisseur: str = ""
+    id_fournisseur: str = ""
     marque: str = ""
+    # etat / affichage : utilises par PHP pour le boost des societes clientes
+    # (logique moteur_solr : etat='Client' OU etat='Pause'+affichage='Complet').
+    etat: str = ""
+    affichage: str = ""
     prix_ht: Optional[float] = None
     score: float
     scores_detail: ScoreDetail

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -79,13 +79,22 @@ def search(
     for r in paged:
         d = r["doc"]
         hits_out.append({
-            "id_produit":   d.get("id_produit"),
-            "nom_produit":  d.get("nom_produit") or "",
-            "categorie":    d.get("categorie") or "",
-            "fournisseur":  d.get("fournisseur") or "",
-            "marque":       d.get("marque") or "",
-            "prix_ht":      d.get("prix_ht"),
-            "score":        round(r["final_score"], 4),
+            "id_produit":    d.get("id_produit"),
+            "nom_produit":   d.get("nom_produit") or "",
+            "categorie":     d.get("categorie") or "",
+            # id_categorie : indispensable pour reconstruire l'URL fiche produit cote front
+            # (pattern /<slug>-<id_categorie>-<id_produit>-produit.html). Sans ce champ,
+            # PHP filtre et rejette les hits -> 0 resultat affiche malgre 30 hits API.
+            "id_categorie":  str(d.get("id_categorie") or ""),
+            "fournisseur":   d.get("fournisseur") or "",
+            "id_fournisseur": str(d.get("id_fournisseur") or ""),
+            "marque":        d.get("marque") or "",
+            # etat / affichage : utilises cote PHP pour le boost "societe cliente"
+            # (etat == 'Client' OU (etat == 'Pause' AND affichage == 'Complet')).
+            "etat":          d.get("etat") or "",
+            "affichage":     d.get("affichage") or "",
+            "prix_ht":       d.get("prix_ht"),
+            "score":         round(r["final_score"], 4),
             "scores_detail": {
                 "vector":     round(r["vec_score"], 4),
                 "bm25":       round(r["bm25_score"], 4),


### PR DESCRIPTION
## Contexte

Test en prod de `?typesense=1&ajax=1` sur hellopro.fr -> **page blanche** alors que l'API retourne bien 30 hits pour la query `minipelle` (cf curl ci-dessous).

```bash
$ curl -s -X POST https://api.hellopro.eu/optimoteur-service/search/text \
    -d '{"query":"minipelle","top_k":30,"candidates":250,"offset":0,"use_vector":false}' \
    | jq '.total_candidates, (.results | length)'
178
30
```

Cause identifiee : l'endpoint `/search/text` retourne `categorie` (le nom) mais **pas `id_categorie`**. Cote PHP (`recup_info_prod_typesense` dans `site/hellopro_fr/fonctions/fonctions_typesense.php`), l'URL fiche produit est reconstruite via :

```
/<slug-nom>-<id_categorie>-<id_produit>-produit.html
```

Sans `id_categorie` -> URL incorrecte (`/--764149-produit.html`) -> filtre cote PHP rejette 100% des hits -> 0 produit affiche.

## Changement

Projection de 4 champs supplementaires dans la reponse `/search/text`, deja presents dans la collection Typesense (cf `ingestion_service._row_to_doc`) :

| Champ | Usage cote PHP | Criticite |
|---|---|---|
| `id_categorie` | Reconstruction URL fiche produit | **Bloquant** |
| `id_fournisseur` | Debug / logs / futur | Nice-to-have |
| `etat` | Boost societe cliente (etat == 'Client') | Nice-to-have |
| `affichage` | Boost societe cliente (etat=='Pause' + affichage=='Complet') | Nice-to-have |

## Fichiers modifies

- `app/schemas/search.py` - ajout des 4 champs dans `Hit` (tous optionnels, default `""`)
- `app/services/search_service.py` - projection des 4 champs dans `hits_out`

**Pas de breaking change** : tous les champs sont optionnels avec defaut vide, les clients existants ne sont pas impactes.

## Test plan

- [ ] Merger la PR sur `features/poc`
- [ ] VM : `git pull` + `docker compose up -d --build --force-recreate opti-moteur-front`
- [ ] Test API direct (verifier que `id_categorie` est desormais present) :
  ```
  curl -s -X POST https://api.hellopro.eu/optimoteur-service/search/text \
    -d '{"query":"minipelle","top_k":3,"use_vector":false}' | jq '.results[0]'
  ```
  Doit contenir : `id_categorie`, `id_fournisseur`, `etat`, `affichage`.
- [ ] Test navigateur : `https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles=minipelle&typesense=1&ajax=1` -> doit afficher des produits (pas page blanche).