### PR TITLE
feat(opti-moteur-front): synonymes - gestion singulier/pluriel + variantes avec stopwords

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
@@ -27,6 +27,7 @@ via endpoint : POST /admin/synonyms/auto-generate
 import logging
 import re
 import unicodedata
+from itertools import product
 from typing import Dict, List, Any, Optional, Tuple, Set
 
 from app.core.credentials import settings
@@ -55,57 +56,116 @@ def _normalize(s: str) -> str:
     return "".join(c for c in s if unicodedata.category(c) != "Mn").lower()
 
 
-def _extract_meaningful_tokens(cat_name: str) -> List[str]:
+def _extract_tokens(cat_name: str, keep_stopwords: bool) -> List[str]:
     """
-    Retourne les tokens 'porteurs' d'une categorie, normalises, dans l'ordre.
+    Retourne les tokens d'une categorie normalises, dans l'ordre.
 
-    Ex :
-      "Mini-pelles (moins de 10 tonnes)"
-        -> ["mini", "pelles"]                 (retire 'moins','de','10','tonnes')
-      "Groupe electrogene industriel"
-        -> ["groupe", "electrogene", "industriel"]
-      "Tractopelles"
-        -> ["tractopelles"]
-      "Pelle rail-route"
-        -> ["pelle", "rail", "route"]
+    keep_stopwords = False : ne garde que les tokens porteurs (comme avant).
+      "Mini-pelles (moins de 10 tonnes)" -> ["mini", "pelles"]
+    keep_stopwords = True  : garde tous les tokens (utile pour matcher
+      les concatenations utilisateur type "fauteuildebureau").
+      "Fauteuil de bureau"  -> ["fauteuil", "de", "bureau"]
     """
     norm = _normalize(cat_name)
     # Supprime tout ce qui est entre parentheses (specs techniques).
     norm = re.sub(r"\([^)]*\)", " ", norm)
-    # Tokenise sur [a-z0-9]+ puis garde >=2 chars et pas dans stopwords,
-    # et pas purement numerique.
     raw = re.findall(r"[a-z0-9]+", norm)
+    if keep_stopwords:
+        return [t for t in raw if len(t) >= 1 and not t.isdigit()]
     return [
         t for t in raw
         if len(t) >= 2 and t not in _STOPWORDS_FR and not t.isdigit()
     ]
 
 
+def _sing_plur_forms(token: str) -> List[str]:
+    """
+    Retourne le token + ses variantes singulier/pluriel (heuristique FR).
+    Utilise pour couvrir les cas "minipelle" (singulier) vs "Mini-pelles"
+    (pluriel dans le nom de categorie).
+    """
+    forms = {token}
+    # pluriel -> singulier
+    if token.endswith("aux") and len(token) >= 5:
+        # journaux -> journal, generaux -> general
+        forms.add(token[:-3] + "al")
+    elif token.endswith("eux") and len(token) >= 4:
+        # cheveux -> cheveu
+        forms.add(token[:-1])
+    elif token.endswith("x") and len(token) >= 3:
+        # choux -> chou, bijoux -> bijou
+        forms.add(token[:-1])
+    elif token.endswith("s") and len(token) >= 3 and not token.endswith("ss"):
+        # pelles -> pelle, chaussures -> chaussure
+        forms.add(token[:-1])
+    else:
+        # singulier -> pluriel (simple ajout de 's')
+        forms.add(token + "s")
+    # Garde uniquement ceux de longueur >= 2
+    return [f for f in forms if len(f) >= 2]
+
+
 def _build_variants(tokens: List[str]) -> Set[str]:
     """
-    Genere les variantes orthographiques equivalentes a partir des tokens :
-      - concatenation (sans separateur) : "minipelles"
-      - join par espace                 : "mini pelles"
-      - join par tiret                  : "mini-pelles"
+    Pour des tokens donnes (ex: ["mini","pelles"]), genere toutes les
+    variantes orthographiques utilisateur :
+      - 3 separateurs : concatenation, espace, tiret
+      - toutes les combinaisons singulier/pluriel de chaque token
 
-    Si le nom ne contient qu'UN seul token (ex: "Tractopelles"), il n'y a
-    pas de compound-word possible -> retourne set vide (pas de synonyme
-    utile a creer).
+    Ex "mini pelles" :
+      - ["mini","pelles"]   -> minipelles, mini pelles, mini-pelles
+      - ["minis","pelles"]  -> minispelles, minis pelles, minis-pelles
+      - ["mini","pelle"]    -> minipelle, mini pelle, mini-pelle    <- AJOUTE
+      - ["minis","pelle"]   -> minispelle, minis pelle, minis-pelle
 
-    Si le nom contient plus de 4 tokens, on ne genere pas non plus : au
-    dela c'est un nom long type "Remorques a ridelles basculantes" et
-    l'utilisateur ne les concatene jamais.
+    Pour 1 token seul (ex: "Tractopelles"), on genere juste ses formes
+    singulier/pluriel (utile pour query "tractopelle").
+
+    Cap a 4 tokens porteurs pour eviter l'explosion combinatoire.
     """
