### PR TITLE
fix(crawler-monitor-frontend): Dockerfile — enable corepack + copy ya…

### DIFF
--- a/apps-microservices/crawler-monitor-frontend/Dockerfile
+++ b/apps-microservices/crawler-monitor-frontend/Dockerfile
@@ -1,9 +1,21 @@
-FROM node:20-alpine as build
+FROM node:20-alpine AS build
 WORKDIR /app
-COPY package*.json ./
-RUN yarn install
+
+# node:20-alpine ships Yarn 1.22.22 but package.json pins
+# "packageManager": "yarn@4.11.0" — Corepack downloads and shims the right
+# version. Enabled before copying deps so yarn.lock (Berry v6 format) is read
+# by Yarn 4, not Yarn 1.
+RUN corepack enable
+
+# Copy dep manifests + Yarn Berry config so corepack + yarn resolve reproducibly.
+COPY package.json yarn.lock .yarnrc.yml ./
+
+# --immutable fails the build if yarn.lock would change — catches drift in CI.
+RUN yarn install --immutable
+
 COPY . .
 RUN yarn build
+
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
…rn.lock

yarn install dans node:20-alpine utilisait Yarn 1.22.22 préinstallé, qui refuse de tourner quand package.json pin packageManager=yarn@4.11.0 (ajouté lors du cleanup Task 1 du framework coherence).

- RUN corepack enable avant yarn install — corepack lit le champ packageManager et downloade/shim Yarn 4.11.0 à la volée
- COPY package.json yarn.lock .yarnrc.yml (au lieu de package*.json qui ratait yarn.lock) pour un install déterministe
- yarn install --immutable pour fail fast si yarn.lock drift