### PR TITLE
fix(mcp-gateway): log real client IP on 401 unauthorized

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/oauth2/middleware.go
+++ b/apps-microservices/mcp-gateway-service/internal/oauth2/middleware.go
@@ -211,9 +211,10 @@ func CombinedMiddleware(
 			}
 
 			// 3. Neither present — return 401 with discovery URL per MCP spec
-			log.Printf("[oauth2] 401 unauthorized: method=%s path=%s remote=%s xff=%q xri=%q cf_ip=%q user_agent=%q mcp_session=%q origin=%q referer=%q",
+			log.Printf("[oauth2] 401 unauthorized: method=%s path=%s remote=%s peer=%s xff=%q xri=%q cf_ip=%q user_agent=%q mcp_session=%q origin=%q referer=%q",
 				r.Method,
 				r.URL.Path,
+				slack.ClientIP(r),
 				r.RemoteAddr,
 				r.Header.Get("X-Forwarded-For"),
 				r.Header.Get("X-Real-IP"),


### PR DESCRIPTION
Use slack.ClientIP (XFF-aware) for remote= field, keep r.RemoteAddr as peer= so Docker hop stays visible. Prior log showed only the container hop IP, masking the real caller behind nginx/Cloudflare.

Utiliser slack.ClientIP (XFF) pour remote=, conserver r.RemoteAddr en peer=. Avant, le log ne montrait que l'IP du conteneur derrière nginx/Cloudflare.