### PR TITLE
fix(crawler-monitor-backend): WS sur /api + routes capacity/history +…

### DIFF
--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/capacity.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/capacity.go
@@ -20,3 +20,17 @@ func capacityGetHandler(rs *redisstore.Client) http.HandlerFunc {
 		})
 	}
 }
+
+// capacityHistoryHandler retourne un tableau vide (historique capacity pas encore implémenté).
+func capacityHistoryHandler(rs *redisstore.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		WriteJSON(w, http.StatusOK, []any{})
+	}
+}
+
+// capacityPlanningRAMHandler retourne un objet vide (planning RAM pas encore implémenté).
+func capacityPlanningRAMHandler(rs *redisstore.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		WriteJSON(w, http.StatusOK, map[string]any{"data": []any{}, "window": r.URL.Query().Get("window")})
+	}
+}

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/router.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/router.go
@@ -51,6 +51,7 @@ func NewRouter(d Deps) http.Handler {
 
 	if d.Hub != nil && d.Config != nil {
 		r.Get("/", ws.UpgradeHandler(d.Hub, d.Config.JWTSecret))
+		r.Get("/api", ws.UpgradeHandler(d.Hub, d.Config.JWTSecret))
 	}
 
 	if d.Config != nil {
@@ -92,6 +93,10 @@ func NewRouter(d Deps) http.Handler {
 			})
 
 			rt.Get("/api/capacity", capacityGetHandler(d.RedisStore))
+			rt.Get("/api/capacity/history", capacityHistoryHandler(d.RedisStore))
+			rt.Route("/api/capacity-planning", func(rt chi.Router) {
+				rt.Get("/ram", capacityPlanningRAMHandler(d.RedisStore))
+			})
 
 			rt.Get("/api/replicas/history", replicasHistoryHandler(d.RedisStore))
 			rt.Get("/api/replicas/{id}/history", replicaHistoryByIDHandler(d.RedisStore))


### PR DESCRIPTION
… capacity-planning/ram

- WebSocket handler enregistré sur /api (Nginx proxifie /api -> backend)
- GET /api/capacity/history stub (retourne [])
- GET /api/capacity-planning/ram stub (retourne {data:[], window})