### PR TITLE
feat(opti-moteur-front): synonymes Typesense + threshold detection categorie 0.80 -> 0.30

### DIFF
--- a/apps-microservices/opti-moteur-front/app/core/credentials.py
+++ b/apps-microservices/opti-moteur-front/app/core/credentials.py
@@ -38,7 +38,10 @@ class Settings(BaseSettings):
     RERANK_W_CAT: float = 0.10
 
     # --- Detection categorie ---
-    CAT_FILTER_THRESHOLD: float = 0.80
+    # Threshold bas (0.30) car la validation est deja stricte via le
+    # prefix-match sur les tokens (is_prefix_match dans utils/text.py).
+    # Confidence < 0.30 = query vraiment ambigue, on laisse filter_by=null.
+    CAT_FILTER_THRESHOLD: float = 0.30
     CAT_FILTER_TOP_N: int = 3
     CAT_PREFIX_LOOKAHEAD: int = 2
 

--- a/apps-microservices/opti-moteur-front/app/core/typesense_client.py
+++ b/apps-microservices/opti-moteur-front/app/core/typesense_client.py
@@ -96,6 +96,65 @@ class TypesenseClient:
             "token_separators": ["-", "/"],
         }
 
+    # ---------- Synonymes ----------
+    # Typesense supporte les synonymes one-way ou multi-way. Utiles pour
+    # remonter les variations orthographiques (minipelle = mini pelle,
+    # tractopelle = tracto pelle, etc.) sans avoir a re-indexer.
+    # cf. https://typesense.org/docs/0.25.1/api/synonyms.html
+
+    def upsert_synonym(
+        self,
+        synonym_id: str,
+        synonyms: list,
+        root: Optional[str] = None,
+        collection: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Enregistre un synonyme dans la collection Typesense.
+        - synonyms=["minipelle","mini pelle","mini-pelle"] + root=None
+          -> synonyme multi-way (n'importe quel terme match tous les autres)
+        - root="minipelle" + synonyms=["mini pelle"]
+          -> synonyme one-way (seul "minipelle" s'expand, pas l'inverse)
+        """
+        collection = collection or settings.TYPESENSE_COLLECTION
+        url = f"{self.base_url()}/collections/{collection}/synonyms/{synonym_id}"
+        body = {"synonyms": list(synonyms)}
+        if root:
+            body["root"] = root
+        r = requests.put(
+            url,
+            headers={
+                "X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY,
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=10,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def list_synonyms(self, collection: Optional[str] = None) -> Dict[str, Any]:
+        collection = collection or settings.TYPESENSE_COLLECTION
+        url = f"{self.base_url()}/collections/{collection}/synonyms"
+        r = requests.get(
+            url,
+            headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY},
+            timeout=10,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def delete_synonym(self, synonym_id: str, collection: Optional[str] = None) -> Dict[str, Any]:
+        collection = collection or settings.TYPESENSE_COLLECTION
+        url = f"{self.base_url()}/collections/{collection}/synonyms/{synonym_id}"
+        r = requests.delete(
+            url,
+            headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY},
+            timeout=10,
+        )
+        r.raise_for_status()
+        return r.json()
+
     def create_collection_if_missing(self, name: Optional[str] = None) -> Dict[str, Any]:
         name = name or settings.TYPESENSE_COLLECTION
         if self.collection_exists(name):

--- a/apps-microservices/opti-moteur-front/app/router/admin.py
+++ b/apps-microservices/opti-moteur-front/app/router/admin.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from app.core.credentials import settings
 from app.core.typesense_client import typesense_client
+from app.services.synonyms_service import auto_generate_synonyms
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
@@ -117,5 +118,33 @@ def upsert_synonyms_batch(req: SynonymsBatchRequest, collection: Optional[str] =
 def delete_synonym(synonym_id: str, collection: Optional[str] = None):
     try:
         return typesense_client.delete_synonym(synonym_id, collection)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/synonyms/auto-generate",
+    summary="Auto-generer les synonymes depuis TOUTES les categories de la collection",
+)
+def synonyms_auto_generate(
+    collection: Optional[str] = None,
+    dry_run: bool = False,
+):
+    """
+    Scan toutes les categories ingerees dans Typesense, et pour chaque
+    categorie multi-tokens (ex: 'Mini-pelles (moins de 10 tonnes)') genere
+    automatiquement les variantes orthographiques equivalentes
+    (minipelles / mini pelles / mini-pelles) comme synonyme multi-way.
+
+    A appeler apres chaque ingestion de nouvelles categories. Sans liste
+    metier manuelle : la source de verite est le catalogue Typesense.
+
+    Parametres query :
+      - collection (optional) : override settings.TYPESENSE_COLLECTION
+      - dry_run (default false) : si true, calcule mais ne push rien
+        (utile pour revue avant activation).
+    """
+    try:
+        return auto_generate_synonyms(collection=collection, dry_run=dry_run)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps-microservices/opti-moteur-front/app/router/admin.py
+++ b/apps-microservices/opti-moteur-front/app/router/admin.py
@@ -1,10 +1,32 @@
 """Routes d'administration Typesense."""
+from typing import List, Optional
+
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
 
 from app.core.credentials import settings
 from app.core.typesense_client import typesense_client
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+class SynonymRequest(BaseModel):
+    """Payload pour enregistrer un synonyme Typesense."""
+    id: str = Field(..., description="Identifiant unique du synonyme", examples=["minipelle"])
+    synonyms: List[str] = Field(
+        ...,
+        description="Liste des termes synonymes (multi-way si root=null)",
+        examples=[["minipelle", "mini pelle", "mini-pelle"]],
+    )
+    root: Optional[str] = Field(
+        None,
+        description="Si defini : synonyme one-way (seul root s'expand)",
+    )
+
+
+class SynonymsBatchRequest(BaseModel):
+    """Batch pour enregistrer plusieurs synonymes d'un coup."""
+    synonyms: List[SynonymRequest]
 
 
 @router.get("/collections", summary="Liste des collections Typesense")
@@ -45,5 +67,55 @@ def delete_collection(name: str, confirm: bool = False):
     try:
         typesense_client.client.collections[name].delete()
         return {"deleted": name}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ---------- Synonymes ----------
+
+@router.get("/synonyms", summary="Lister les synonymes de la collection")
+def list_synonyms(collection: Optional[str] = None):
+    try:
+        return typesense_client.list_synonyms(collection)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.put("/synonyms", summary="Creer ou mettre a jour UN synonyme")
+def upsert_synonym(req: SynonymRequest, collection: Optional[str] = None):
+    try:
+        return typesense_client.upsert_synonym(
+            synonym_id=req.id,
+            synonyms=req.synonyms,
+            root=req.root,
+            collection=collection,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.put("/synonyms/batch", summary="Creer/mettre a jour plusieurs synonymes")
+def upsert_synonyms_batch(req: SynonymsBatchRequest, collection: Optional[str] = None):
+    """
+    Pratique pour initialiser le jeu de synonymes metier (mots composes FR B2B) :
+    minipelle, tractopelle, microchargeuse, etc.
+    """
+    results = []
+    errors = []
+    for s in req.synonyms:
+        try:
+            res = typesense_client.upsert_synonym(
+                synonym_id=s.id, synonyms=s.synonyms, root=s.root, collection=collection,
+            )
+            results.append({"id": s.id, "ok": True, "response": res})
+        except Exception as e:
+            errors.append({"id": s.id, "ok": False, "error": str(e)})
+    return {"ok": len(errors) == 0, "done": len(results), "errors": errors}
+
+
+@router.delete("/synonyms/{synonym_id}", summary="Supprimer un synonyme")
+def delete_synonym(synonym_id: str, collection: Optional[str] = None):
+    try:
+        return typesense_client.delete_synonym(synonym_id, collection)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
@@ -1,0 +1,207 @@
+"""
+Synonyms service : auto-generation des synonymes Typesense pour les mots
+composes (compound words) et variantes tiret / espace / concatenation.
+
+Contexte :
+Typesense BM25 est token-exact : il ne matchera pas "minipelle" (1 token)
+contre "Mini-pelles" (tokens "mini", "pelles" apres split sur le tiret).
+La solution generique : scanner TOUS les noms de categories ingerees et
+generer automatiquement pour chacun les 3 variantes equivalentes :
+
+  "Mini-pelles (moins de 10 tonnes)"
+    -> base tokens : ["mini", "pelles"]
+    -> variantes   : "minipelles" (concat), "mini pelles" (espace), "mini-pelles" (tiret)
+    -> synonyme multi-way : toute query avec l'une de ces formes remonte les autres.
+
+Ainsi, pour n'importe quelle categorie future (Tractopelle, Microtracteur,
+Electrogene, etc.) dont le nom contient au moins un mot compose (tokens
+separes par tiret OU par espace), on couvre toutes les variantes
+d'ecriture utilisateur sans maintenance manuelle de liste metier.
+
+A appeler :
+  - une fois apres ingestion initiale
+  - apres chaque ingestion batch de nouvelles categories
+
+via endpoint : POST /admin/synonyms/auto-generate
+"""
+import logging
+import re
+import unicodedata
+from typing import Dict, List, Any, Optional, Tuple, Set
+
+from app.core.credentials import settings
+from app.core.typesense_client import typesense_client
+
+logger = logging.getLogger(__name__)
+
+
+# Stopwords FR B2B a retirer des noms de categorie avant de generer les
+# variantes. Ce ne sont pas des mots porteurs de sens pour la query user.
+_STOPWORDS_FR = {
+    "de", "du", "la", "le", "les", "des", "un", "une", "et", "ou", "a", "au",
+    "aux", "en", "dans", "pour", "par", "avec", "sans", "sur", "sous", "entre",
+    "moins", "plus", "tonnes", "tonne", "kg", "mm", "cm", "m", "kw", "kva",
+    "litres", "litre", "l", "ans", "an", "heures", "heure", "h",
+}
+# Nombres et tokens purement numeriques -> a retirer aussi (pas discriminants
+# pour la query "minipelle" vs "Mini-pelles (moins de 10 tonnes)").
+
+
+def _normalize(s: str) -> str:
+    """Retire accents + lowercase."""
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFD", s)
+    return "".join(c for c in s if unicodedata.category(c) != "Mn").lower()
+
+
+def _extract_meaningful_tokens(cat_name: str) -> List[str]:
+    """
+    Retourne les tokens 'porteurs' d'une categorie, normalises, dans l'ordre.
+
+    Ex :
+      "Mini-pelles (moins de 10 tonnes)"
+        -> ["mini", "pelles"]                 (retire 'moins','de','10','tonnes')
+      "Groupe electrogene industriel"
+        -> ["groupe", "electrogene", "industriel"]
+      "Tractopelles"
+        -> ["tractopelles"]
+      "Pelle rail-route"
+        -> ["pelle", "rail", "route"]
+    """
+    norm = _normalize(cat_name)
+    # Supprime tout ce qui est entre parentheses (specs techniques).
+    norm = re.sub(r"\([^)]*\)", " ", norm)
+    # Tokenise sur [a-z0-9]+ puis garde >=2 chars et pas dans stopwords,
+    # et pas purement numerique.
+    raw = re.findall(r"[a-z0-9]+", norm)
+    return [
+        t for t in raw
+        if len(t) >= 2 and t not in _STOPWORDS_FR and not t.isdigit()
+    ]
+
+
+def _build_variants(tokens: List[str]) -> Set[str]:
+    """
+    Genere les variantes orthographiques equivalentes a partir des tokens :
+      - concatenation (sans separateur) : "minipelles"
+      - join par espace                 : "mini pelles"
+      - join par tiret                  : "mini-pelles"
+
+    Si le nom ne contient qu'UN seul token (ex: "Tractopelles"), il n'y a
+    pas de compound-word possible -> retourne set vide (pas de synonyme
+    utile a creer).
+
+    Si le nom contient plus de 4 tokens, on ne genere pas non plus : au
+    dela c'est un nom long type "Remorques a ridelles basculantes" et
+    l'utilisateur ne les concatene jamais.
+    """
+    if len(tokens) < 2 or len(tokens) > 4:
+        return set()
+    variants = {
+        "".join(tokens),
+        " ".join(tokens),
+        "-".join(tokens),
+    }
+    # Filtre : on ne garde que si les variantes sont reellement differentes
+    # et contiennent au moins 4 chars.
+    return {v for v in variants if len(v) >= 4}
+
+
+def _slug_id(s: str) -> str:
+    """Transforme une string en id stable pour Typesense (alphanum + tirets)."""
+    s = _normalize(s)
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:128] or "auto"
+
+
+def _list_categories(collection: str) -> List[str]:
+    """
+    Retourne la liste des noms de categories distincts dans la collection
+    via un facet query 'match all'. Cap a 2000 categories (HelloPro tourne
+    autour de 8300 rubriques en BDD mais toutes ne sont pas ingerees).
+    """
+    params = {
+        "collection": collection,
+        "q": "*",
+        "query_by": "categorie",
+        "per_page": 1,
+        "facet_by": "categorie",
+        "max_facet_values": 2000,
+    }
+    try:
+        res = typesense_client.multi_search({"searches": [params]})
+        result = res["results"][0]
+    except Exception as e:
+        logger.error("list_categories error: %s", e)
+        return []
+    facets = result.get("facet_counts", [])
+    if not facets:
+        return []
+    counts = facets[0].get("counts", [])
+    return [c["value"] for c in counts if c.get("value")]
+
+
+def auto_generate_synonyms(
+    collection: Optional[str] = None,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """
+    Scan toutes les categories de la collection, genere les variantes
+    compound-words, et les enregistre comme synonymes multi-way Typesense.
+
+    Retourne un dict de stats :
+      {
+        "nb_categories": int,
+        "nb_synonyms_generated": int,    # categories eligibles (multi-tokens)
+        "nb_synonyms_pushed": int,       # effectivement PUT dans Typesense
+        "nb_errors": int,
+        "examples": [{"cat":..., "variants":[...]}],   # 10 premiers
+        "errors": [{"cat":..., "error":...}],
+        "dry_run": bool,
+      }
+
+    dry_run=True : calcule les synonymes mais ne les push pas (utile pour
+    revue avant activation).
+    """
+    collection = collection or settings.TYPESENSE_COLLECTION
+    cats = _list_categories(collection)
+    nb_generated = 0
+    nb_pushed = 0
+    errors: List[Dict[str, str]] = []
+    examples: List[Dict[str, Any]] = []
+
+    for cat in cats:
+        tokens = _extract_meaningful_tokens(cat)
+        variants = _build_variants(tokens)
+        if not variants:
+            continue  # 1 token seul ou trop long -> pas de compound utile
+        nb_generated += 1
+
+        syn_id = "auto-" + _slug_id(cat)
+        if len(examples) < 10:
+            examples.append({"cat": cat, "variants": sorted(variants)})
+
+        if dry_run:
+            continue
+
+        try:
+            typesense_client.upsert_synonym(
+                synonym_id=syn_id,
+                synonyms=sorted(variants),
+                root=None,
+                collection=collection,
+            )
+            nb_pushed += 1
+        except Exception as e:
+            errors.append({"cat": cat, "error": str(e)})
+
+    return {
+        "nb_categories": len(cats),
+        "nb_synonyms_generated": nb_generated,
+        "nb_synonyms_pushed": nb_pushed,
+        "nb_errors": len(errors),
+        "examples": examples,
+        "errors": errors[:20],
+        "dry_run": dry_run,
+    }


### PR DESCRIPTION
## Contexte

Sur la query **minipelle**, le front n'affiche que du bruit (separateurs tubulaires MANUTAN, tachymetres, cuves PRIMAGAZ...) au lieu de vraies mini-pelles. Pourtant la BDD compte **578 Mini-pelles** (dont ~182 reellement visibles Client/Complet ou Pause/Complet).

Root cause en 2 points :

### 1. Typesense BM25 ne matche pas les mots composes

- Query: \"minipelle\" -> 1 token
- Categorie: \"Mini-pelles (moins de 10 tonnes)\" -> tokens \"mini\", \"pelles\" (split sur tiret)
- BM25 token-exact -> aucun match

### 2. CAT_FILTER_THRESHOLD = 0.80 trop strict

- detect_categories retourne un top_cat avec confiance spreadee -> ~10-20% -> threshold 0.80 non atteint -> `filter_by=null` -> pool non filtre -> bruit.

Resultat : 200 hits rendus par l'API, non filtres par categorie -> PHP en prend 30 avec beaucoup de bruit.

## Solution : **auto-generation** depuis le catalogue

**Pas de liste metier manuelle** (ne scale pas : nouvelle categorie = maintenance). La source de verite est le catalogue Typesense lui-meme.

### Principe

Pour chaque categorie multi-tokens :
- \"Mini-pelles (moins de 10 tonnes)\" -> extraction tokens porteurs : `[\"mini\", \"pelles\"]` (retire stopwords FR, parentheses, mesures, numeriques)
- Generation variantes equivalentes :
  - concatenation : `\"minipelles\"`
  - espace : `\"mini pelles\"`
  - tiret : `\"mini-pelles\"`
- Enregistrement synonyme multi-way Typesense (id = `auto-<slug>`)

Couvre automatiquement **tout le catalogue actuel + futur** sans maintenance. Toute query avec l'une de ces variantes ramene la categorie correspondante.

### CAT_FILTER_THRESHOLD 0.80 -> 0.30

Threshold 0.80 trop strict pour queries courtes. 0.30 permet `filter_by` quand la detection est deterministe (is_prefix_match). La validation reste stricte via `is_prefix_match` qui verifie tokens en debut de nom categorie.

## Fichiers ajoutes / modifies

- **[nouveau]** `app/services/synonyms_service.py` : extraction tokens porteurs + generation variantes + push Typesense
- **[modif]** `app/router/admin.py` :
  - `GET    /admin/synonyms` : lister
  - `PUT    /admin/synonyms` : upsert 1 synonyme
  - `PUT    /admin/synonyms/batch` : upsert batch
  - `DELETE /admin/synonyms/{id}` : supprimer
  - **`POST /admin/synonyms/auto-generate?dry_run=true|false`** : scan toutes les categories + auto-genere
- **[modif]** `app/core/typesense_client.py` : methodes `upsert_synonym`, `list_synonyms`, `delete_synonym`
- **[modif]** `app/core/credentials.py` : CAT_FILTER_THRESHOLD 0.80 -> 0.30

## Test plan

- [ ] Merger sur `features/poc`
- [ ] VM : `git pull && docker compose up -d --build --force-recreate opti-moteur-front`
- [ ] **Revue a blanc** (dry-run, voir ce qui serait genere) :
  \`\`\`bash
  curl -s -X POST \"https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate?dry_run=true\" | jq
  \`\`\`
  Retourne nb_categories, nb_synonyms_generated, 10 exemples.
- [ ] **Activation** :
  \`\`\`bash
  curl -s -X POST https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate | jq
  \`\`\`
- [ ] **Test API** (filter_by doit s'appliquer) :
  \`\`\`bash
  curl -s -X POST https://api.hellopro.eu/optimoteur-service/search/text \
    -H \"Content-Type: application/json\" \
    -d '{\"query\":\"minipelle\",\"top_k\":30,\"use_vector\":false}' \
    | jq '{filter:.filter_by_category, top5:[.results[0:5][] | .categorie]}'
  \`\`\`
  Attendu : `filter` non-null, top5 = 5 \"Mini-pelles\".
- [ ] Tests avec autres mots composes : tractopelle, microtracteur, etc.
- [ ] Test navigateur : `?typesense=1&ajax=1&mot_cles=minipelle` -> ~30 vraies mini-pelles.

**Apres chaque ingestion future de categories** : relancer l'endpoint auto-generate.