### PR TITLE
fix(mcp-gateway-frontend): allow Tailwind CDN and inline scripts on /…

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/nginx.conf
+++ b/apps-microservices/mcp-gateway-frontend/nginx.conf
@@ -114,6 +114,21 @@ server {
         limit_req zone=auth_authorize burst=10 nodelay;
         proxy_hide_header Content-Security-Policy;
         proxy_hide_header X-Frame-Options;
+
+        # nginx replaces (does not merge) parent add_header when a location block
+        # declares its own — restate the baseline security headers here.
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        # Loosened CSP for the OAuth2 login/consent templates: allow the Tailwind
+        # CDN runtime (needs 'unsafe-eval') and the small inline <script> blocks
+        # in login.html / consent.html ('unsafe-inline'). Long-term: self-host
+        # Tailwind + extract inline scripts so this can drop back to strict CSP.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
…authorize

Override nginx CSP for the OAuth2 /authorize location so the Tailwind CDN runtime and the inline <script> blocks in login.html / consent.html are not blocked. Restate the other baseline security headers because nginx replaces parent add_header when a location declares its own. Strict CSP stays in effect for every other route.

Surcharger CSP nginx pour /authorize afin d'autoriser le runtime Tailwind CDN et les <script> inline de login.html / consent.html. Réénoncer les autres en-têtes de sécurité, car nginx remplace add_header parent dès qu'un location en déclare un. CSP strict conservé sur tout le reste.