### PR TITLE
feat(mcp-gateway): manual rows override + refresh button on bdd table…

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/api/bdd.ts
+++ b/apps-microservices/mcp-gateway-frontend/src/api/bdd.ts
@@ -94,6 +94,7 @@ export const bddApi = {
       default_order_by?: string
       relations?: BDDRelations
       notes?: string
+      rows?: number
     },
   ) => api.patch<BDDUsedTable>(`${BASE}/bdd/used/tables/${id}`, body),
   refreshCatalog: (id: string) =>

--- a/apps-microservices/mcp-gateway-frontend/src/views/BDDTableDetailView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/BDDTableDetailView.vue
@@ -88,11 +88,26 @@
       <!-- Stat strip -->
       <section class="grid grid-cols-2 gap-px bg-gray-100 dark:bg-gray-800 sm:grid-cols-4">
         <div class="bg-white dark:bg-transparent px-4 py-3">
-          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-            Lignes
-          </p>
+          <div class="flex items-center justify-between gap-2">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Lignes
+            </p>
+            <button
+              v-if="authStore.isAdmin"
+              type="button"
+              :disabled="refreshingRows"
+              class="p-1 rounded text-gray-500 hover:text-brand-600 hover:bg-brand-50 dark:hover:bg-brand-500/10 disabled:opacity-50"
+              :title="refreshError || 'Rafraichir le compte depuis le catalogue'"
+              @click="refreshRows"
+            >
+              <i :class="refreshingRows ? 'pi pi-spinner pi-spin' : 'pi pi-refresh'" class="text-xs" />
+            </button>
+          </div>
           <p class="mt-1 text-sm font-mono text-gray-900 dark:text-white">
             {{ table.rows !== null && table.rows !== undefined ? formatRows(table.rows) : '—' }}
+          </p>
+          <p v-if="refreshError" class="mt-1 text-xs text-error-500 truncate" :title="refreshError">
+            {{ refreshError }}
           </p>
         </div>
         <div class="bg-white dark:bg-transparent px-4 py-3">
@@ -254,8 +269,25 @@ const authStore = useAuthStore();
 const id = computed(() => String(route.params.id || ''));
 const table = ref<BDDUsedTable | null>(null);
 const loading = ref(false);
+const refreshingRows = ref(false);
+const refreshError = ref<string | null>(null);
 
 const hasFields = computed(() => (table.value?.fields.length ?? 0) > 0);
+
+async function refreshRows() {
+  if (!table.value) return;
+  refreshingRows.value = true;
+  refreshError.value = null;
+  try {
+    const updated = await bddApi.refreshCatalog(table.value.id);
+    table.value = updated;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Erreur inconnue';
+    refreshError.value = msg;
+  } finally {
+    refreshingRows.value = false;
+  }
+}
 
 const RELATION_RE = /^\s*(\w+)\.(\w+)\s*->\s*(\w+)\.(\w+)\s*$/;
 

--- a/apps-microservices/mcp-gateway-frontend/src/views/BDDTableFieldsView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/BDDTableFieldsView.vue
@@ -189,31 +189,61 @@
                 Nombre de lignes
                 <span class="text-[10px] text-gray-400 ml-1">(catalogue)</span>
               </span>
-              <button
-                v-if="isAdmin"
-                type="button"
-                :disabled="refreshingCatalog || !table?.upstream_table_id"
-                class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-brand-600 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed dark:text-brand-400"
-                title="Re-synchroniser depuis le catalogue"
-                @click="refreshFromCatalog"
-              >
-                <i
-                  :class="refreshingCatalog ? 'pi pi-spinner pi-spin' : 'pi pi-refresh'"
-                  class="text-[10px]"
-                />
-                Actualiser
-              </button>
+              <span v-if="isAdmin" class="inline-flex items-center gap-2">
+                <button
+                  type="button"
+                  :disabled="savingRows || !rowsDirty || rowsDraft === ''"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-success-700 hover:text-success-800 disabled:opacity-50 disabled:cursor-not-allowed dark:text-success-400"
+                  title="Sauvegarder le compte saisi en base"
+                  @click="saveRowsManual"
+                >
+                  <i
+                    :class="savingRows ? 'pi pi-spinner pi-spin' : 'pi pi-save'"
+                    class="text-[10px]"
+                  />
+                  Enregistrer
+                </button>
+                <button
+                  type="button"
+                  :disabled="refreshingCatalog || !table?.upstream_table_id"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-brand-600 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed dark:text-brand-400"
+                  title="Re-synchroniser depuis le catalogue"
+                  @click="refreshFromCatalog"
+                >
+                  <i
+                    :class="refreshingCatalog ? 'pi pi-spinner pi-spin' : 'pi pi-refresh'"
+                    class="text-[10px]"
+                  />
+                  Actualiser
+                </button>
+              </span>
             </label>
