### PR TITLE
fix(mcp-gateway): harden security headers, rate limits, OAuth metadata

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/Dockerfile
+++ b/apps-microservices/mcp-gateway-frontend/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 FROM nginx:1.27-alpine
 RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx-limits.conf /etc/nginx/conf.d/00-limits.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 RUN chown -R appuser:appgroup /var/cache/nginx /var/log/nginx /usr/share/nginx/html \
     && touch /var/run/nginx.pid && chown appuser:appgroup /var/run/nginx.pid

--- a/apps-microservices/mcp-gateway-frontend/nginx-limits.conf
+++ b/apps-microservices/mcp-gateway-frontend/nginx-limits.conf
@@ -1,0 +1,8 @@
+# Rate-limit zones for the MCP Gateway auth surface.
+# Loaded at http{} scope (default.conf loads at server{} scope cannot declare zones).
+# File name "00-" prefix ensures load order before default.conf.
+
+limit_req_zone $binary_remote_addr zone=auth_token:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=auth_authorize:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=auth_register:10m rate=2r/s;
+limit_req_zone $binary_remote_addr zone=auth_login:10m rate=5r/s;

--- a/apps-microservices/mcp-gateway-frontend/nginx.conf
+++ b/apps-microservices/mcp-gateway-frontend/nginx.conf
@@ -2,6 +2,9 @@ server {
     listen 8581;
     server_name _;
 
+    # Hide nginx version in Server header and default error pages.
+    server_tokens off;
+
     # Allow uploads up to 10 MB (icons up to 2 MB, doc images up to 5 MB,
     # plus multipart envelope overhead). Without this, nginx's default 1 MB
     # cap rejects file uploads with HTTP 413 before they reach the Go backend.
@@ -13,7 +16,33 @@ server {
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $backend http://mcp-gateway-service:8592;
 
-    # Prevent search engine indexing
+    # Trust X-Forwarded-For from upstream (host VM nginx + docker bridges).
+    # Without this, $binary_remote_addr = upstream peer IP → rate limits would
+    # apply per-upstream, not per-client. Only the listed CIDRs are trusted to
+    # set the forwarded header; public IPs are ignored by ngx_http_realip_module.
+    set_real_ip_from 127.0.0.1;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 10.0.0.0/8;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    # Return 429 (not the nginx default 503) when a rate limit is tripped.
+    limit_req_status 429;
+
+    # --- Baseline security headers (applied to every response, static + proxied) ---
+    # HSTS: pin browsers to HTTPS for 1 year, include subdomains, submit for preload.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    # Clickjacking defense — SAMEORIGIN allows the admin SPA to frame /authorize on same origin.
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    # MIME sniffing defense.
+    add_header X-Content-Type-Options "nosniff" always;
+    # Limit referrer leakage on outbound navigations.
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Deny risky browser features.
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    # CSP — 'unsafe-inline' kept for style-src because PrimeVue 4 + Tailwind 4 inject runtime styles.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.hellopro.fr; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    # Prevent search engine indexing.
     add_header X-Robots-Tag "noindex, nofollow" always;
 
     root /usr/share/nginx/html;
@@ -40,6 +69,8 @@ server {
 
     location @login_api {
         internal;
+        # Throttle admin login brute-force (5 r/s per IP, burst 10).
+        limit_req zone=auth_login burst=10 nodelay;
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -56,9 +87,33 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # OAuth2 token + registration endpoints → Go backend
-    # Note: /authorize is an SPA route (Vue handles the UI)
-    location ~ ^/(token|register)$ {
+    # OAuth2 token endpoint — credential stuffing / code replay throttle (10 r/s, burst 20).
+    location = /token {
+        limit_req zone=auth_token burst=20 nodelay;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # OAuth2 dynamic client registration — limit automated probing (2 r/s, burst 5).
+    location = /register {
+        limit_req zone=auth_register burst=5 nodelay;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # OAuth2 authorization endpoint (login form + consent) — throttle form brute-force (5 r/s, burst 10).
+    # proxy_hide_header drops the Go backend's legacy CSP/X-Frame headers so the nginx-level
+    # security headers win without duplication.
+    location = /authorize {
+        limit_req zone=auth_authorize burst=10 nodelay;
+        proxy_hide_header Content-Security-Policy;
+        proxy_hide_header X-Frame-Options;
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
@@ -34,9 +34,6 @@ type authorizeParams struct {
 }
 
 func (s *AuthServer) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("X-Frame-Options", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
-
 	params, err := s.parseAuthorizeParams(r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"invalid_request","error_description":"%s"}`, err.Error()), http.StatusBadRequest)

--- a/apps-microservices/mcp-gateway-service/internal/authserver/metadata.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/metadata.go
@@ -40,7 +40,7 @@ func (s *AuthServer) HandleMetadata(w http.ResponseWriter, r *http.Request) {
 		AuthorizationEndpoint:             issuer + "/authorize",
 		TokenEndpoint:                     issuer + "/token",
 		RegistrationEndpoint:              issuer + "/register",
-		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
 		GrantTypesSupported:               []string{"authorization_code", "client_credentials"},
 		ResponseTypesSupported:            []string{"code"},
 		CodeChallengeMethodsSupported:     []string{"S256"},

--- a/apps-microservices/mcp-gateway-service/internal/authserver/metadata_test.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/metadata_test.go
@@ -32,6 +32,14 @@ func TestHandleMetadata(t *testing.T) {
 	if meta["registration_endpoint"] != "https://mcp.example.com/register" {
 		t.Fatalf("unexpected registration_endpoint: %v", meta["registration_endpoint"])
 	}
+
+	methods, ok := meta["token_endpoint_auth_methods_supported"].([]interface{})
+	if !ok {
+		t.Fatalf("token_endpoint_auth_methods_supported missing or wrong type: %T", meta["token_endpoint_auth_methods_supported"])
+	}
+	if len(methods) != 1 || methods[0] != "client_secret_basic" {
+		t.Fatalf("expected only [\"client_secret_basic\"] advertised, got %v", methods)
+	}
 }
 
 func TestHandleMetadata_MethodNotAllowed(t *testing.T) {

--- a/apps-microservices/mcp-gateway-service/internal/authserver/register.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/register.go
@@ -62,7 +62,7 @@ func (s *AuthServer) HandleRegister(w http.ResponseWriter, r *http.Request) {
 		req.GrantTypes = []string{"authorization_code"}
 	}
 	if req.TokenEndpointAuthMethod == "" {
-		req.TokenEndpointAuthMethod = "client_secret_post"
+		req.TokenEndpointAuthMethod = "client_secret_basic"
 	}
 
 	clientID, clientSecret, secretHash, secretPrefix, err := oauth2pkg.GenerateCredentials()


### PR DESCRIPTION
EN:
- nginx: add HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy on every response; server_tokens off
- nginx: per-IP rate limits on /token, /authorize, /register, /login (POST) with limit_req_status 429
- nginx: trust X-Forwarded-For from upstream (set_real_ip_from + realip) so rate limits key on real client IP, not docker bridge gateway
- nginx: proxy_hide_header on /authorize to drop duplicate CSP/X-Frame now that nginx owns them
- authserver: drop client_secret_post from advertised metadata methods (RFC 8414); register endpoint defaults new clients to client_secret_basic
- authserver: remove CSP and X-Frame-Options writes from /authorize handler (now owned by nginx layer)

Closes audit findings HIGH-2 (missing headers), HIGH-4 partial (rate limits added; WAF still pending), MED-4 (client_secret_post disclosure). HIGH-3 / MED-5 (host VM nginx 1.18.0) remain — separate ops handoff.

FR:
- nginx : ajout des en-têtes HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy sur toutes les réponses ; server_tokens off
- nginx : limites de débit par IP sur /token, /authorize, /register, /login (POST) avec limit_req_status 429
- nginx : prise en compte du X-Forwarded-For amont (set_real_ip_from + realip) pour clé de rate limit sur l'IP cliente réelle
- nginx : proxy_hide_header sur /authorize pour éviter la duplication des en-têtes CSP/X-Frame désormais portés par nginx
- authserver : suppression de client_secret_post des méthodes annoncées par /.well-known/oauth-authorization-server (RFC 8414) ; le endpoint /register utilise désormais client_secret_basic par défaut
- authserver : retrait des en-têtes CSP et X-Frame-Options du handler /authorize (gérés par nginx)

Corrige les findings d'audit HIGH-2, HIGH-4 (partiel — WAF restant), MED-4. HIGH-3 / MED-5 (nginx 1.18.0 hôte VM) traités hors scope.