### PR TITLE
fix(compose): crawler-monitor-frontend profile disabled -> app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1352,7 +1352,7 @@ services:
       context: ./apps-microservices/crawler-monitor-frontend
       dockerfile: Dockerfile
     container_name: crawler-monitor-frontend
-    profiles: ["disabled"]
+    profiles: ["app"]
     restart: unless-stopped
     ports:
       - "3002:8099" # Exposé sur le port 3002


### PR DESCRIPTION
Le frontend dépend du backend (depends_on) qui est sur profil app. Les deux doivent être dans le même profil pour démarrer ensemble.