### PR TITLE
fix(crawler-monitor-backend): bump Dockerfile builder to golang:1.25-…

### DIFF
--- a/apps-microservices/crawler-monitor-backend/Dockerfile
+++ b/apps-microservices/crawler-monitor-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates
 COPY go.mod go.sum ./


### PR DESCRIPTION
…alpine

go.mod requires go >= 1.25.0 (upgraded by x/crypto + httprate deps).