-    if len(tokens) < 2 or len(tokens) > 4:
+    if not tokens or len(tokens) > 4:
         return set()
-    variants = {
-        "".join(tokens),
-        " ".join(tokens),
-        "-".join(tokens),
-    }
-    # Filtre : on ne garde que si les variantes sont reellement differentes
-    # et contiennent au moins 4 chars.
+
+    # Pour chaque token, ses formes s/p
+    token_forms = [_sing_plur_forms(t) for t in tokens]
+
+    variants: Set[str] = set()
+    for combo in product(*token_forms):
+        if len(combo) == 1:
+            # 1 mot : pas de separateur, juste la forme
+            variants.add(combo[0])
+        else:
+            variants.add("".join(combo))
+            variants.add(" ".join(combo))
+            variants.add("-".join(combo))
+
+    # Cap de securite : pas plus de 32 variantes par categorie
+    # (4 tokens x 2 formes x 3 separateurs = 48 theorique, mais en pratique
+    # beaucoup sont deja dedupliques).
     return {v for v in variants if len(v) >= 4}
+
+
+def _build_all_variants(cat_name: str) -> Set[str]:
+    """
+    Genere TOUTES les variantes pour une categorie :
+      1. Avec tokens porteurs uniquement (retire stopwords) : "mini pelles"
+      2. Avec TOUS les tokens (stopwords inclus) : "mini pelles moins"
+         -> sert surtout pour la concatenation "fauteuildebureau".
+
+    L'utilisateur peut taper aussi bien "fauteuilbureau" que
+    "fauteuildebureau" -> les deux doivent ramener la categorie.
+    """
+    core_tokens = _extract_tokens(cat_name, keep_stopwords=False)
+    full_tokens = _extract_tokens(cat_name, keep_stopwords=True)
+
+    variants = _build_variants(core_tokens)
+
+    # Ajoute variantes avec stopwords SI le set de tokens est different
+    # (= la categorie contient des stopwords entre les mots porteurs).
+    if full_tokens != core_tokens and len(full_tokens) <= 5:
+        variants |= _build_variants(full_tokens)
+
+    return variants
 
 
 def _slug_id(s: str) -> str:
