### PR TITLE
fix(crawler-monitor-backend): porter parite Express manquante (REST s…

### DIFF
--- a/apps-microservices/crawler-monitor-backend/cmd/server/main.go
+++ b/apps-microservices/crawler-monitor-backend/cmd/server/main.go
@@ -51,6 +51,24 @@ func main() {
 	ps := ws.NewPubSub(rs.Raw(), hub, redisstore.UpdatesChannel, redisstore.HeartbeatChannel)
 	go ps.Run(ctx)
 
+	// Capacity snapshot ticker (60s) — feeds capacity:history:zset.
+	go func() {
+		// Initial snapshot so the chart isn't empty on first load.
+		_ = rs.SnapshotCapacity(ctx)
+		t := time.NewTicker(60 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := rs.SnapshotCapacity(ctx); err != nil {
+					slog.Warn("capacity.snapshot", "err", err)
+				}
+			}
+		}
+	}()
+
 	r := httpapi.NewRouter(httpapi.Deps{
 		Version:    version,
 		Config:     cfg,

--- a/apps-microservices/crawler-monitor-backend/internal/domain/capacityplanning/capacityplanning.go
+++ b/apps-microservices/crawler-monitor-backend/internal/domain/capacityplanning/capacityplanning.go
@@ -1,0 +1,134 @@
+// Package capacityplanning aggregates per-replica heartbeats to answer
+// "can we reduce RAM per replica and run more of them?".
+//
+// Mirrors src/lib/capacityPlanning.js exactly (same field names + sort order).
+package capacityplanning
+
+import (
+	"errors"
+	"sort"
+)
+
+// WindowMap maps frontend window keys to milliseconds.
+var WindowMap = map[string]int64{
+	"1h":  60 * 60 * 1000,
+	"24h": 24 * 60 * 60 * 1000,
+	"7d":  7 * 24 * 60 * 60 * 1000,
+}
+
+func ParseWindow(key string) (int64, error) {
+	ms, ok := WindowMap[key]
+	if !ok {
+		return 0, errors.New("Invalid window. Use '1h', '24h' or '7d'.")
+	}
+	return ms, nil
+}
+
+// Sample is one heartbeat measurement (cpu/ram) for a replica at ts ms.
+type Sample struct {
+	Ts       int64
+	CPU      float64
+	RAM      float64
+	TotalRAM float64
+	JobID    string
+}
+
+// ReplicaStats is the per-replica aggregated view returned to the UI.
+type ReplicaStats struct {
+	ReplicaID   string  `json:"replicaId"`
+	Allocated   float64 `json:"allocated"`
+	Peak        float64 `json:"peak"`
+	PeakTs      int64   `json:"peak_ts"`
+	PeakJobID   *string `json:"peak_job_id"`
+	Avg         float64 `json:"avg"`
+	SampleCount int     `json:"sample_count"`
+	LastSeen    int64   `json:"last_seen"`
+	Efficiency  float64 `json:"efficiency"`
+}
+
+// Totals is the cross-replica summary.
+type Totals struct {
+	ReplicaCount    int     `json:"replica_count"`
+	TotalAllocated  float64 `json:"total_allocated"`
+	TotalPeakWorst  float64 `json:"total_peak_worst"`
+	TotalAvg        float64 `json:"total_avg"`
+	Waste           float64 `json:"waste"`
+	WastePct        float64 `json:"waste_pct"`
+	Efficiency      float64 `json:"efficiency"`
+}
+
+// AggregateByReplica folds per-replica points into ReplicaStats sorted by peak desc.
+func AggregateByReplica(pointsByReplica map[string][]Sample) []ReplicaStats {
+	out := make([]ReplicaStats, 0, len(pointsByReplica))
+	for id, points := range pointsByReplica {
+		if len(points) == 0 {
+			continue
+		}
+		var allocated, peak, sum float64
+		var peakTs, lastTs int64
+		var peakJobID *string
+		for _, p := range points {
+			if p.TotalRAM > allocated {
+				allocated = p.TotalRAM
+			}
+			if p.RAM > peak {
+				peak = p.RAM
+				peakTs = p.Ts
+				if p.JobID != "" {
+					j := p.JobID
+					peakJobID = &j
+				} else {
+					peakJobID = nil
+				}
+			}
+			sum += p.RAM
+			if p.Ts > lastTs {
+				lastTs = p.Ts
+			}
+		}
+		avg := sum / float64(len(points))
+		eff := 0.0
+		if allocated > 0 {
+			eff = peak / allocated
+		}
+		out = append(out, ReplicaStats{
+			ReplicaID:   id,
+			Allocated:   allocated,
+			Peak:        peak,
+			PeakTs:      peakTs,
+			PeakJobID:   peakJobID,
+			Avg:         avg,
+			SampleCount: len(points),
+			LastSeen:    lastTs,
+			Efficiency:  eff,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Peak > out[j].Peak })
+	return out
+}
+
+// ComputeTotals folds the per-replica stats into a single summary.
+func ComputeTotals(replicas []ReplicaStats) Totals {
+	var totAlloc, totPeak, totAvg float64
+	for _, r := range replicas {
+		totAlloc += r.Allocated
+		totPeak += r.Peak
+		totAvg += r.Avg
+	}
+	waste := totAlloc - totPeak
+	wastePct := 0.0
+	eff := 0.0
+	if totAlloc > 0 {
+		wastePct = waste / totAlloc
+		eff = totPeak / totAlloc
+	}
+	return Totals{
+		ReplicaCount:   len(replicas),
+		TotalAllocated: totAlloc,
+		TotalPeakWorst: totPeak,
+		TotalAvg:       totAvg,
+		Waste:          waste,
+		WastePct:       wastePct,
+		Efficiency:     eff,
+	}
+}

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/alerts.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/alerts.go
@@ -57,8 +57,18 @@ func alertsHandler(rs *redisstore.Client) http.HandlerFunc {
 			FailedCallbackCount: failedCount,
 		}
 
-		result := alerts.Evaluate(inputs, time.Now().UnixMilli(), alerts.DefaultThresholds())
-		WriteJSON(w, 200, result)
+		nowMs := time.Now().UnixMilli()
+		thresholds := alerts.DefaultThresholds()
+		result := alerts.Evaluate(inputs, nowMs, thresholds)
+		if result == nil {
+			result = []alerts.Alert{}
+		}
+		WriteJSON(w, 200, map[string]any{
+			"generated_at": time.UnixMilli(nowMs).UTC().Format(time.RFC3339Nano),
+			"thresholds":   thresholds,
+			"count":        len(result),
+			"alerts":       result,
+		})
 	}
 }
 

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/capacity.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/capacity.go
@@ -2,9 +2,32 @@ package httpapi
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/capacityplanning"
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/systemstats"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/store/redisstore"
 )
+
+// capacityWindowMap maps frontend window strings to milliseconds.
+// Mirrors JS parseCapacityWindow.
+var capacityWindowMap = map[string]int64{
+	"15m": 15 * 60 * 1000,
+	"1h":  60 * 60 * 1000,
+	"6h":  6 * 60 * 60 * 1000,
+	"24h": 24 * 60 * 60 * 1000,
+}
+
+func parseCapacityWindow(s string) (int64, string) {
+	if s == "" {
+		s = "1h"
+	}
+	ms, ok := capacityWindowMap[s]
+	if !ok {
+		return 60 * 60 * 1000, "1h"
+	}
+	return ms, s
+}
 
 func capacityGetHandler(rs *redisstore.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -14,23 +37,67 @@ func capacityGetHandler(rs *redisstore.Client) http.HandlerFunc {
 			return
 		}
 		WriteJSON(w, 200, map[string]any{
-			"running": running,
-			"max":     max,
-			"full":    max > 0 && running >= max,
+			"running_jobs":    running,
+			"max_global_jobs": max,
+			"is_full":         max > 0 && running >= max,
 		})
 	}
 }
 