+            <input
+              v-if="isAdmin"
+              v-model.number="rowsDraft"
+              type="number"
+              min="0"
+              step="1"
+              placeholder="Saisir le nombre de lignes"
+              class="h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-mono dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+            />
             <div
+              v-else
               class="h-9 w-full flex items-center rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 text-sm text-gray-700 dark:text-gray-300"
             >
               <span v-if="table?.rows != null">
                 {{ table.rows.toLocaleString('fr-FR') }}
               </span>
               <span v-else class="text-xs text-gray-400 italic">
-                Non synchronise — cliquer Actualiser
+                Non synchronise
               </span>
             </div>
+            <p
+              v-if="isAdmin && rowsError"
+              class="mt-1 text-[11px] text-error-500"
+            >
+              {{ rowsError }}
+            </p>
           </div>
         </div>
         <div class="mt-3">
@@ -618,6 +648,18 @@ const metaDraft = ref<MetaDraft>(emptyMetaDraft());
 const metaSnapshot = ref<MetaDraft>(emptyMetaDraft());
 const savingMeta = ref(false);
 const refreshingCatalog = ref(false);
+
+// Manual rows override — admin can enter a row count and persist it
+// without firing the upstream /count (which times out on huge tables).
+const rowsDraft = ref<number | string>('');
+const savingRows = ref(false);
+const rowsError = ref<string | null>(null);
+const rowsDirty = computed(() => {
+  if (rowsDraft.value === '' || rowsDraft.value === null) return false;
+  const n = Number(rowsDraft.value);
+  if (!Number.isFinite(n) || n < 0) return false;
+  return n !== (table.value?.rows ?? null);
+});
 const allRegisteredTables = ref<BDDUsedTable[]>([]);
 
 const catalogByName = ref<Record<string, BDDCatalogField>>({});
@@ -792,6 +834,8 @@ async function loadTable() {
     relationsParseError.value = null;
     dirtyFields.value = new Set();
     pendingDescriptions.value = {};
+    rowsDraft.value = res.rows ?? '';
+    rowsError.value = null;
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
       table.value = null;
@@ -889,6 +933,8 @@ async function refreshFromCatalog() {
       table.value.primary_key = updated.primary_key;
       table.value.rows = updated.rows;
     }
+    rowsDraft.value = updated.rows ?? '';
+    rowsError.value = null;
     toast.success('Synchronisation catalogue OK');
   } catch (err) {
     const body = (err as { body?: { error?: string } })?.body;
@@ -897,6 +943,36 @@ async function refreshFromCatalog() {
     toast.error('Echec de la synchronisation: ' + msg);
   } finally {
     refreshingCatalog.value = false;
+  }
+}
+
+// Manual rows override: persists the integer typed in the input via
+// PATCH (no upstream call). Useful when refresh-catalog times out on
+// huge tables but the admin already knows the count.
+async function saveRowsManual() {
+  if (!table.value || savingRows.value) return;
+  const n = Number(rowsDraft.value);
+  if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+    rowsError.value = 'Saisir un entier positif (>= 0).';
+    return;
+  }
+  savingRows.value = true;
+  rowsError.value = null;
+  try {
+    const updated = await bddApi.patchUsed(id.value, { rows: n });
+    if (table.value) {
+      table.value.rows = updated.rows;
+    }
+    rowsDraft.value = updated.rows ?? '';
+    toast.success('Nombre de lignes enregistre');
+  } catch (err) {
+    const body = (err as { body?: { error?: string } })?.body;
+    const msg =
+      body?.error || (err instanceof Error ? err.message : 'Erreur inconnue');
+    rowsError.value = msg;
+    toast.error('Echec de la sauvegarde: ' + msg);
+  } finally {
+    savingRows.value = false;
   }
 }
 

