### PR TITLE
chore(mcp-gateway): wire BDD_PUBLIC_API_TOKEN env to gateway container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2277,6 +2277,7 @@ services:
       # Empty = picker disabled (503); gateway-owned registry CRUD still works.
       - BDD_CATALOG_BASE_URL=${BDD_CATALOG_BASE_URL}
       - BDD_CATALOG_TOKEN=${BDD_CATALOG_TOKEN}
+      - BDD_PUBLIC_API_TOKEN=${BDD_PUBLIC_API_TOKEN}
       - ALLOWED_EMAILS=${MCP_ALLOWED_EMAILS}
       # Google Sheets import (OAuth2)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
EN: pass BDD_PUBLIC_API_TOKEN through to mcp-gateway-service so the public BDD endpoints (/api/v1/public/bdd/config and /api/v1/public/bdd/schema-doc) become reachable. Without it the shared-secret check returns 503 and the external PHP MCP runner falls back to an empty whitelist + no doc. Empty value keeps the endpoints disabled — same on/off behaviour as the existing BDD_CATALOG_* pair.

FR: propagation de BDD_PUBLIC_API_TOKEN sur le container mcp-gateway-service pour activer les endpoints publics BDD (/api/v1/public/bdd/config et /api/v1/public/bdd/schema-doc). Sans cette variable la verification du secret partage repond 503 et le runner MCP PHP externe retombe sur une whitelist vide + pas de doc. Valeur vide = endpoints desactives, meme logique on/off que la paire BDD_CATALOG_* existante.