-// capacityHistoryHandler retourne un tableau vide (historique capacity pas encore implémenté).
+// capacityHistoryHandler returns capacity snapshots over the requested window.
+// Response: { window, count, points: [{ts, running, max, full}, …] }
 func capacityHistoryHandler(rs *redisstore.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		WriteJSON(w, http.StatusOK, []any{})
+		windowMs, windowStr := parseCapacityWindow(r.URL.Query().Get("window"))
+		points, err := rs.ReadCapacityHistory(r.Context(), windowMs)
+		if err != nil {
+			WriteError(w, 500, "Failed to read capacity history")
+			return
+		}
+		if points == nil {
+			points = []systemstats.CapacityPoint{}
+		}
+		WriteJSON(w, http.StatusOK, map[string]any{
+			"window": windowStr,
+			"count":  len(points),
+			"points": points,
+		})
 	}
 }
 
-// capacityPlanningRAMHandler retourne un objet vide (planning RAM pas encore implémenté).
+// capacityPlanningRAMHandler aggregates per-replica RAM usage over the requested
+// window. Window=1h reads replica:history; window=24h|7d scans job:perf:*.
+// Response: { window, window_ms, generated_at, replicas:[…], totals:{…} }
 func capacityPlanningRAMHandler(rs *redisstore.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		WriteJSON(w, http.StatusOK, map[string]any{"data": []any{}, "window": r.URL.Query().Get("window")})
+		windowKey := r.URL.Query().Get("window")
+		if windowKey == "" {
+			windowKey = "1h"
+		}
+		windowMs, err := capacityplanning.ParseWindow(windowKey)
+		if err != nil {
+			WriteError(w, 400, err.Error())
+			return
+		}
+		ctx := r.Context()
+		var pointsByReplica map[string][]capacityplanning.Sample
+		if windowKey == "1h" {
+			pointsByReplica, err = rs.ReplicaHistoryAsSamples(ctx, windowMs)
+		} else {
+			pointsByReplica, err = rs.ScanJobPerfByReplica(ctx, windowMs)
+		}
+		if err != nil {
+			WriteError(w, 500, "Failed to load capacity planning data")
+			return
+		}
+		replicas := capacityplanning.AggregateByReplica(pointsByReplica)
+		totals := capacityplanning.ComputeTotals(replicas)
+		WriteJSON(w, http.StatusOK, map[string]any{
+			"window":       windowKey,
+			"window_ms":    windowMs,
+			"generated_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"replicas":     replicas,
+			"totals":       totals,
+		})
 	}
 }

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/domains.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/domains.go
@@ -63,7 +63,14 @@ func domainsListHandler(rs *redisstore.Client) http.HandlerFunc {
 		jobs := rawJobsToDomain(rawJobs)
 		now := time.Now().UnixMilli()
 		result := domains.AggregateDomains(jobs, now, windowMs)
-		WriteJSON(w, 200, result)
+		if result == nil {
+			result = []domains.DomainSummary{}
+		}
+		WriteJSON(w, 200, map[string]any{
+			"window":  windowStr,
+			"count":   len(result),
+			"domains": result,
+		})
 	}
 }
 

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/replicas.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/replicas.go
@@ -26,7 +26,13 @@ func replicasHistoryHandler(rs *redisstore.Client) http.HandlerFunc {
 			WriteError(w, 500, "Failed to read replicas history")
 			return
 		}