--- a/apps-microservices/mcp-gateway-service/internal/api/bdd_dto.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/bdd_dto.go
@@ -78,14 +78,19 @@ type CreateBDDUsedFieldInline struct {
 // UpdateBDDUsedTableRequest is the payload for PATCH /api/v1/bdd/used/tables/{id}.
 // All fields are optional pointers — nil means "leave the column alone".
 //
-// Rows and PrimaryKey are intentionally NOT exposed here: both are
-// upstream-derived and refreshed via the dedicated
-// POST /bdd/used/tables/{id}/refresh-catalog endpoint.
+// PrimaryKey is intentionally NOT exposed here — it is upstream-derived
+// and only refreshed via POST /bdd/used/tables/{id}/refresh-catalog.
+//
+// Rows is exposed as an admin override: the refresh-catalog endpoint
+// sets it from the upstream /count, but on multi-million-row tables
+// where the live COUNT(*) times out admins need a manual escape
+// hatch. Pass a non-negative integer to set, omit to leave alone.
 type UpdateBDDUsedTableRequest struct {
 	Description    *string         `json:"description,omitempty"`
 	DefaultOrderBy *string         `json:"default_order_by,omitempty"`
 	Relations      json.RawMessage `json:"relations,omitempty"`
 	Notes          *string         `json:"notes,omitempty"`
+	Rows           *int64          `json:"rows,omitempty"`
 }
 
 // UpdateBDDUsedFieldRequest is the payload for PATCH /api/v1/bdd/used/tables/{id}/fields/{field_id}.

--- a/apps-microservices/mcp-gateway-service/internal/api/bdd_handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/bdd_handlers.go
@@ -378,6 +378,13 @@ func (h *Handler) updateBDDUsedTable(w http.ResponseWriter, r *http.Request, id 
 	if req.Notes != nil {
 		updates["notes"] = *req.Notes
 	}
+	if req.Rows != nil {
+		if *req.Rows < 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "rows must be >= 0"})
+			return
+		}
+		updates["rows"] = *req.Rows
+	}
 
 	if err := h.bddUsedRepo.UpdateTableMetadata(r.Context(), id, updates); err != nil {
 		if errors.Is(err, repository.ErrBDDNotFound) {


### PR DESCRIPTION
… detail

EN: add an admin escape hatch for the bdd table row count. The PATCH /api/v1/bdd/used/tables/{id} endpoint now accepts an optional `rows` field (non-negative int64) so admins can persist a manually-known count without firing the upstream /count — the Refresh path times out via MAX_EXECUTION_TIME on multi-million-row tables (e.g. seo_analyse_mot_cle_recherche), which used to leave the registry stuck with rows=null. The fields-edit page turns the previously read-only "Nombre de lignes" cell into an editable number input with two buttons: "Enregistrer" persists the typed value through PATCH, "Actualiser" keeps the existing /refresh-catalog upstream path. The detail page also gets a small refresh icon next to the Lignes stat so admins can re-snapshot from read-only mode without entering the editor. Validation is server-side (rejects negative values with 400) and surfaced inline.

FR: ajout d'une porte de sortie admin pour le compteur de lignes des tables BDD. PATCH /api/v1/bdd/used/tables/{id} accepte maintenant un champ optionnel `rows` (int64 >= 0) pour persister un nombre connu manuellement sans declencher le /count upstream — le Refresh time out via MAX_EXECUTION_TIME sur les tables a plusieurs millions de lignes (par ex. seo_analyse_mot_cle_recherche), qui restaient avec rows=null dans le registre. La page d'edition transforme la cellule "Nombre de lignes" en input numerique editable avec deux boutons : "Enregistrer" persiste la valeur via PATCH, "Actualiser" garde le chemin /refresh-catalog upstream existant. La page de detail recoit aussi une petite icone de rafraichissement a cote de la statistique Lignes pour permettre aux admins de re-snapshoter depuis le mode lecture seule sans entrer dans l'editeur. La validation est cote serveur (refus des valeurs negatives avec 400) et remontee inline.