@@ -172,10 +232,9 @@ def auto_generate_synonyms(
     examples: List[Dict[str, Any]] = []
 
     for cat in cats:
-        tokens = _extract_meaningful_tokens(cat)
-        variants = _build_variants(tokens)
+        variants = _build_all_variants(cat)
         if not variants:
-            continue  # 1 token seul ou trop long -> pas de compound utile
+            continue  # Categorie trop longue ou vide apres normalisation
         nb_generated += 1
 
         syn_id = "auto-" + _slug_id(cat)


### PR DESCRIPTION
## Contexte

Suite a la PR #476 mergee, tests de validation sur 5 queries :

| Query | Resultat | Pourquoi |
|---|---|---|
| `minipelle` | filter null mais top5 OK (rerank) | Synonyme au pluriel (`minipelles`) uniquement, pas de match exact avec `minipelle` |
| `tractopelle` | OK | 1 token, synonyme non genere, mais BM25 fuzzy trouve |
| `chariotelevateur` | OK | Variante `chariotelevateur` (stopwords retires) matche |
| `chaussuressecurite` | OK | Idem |
| `fauteuildebureau` | **0 hit** | Synonyme genere = `fauteuilbureau` (stopword \"de\" retire), mais user tape avec \"de\" -> 0 match |

Deux limites identifiees :
1. Pas de variante **singulier** alors que les noms de categorie sont au pluriel (`Mini-pelles`)
2. Stopwords systematiquement retires -> pas de variante `fauteuildebureau` pour la categorie \"Fauteuil de bureau\"

## Solution

### 1. Singulier/pluriel automatique

Nouvelle fonction `_sing_plur_forms(token)` avec heuristique FR :

| Token | Singulier/Pluriel detecte |
|---|---|
| pelles | {pelles, pelle} |
| chaussures | {chaussures, chaussure} |
| bijoux | {bijoux, bijou} |
| journaux | {journaux, journal} |
| cheveux | {cheveux, cheveu} |
| mini | {mini, minis} |

Pour chaque token d'une categorie, on genere ses 2 formes puis produit cartesien x 3 separateurs (concat/espace/tiret).

Pour **Mini-pelles (moins de 10 tonnes)** [`mini`, `pelles`] on passe de **3 variantes** a **12** :
- minipelles, mini pelles, mini-pelles, minispelles, minis pelles, minis-pelles
- minipelle, mini pelle, mini-pelle, minispelle, minis pelle, minis-pelle  <- fix principal

### 2. Variantes AVEC stopwords

Nouvelle fonction `_build_all_variants(cat)` qui fait 2 passes :
- a) tokens porteurs uniquement (comportement actuel)
- b) tokens complets avec stopwords (si different de a)

Pour **Fauteuil de bureau** [`fauteuil`, `de`, `bureau`] :
- Passe a : `fauteuilbureau`, `fauteuil bureau`, `fauteuil-bureau` + variantes pluriel
- Passe b : `fauteuildebureau`, `fauteuil de bureau`, `fauteuil-de-bureau` + variantes pluriel

L'utilisateur peut taper indifferemment `fauteuilbureau` ou `fauteuildebureau`.

### 3. Categories a 1 token aussi couvertes

Avant : `_build_variants` retournait vide si 1 token. Apres : genere les 2 formes s/p (`tractopelles` + `tractopelle`). Utile pour toutes les queries au singulier d'une categorie au pluriel.

## Fichier modifie

- `app/services/synonyms_service.py` (+96 / -37)

## Test plan

- [ ] Merger sur `features/poc`
- [ ] VM : git pull + docker compose up -d --build --force-recreate opti-moteur-front
- [ ] Relancer l'auto-generate (va ecraser les 1648 anciens synonymes) :
  \`\`\`bash
  curl -s -X POST https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate | jq '.nb_synonyms_pushed'
  \`\`\`
  Attendu : le nombre sera plus eleve (categories 1-token desormais eligibles).
- [ ] Verifier nouveau contenu pour mini-pelles :
  \`\`\`bash
  curl -s \"https://api.hellopro.eu/optimoteur-service/admin/synonyms\" | jq '.synonyms[] | select(.id | contains(\"mini-pelles\"))'
  \`\`\`
  Attendu : doit contenir **minipelle** (singulier) et ses variantes tiret/espace.
- [ ] Re-test exhaustif des 5 queries :
  \`\`\`bash
  for q in \"minipelle\" \"tractopelle\" \"chariotelevateur\" \"fauteuildebureau\" \"chaussuressecurite\"; do
    curl -s -X POST https://api.hellopro.eu/optimoteur-service/search/text \
      -H \"Content-Type: application/json\" \
      -d \"{\\\"query\\\":\\\"\$q\\\",\\\"top_k\\\":3,\\\"use_vector\\\":false}\" \
      | jq --arg q \"\$q\" '{q:\$q, filter:.filter_by_category, cats:[.results[0:3][] | .categorie]}'
  done
  \`\`\`
  Attendu : **5/5** queries ramenent la bonne categorie (et ideallement filter_by non null).