-		WriteJSON(w, 200, all)
+		if all == nil {
+			all = map[string][]replicahistory.HeartbeatSample{}
+		}
+		WriteJSON(w, 200, map[string]any{
+			"window":   windowStr,
+			"replicas": all,
+		})
 	}
 }
 

--- a/apps-microservices/crawler-monitor-backend/internal/store/redisstore/capacity_snapshot.go
+++ b/apps-microservices/crawler-monitor-backend/internal/store/redisstore/capacity_snapshot.go
@@ -1,0 +1,39 @@
+package redisstore
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/systemstats"
+	"github.com/redis/go-redis/v9"
+)
+
+// CapacityRetentionMs is 24 hours.
+const CapacityRetentionMs = int64(24 * 60 * 60 * 1000)
+
+// SnapshotCapacity reads running/max from Redis, ZADDs a CapacityPoint to
+// capacity:history:zset, and prunes entries older than 24h.
+// Mirrors JS snapshotCapacity().
+func (c *Client) SnapshotCapacity(ctx context.Context) error {
+	running, max, err := c.GetCapacity(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UnixMilli()
+	point := systemstats.CapacityPoint{
+		Ts:      now,
+		Running: running,
+		Max:     max,
+		Full:    max > 0 && running >= max,
+	}
+	raw, err := json.Marshal(point)
+	if err != nil {
+		return err
+	}
+	if err := c.rdb.ZAdd(ctx, CapacityHistoryKey, redis.Z{Score: float64(now), Member: string(raw)}).Err(); err != nil {
+		return err
+	}
+	_ = c.rdb.ZRemRangeByScore(ctx, CapacityHistoryKey, "0", formatScore(now-CapacityRetentionMs)).Err()
+	return nil
+}

--- a/apps-microservices/crawler-monitor-backend/internal/store/redisstore/job_perf.go
+++ b/apps-microservices/crawler-monitor-backend/internal/store/redisstore/job_perf.go
@@ -1,0 +1,118 @@
+package redisstore
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/capacityplanning"
+	"github.com/redis/go-redis/v9"
+)
+
+// RetentionJobPerfMs is 7 days.
+const RetentionJobPerfMs = int64(7 * 24 * 60 * 60 * 1000)
+
+// PersistJobPerfSample appends a perf sample to job:perf:<jobId> ZSet.
+// Score = ts ms. Auto-prunes entries older than 7 days. Tolerant: errors swallowed.
+func (c *Client) PersistJobPerfSample(ctx context.Context, jobID string, ts int64, sample any) {
+	if jobID == "" {
+		return
+	}
+	if ts == 0 {
+		ts = time.Now().UnixMilli()
+	}
+	raw, err := json.Marshal(sample)
+	if err != nil {
+		return
+	}
+	key := JobPerfPrefix + jobID
+	_ = c.rdb.ZAdd(ctx, key, redis.Z{Score: float64(ts), Member: string(raw)}).Err()
+	_ = c.rdb.ZRemRangeByScore(ctx, key, "0", formatScore(ts-RetentionJobPerfMs)).Err()
+	_ = c.rdb.Expire(ctx, key, time.Duration(RetentionJobPerfMs)*time.Millisecond).Err()
+}
+
+// ScanJobPerfByReplica scans every job:perf:* key and groups all samples in
+// [now-windowMs, now] per replicaId. Mirrors JS defaultScanJobPerf.
+func (c *Client) ScanJobPerfByReplica(ctx context.Context, windowMs int64) (map[string][]capacityplanning.Sample, error) {
+	now := time.Now().UnixMilli()
+	cutoff := formatScore(now - windowMs)
+	out := make(map[string][]capacityplanning.Sample)
+
+	var cursor uint64
+	for {
+		batch, next, err := c.rdb.Scan(ctx, cursor, JobPerfPrefix+"*", 200).Result()
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range batch {
+			rawList, err := c.rdb.ZRangeByScore(ctx, key, &redis.ZRangeBy{Min: cutoff, Max: "+inf"}).Result()
+			if err != nil {
+				continue
+			}
+			jobID := strings.TrimPrefix(key, JobPerfPrefix)
+			for _, s := range rawList {
+				var p map[string]any
+				if err := json.Unmarshal([]byte(s), &p); err != nil {
+					continue
+				}
+				replicaID, _ := p["replicaId"].(string)
+				if replicaID == "" {
+					continue
+				}
+				smp := capacityplanning.Sample{}
+				if v, ok := p["ts"].(float64); ok {
+					smp.Ts = int64(v)
+				}
+				if v, ok := p["cpu"].(float64); ok {
+					smp.CPU = v
+				}
+				if v, ok := p["ram"].(float64); ok {
+					smp.RAM = v
+				}
+				if v, ok := p["totalRam"].(float64); ok {
+					smp.TotalRAM = v
+				}
+				if v, ok := p["jobId"].(string); ok && v != "" {
+					smp.JobID = v
+				} else {
+					smp.JobID = jobID
+				}
+				out[replicaID] = append(out[replicaID], smp)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// ReplicaHistoryAsSamples returns ReadAllReplicasHistory data converted to
+// the capacityplanning.Sample shape (used by the 1h fast path).
+func (c *Client) ReplicaHistoryAsSamples(ctx context.Context, windowMs int64) (map[string][]capacityplanning.Sample, error) {
+	hist, err := c.ReadAllReplicasHistory(ctx, windowMs)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string][]capacityplanning.Sample, len(hist))
+	for id, samples := range hist {
+		conv := make([]capacityplanning.Sample, 0, len(samples))
+		for _, s := range samples {
+			jobID := ""
+			if s.JobID != nil {
+				jobID = *s.JobID
+			}
+			conv = append(conv, capacityplanning.Sample{
+				Ts:       s.Ts,
+				CPU:      s.CPU,
+				RAM:      s.RAM,
+				TotalRAM: s.TotalRAM,
+				JobID:    jobID,
+			})
+		}
+		out[id] = conv
+	}
+	return out, nil
+}

--- a/apps-microservices/crawler-monitor-backend/internal/ws/pubsub.go
+++ b/apps-microservices/crawler-monitor-backend/internal/ws/pubsub.go
@@ -39,6 +39,10 @@ const knownReplicasKey = "replica:known"
 // retentionMs: 1h replica history retention (matches redisstore.RetentionReplicaHistoryMs).
 const retentionMs = int64(60 * 60 * 1000)
 
+// jobPerfPrefix and jobPerfRetentionMs mirror redisstore constants.
+const jobPerfPrefix = "job:perf:"
+const jobPerfRetentionMs = int64(7 * 24 * 60 * 60 * 1000) // 7 days
+
 type PubSub struct {
 	rdb      *redis.Client
 	hub      *Hub
@@ -149,6 +153,7 @@ func (p *PubSub) persistAndNotify(ctx context.Context, payload string) {
 	}
 	p.persistJob(ctx, msg)
 	p.persistReplica(ctx, msg)
+	p.persistJobPerf(ctx, msg)
 }
 
 // persistJob upserts crawl_job:<jobId> preserving start_time on existing entries.
@@ -254,4 +259,42 @@ func (p *PubSub) persistReplica(ctx context.Context, msg map[string]any) {
 	_ = p.rdb.ZAdd(ctx, key, redis.Z{Score: float64(ts), Member: string(raw)}).Err()
 	_ = p.rdb.ZRemRangeByScore(ctx, key, "0", minScore).Err()
 	_ = p.rdb.SAdd(ctx, knownReplicasKey, replicaID).Err()
+}
+
+// persistJobPerf appends a perf sample to job:perf:<jobId> (ZSet, score=ts, 7d TTL).
+// Member shape: {ts, cpu, ram, totalRam, replicaId, jobId} — matches Express persistJobPerf
+// so the existing computeCapacityPlanning loader can decode it without changes.
+func (p *PubSub) persistJobPerf(ctx context.Context, msg map[string]any) {
+	jobID := stringOrNum(msg["jobId"])
+	if jobID == "" {
+		return
+	}
+	replicaID := stringOrNum(msg["replicaId"])
+	ts := time.Now().UnixMilli()
+	if v, ok := msg["timestamp"].(float64); ok {
+		ts = int64(v)
+	}
+	cpu, _ := msg["cpu"].(float64)
+	ram, _ := msg["ram"].(float64)
+	totalRAM, _ := msg["totalRam"].(float64)
+
+	sample := map[string]any{
+		"ts":       ts,
+		"cpu":      cpu,
+		"ram":      ram,
+		"totalRam": totalRAM,
+		"jobId":    jobID,
+	}
+	if replicaID != "" {
+		sample["replicaId"] = replicaID
+	}
+	raw, err := json.Marshal(sample)
+	if err != nil {
+		return
+	}
+	key := jobPerfPrefix + jobID
+	minScore := strconv.FormatInt(ts-jobPerfRetentionMs, 10)
+	_ = p.rdb.ZAdd(ctx, key, redis.Z{Score: float64(ts), Member: string(raw)}).Err()
+	_ = p.rdb.ZRemRangeByScore(ctx, key, "0", minScore).Err()
+	_ = p.rdb.Expire(ctx, key, time.Duration(jobPerfRetentionMs)*time.Millisecond).Err()
 }

--- a/apps-microservices/crawler-monitor-backend/tests/alerts_test.go
+++ b/apps-microservices/crawler-monitor-backend/tests/alerts_test.go
@@ -287,11 +287,17 @@ func TestAlerts_Endpoint_ReturnsArray(t *testing.T) {
 		b, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, b)
 	}
-	var body []any
+	var body struct {
+		Alerts []any `json:"alerts"`
+		Count  int   `json:"count"`
+	}
 	decodeJSON(t, resp.Body, &body)
 	// Empty system → no alerts (but must be an array, not null).
-	if body == nil {
-		t.Error("expected non-nil array")
+	if body.Alerts == nil {
+		t.Error("expected non-nil alerts array")
+	}
+	if body.Count != len(body.Alerts) {
+		t.Errorf("count=%d len=%d", body.Count, len(body.Alerts))
 	}
 }
 
@@ -327,10 +333,12 @@ func TestAlerts_Endpoint_WithFailedCallbacks(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
-	var body []map[string]any
+	var body struct {
+		Alerts []map[string]any `json:"alerts"`
+	}
 	decodeJSON(t, resp.Body, &body)
 	found := false
-	for _, a := range body {
+	for _, a := range body.Alerts {
 		if a["id"] == "callbacks_failing" {
 			found = true
 		}

--- a/apps-microservices/crawler-monitor-backend/tests/domains_test.go
+++ b/apps-microservices/crawler-monitor-backend/tests/domains_test.go
@@ -226,12 +226,19 @@ func TestDomainsHTTP_List(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	var body []domains.DomainSummary
+	var body struct {
+		Window  string                  `json:"window"`
+		Count   int                     `json:"count"`
+		Domains []domains.DomainSummary `json:"domains"`
+	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatal(err)
 	}
-	if len(body) != 2 {
-		t.Errorf("len(body) = %d, want 2", len(body))
+	if len(body.Domains) != 2 {
+		t.Errorf("len(body.Domains) = %d, want 2", len(body.Domains))
+	}
+	if body.Count != 2 {
+		t.Errorf("body.Count = %d, want 2", body.Count)
 	}
 }
 

--- a/apps-microservices/crawler-monitor-backend/tests/jobs_test.go
+++ b/apps-microservices/crawler-monitor-backend/tests/jobs_test.go
@@ -82,7 +82,10 @@ func TestCapacity_Ok(t *testing.T) {
 	}
 	var body map[string]any
 	_ = json.NewDecoder(resp.Body).Decode(&body)
-	if body["running"].(float64) != 5 || body["max"].(float64) != 10 {
+	if body["running_jobs"].(float64) != 5 || body["max_global_jobs"].(float64) != 10 {
 		t.Errorf("body=%v", body)
+	}
+	if body["is_full"] != false {
+		t.Errorf("is_full=%v", body["is_full"])
 	}
 }

--- a/apps-microservices/crawler-monitor-backend/tests/replica_history_test.go
+++ b/apps-microservices/crawler-monitor-backend/tests/replica_history_test.go
@@ -254,10 +254,13 @@ func TestReplicaHTTP_AllHistory(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	var body map[string]any
+	var body struct {
+		Window   string                   `json:"window"`
+		Replicas map[string][]any         `json:"replicas"`
+	}
 	decodeJSON(t, resp.Body, &body)
-	if _, ok := body["r1"]; !ok {
-		t.Error("r1 missing from response")
+	if _, ok := body.Replicas["r1"]; !ok {
+		t.Errorf("r1 missing from response: %+v", body)
 	}
 }
 


### PR DESCRIPTION
…hapes + snapshotters)

Audit Express -> Go a revele 4 categories de regressions cassant le dashboard au-dela du WS heartbeat (deja fixe). Tous les widgets affichaient 0 car les shapes de reponse ne matchaient pas ce que le frontend attendait.

REST wrappers manquants (les widgets ignoraient les reponses):
- /api/capacity: {running,max,full} -> {running_jobs,max_global_jobs,is_full}
- /api/capacity/history: stub [] -> {window,count,points} (vraie lecture ZSet)
- /api/capacity-planning/ram: stub vide -> {window,window_ms,generated_at,replicas,totals} (port complet de computeCapacityPlanning + aggregateByReplica + computeTotals)
- /api/replicas/history: map brute -> {window,replicas:{id:[]}}
- /api/alerts: []Alert -> {generated_at,thresholds,count,alerts}
- /api/domains: []DomainSummary -> {window,count,domains}

Snapshotters non portes (donnees historiques jamais ecrites):
- snapshotCapacity (ticker 60s) ecrit capacity:history:zset (24h retention)
- persistJobPerf ecrit job:perf:<jobId> (ZSet 7d retention) depuis heartbeats

Tests mis a jour pour matcher les nouvelles shapes.