### PR TITLE
fix(albums): proxy envoie Connection: close (anti-pool stale quand re…

### DIFF
--- a/apps-microservices/crawler-monitor-backend/src/lib/imageDownloadProxy.js
+++ b/apps-microservices/crawler-monitor-backend/src/lib/imageDownloadProxy.js
@@ -9,6 +9,16 @@
  * - AbortError (timeout) → 504.
  *
  * Le helper n'inclut pas l'audit logging — celui-ci est géré dans `albums.js`.
+ *
+ * Pas de keep-alive sur les connexions sortantes :
+ * image-download-service tourne en multiples replicas (jusqu'à 20+ en prod).
+ * Le keep-alive undici (activé par défaut sur fetch global Node 18+) cache des
+ * sockets TCP vers chaque IP de replica. Quand un replica recycle/scale-down,
+ * sa socket reste dans le pool → la prochaine requête tombe en ECONNREFUSED
+ * même si d'autres replicas sont healthy. On envoie `Connection: close` à
+ * chaque fetch pour forcer une nouvelle connexion par appel et bénéficier du
+ * DNS round-robin Docker. Coût : ~1ms TCP setup par requête, négligeable face
+ * au reste de la latence (FS NFS, etc.).
  */
 
 const DEFAULT_BASE = process.env.IMAGE_DOWNLOAD_SERVICE_URL || 'http://image-download-service:8505';
@@ -30,7 +40,9 @@ export async function proxyToImageDownload(req, res, opts) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
 
-  const headers = {};
+  // Connection: close — voir le bandeau du fichier (évite le pool keepalive
+  // stale quand les replicas image-download-service scale up/down).
+  const headers = { connection: 'close' };
   let body;
   if (['POST', 'PUT', 'PATCH'].includes(method) && req.body !== undefined && req.body !== null) {
     headers['content-type'] = 'application/json';


### PR DESCRIPTION
…plicas scale)

Cause prod observee : image-download-service tourne en 20 replicas, et le keep-alive undici (activation par defaut sur fetch global Node 18+) cachait des sockets TCP vers chaque IP de replica. Quand un replica recycle ou scale-down, sa socket restait dans le pool -> ECONNREFUSED 172.20.0.116:8505 au prochain fetch meme si d'autres replicas etaient healthy.

Fix : on envoie l'en-tete `Connection: close` sur chaque fetch outbound, ce qui force la fermeture de la socket cote client apres la reponse et evite le pool stale. Cout : ~1ms TCP setup supplementaire par requete, negligeable face au reste de la latence (FS NFS du service Python, etc.).

Tests : 7+9 = 16 tests verts, sans modification (les fakes ignorent les en-tetes additionnels que le helper ajoute).