### PR TITLE
fix(crawler-monitor-backend): tolerant date parsing + faster SCAN

### DIFF
--- a/apps-microservices/crawler-monitor-backend/internal/datetime/datetime.go
+++ b/apps-microservices/crawler-monitor-backend/internal/datetime/datetime.go
@@ -1,0 +1,103 @@
+// Package datetime provides lenient timestamp parsing matching JS Date.parse
+// behaviour, which is what the Express version of the monitor relied on.
+//
+// The Python crawler stores start_time / end_time in various formats:
+//   - "2026-04-29T15:16:20.123456+00:00"    (datetime.now(timezone.utc).isoformat())
+//   - "2026-04-29T15:16:20.123456Z"
+//   - "2026-04-29T15:16:20.123456"          (datetime.utcnow().isoformat() — naive)
+//   - "2026-04-29T15:16:20Z"
+//   - 1776924980000                          (raw Unix milliseconds, JSON number)
+//
+// Go's stdlib parsers are strict, so we try a series of layouts and finally
+// fall back to numeric parsing. Returns -1 if nothing matches.
+package datetime
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// layouts is the ordered list of time formats we try, from most specific to
+// most permissive. Naive layouts (no timezone) are interpreted as UTC.
+var layouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.000000Z07:00",
+	"2006-01-02T15:04:05.999999",
+	"2006-01-02T15:04:05.000000",
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05.999999",
+	"2006-01-02 15:04:05",
+}
+
+// ParseStringMs returns the Unix-millisecond timestamp encoded in s, or -1 on failure.
+func ParseStringMs(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return -1
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UnixMilli()
+		}
+	}
+	// Last resort: numeric string. Treat values >1e12 as ms, smaller ones as seconds.
+	if n, err := strconv.ParseFloat(s, 64); err == nil {
+		if n > 1e12 {
+			return int64(n)
+		}
+		if n > 1e9 {
+			return int64(n * 1000)
+		}
+	}
+	return -1
+}
+
+// ParseAnyMs accepts an interface{} typically pulled from a JSON map and returns
+// Unix-ms (-1 on failure). Handles strings, float64 (json.Unmarshal default for
+// numbers), and int64.
+func ParseAnyMs(v any) int64 {
+	switch x := v.(type) {
+	case nil:
+		return -1
+	case string:
+		return ParseStringMs(x)
+	case float64:
+		if x > 1e12 {
+			return int64(x)
+		}
+		if x > 1e9 {
+			return int64(x * 1000)
+		}
+	case int64:
+		if x > 1e12 {
+			return x
+		}
+		if x > 1e9 {
+			return x * 1000
+		}
+	case int:
+		return ParseAnyMs(int64(x))
+	}
+	return -1
+}
+
+// AnyToISO accepts an interface{} from a JSON map and returns its canonical
+// RFC3339Nano string representation, or "" if it cannot be parsed.
+// Useful when downstream code expects start_time as a string.
+func AnyToISO(v any) string {
+	if s, ok := v.(string); ok && s != "" {
+		// Already a string; if parseable, normalize, else return as-is.
+		if ParseStringMs(s) > 0 {
+			return s
+		}
+		return s
+	}
+	ms := ParseAnyMs(v)
+	if ms <= 0 {
+		return ""
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
+}

--- a/apps-microservices/crawler-monitor-backend/internal/domain/alerts/alerts.go
+++ b/apps-microservices/crawler-monitor-backend/internal/domain/alerts/alerts.go
@@ -12,7 +12,8 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 )
 
 // Thresholds holds all configurable alert thresholds.
@@ -299,14 +300,5 @@ func Evaluate(inputs Inputs, nowMs int64, t Thresholds) []Alert {
 
 // parseJobTimeMs parses an ISO timestamp string and returns UnixMilli, or -1.
 func parseJobTimeMs(s string) int64 {
-	if s == "" {
-		return -1
-	}
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05Z"} {
-		t, err := time.Parse(layout, s)
-		if err == nil {
-			return t.UnixMilli()
-		}
-	}
-	return -1
+	return datetime.ParseStringMs(s)
 }

--- a/apps-microservices/crawler-monitor-backend/internal/domain/domains/domains.go
+++ b/apps-microservices/crawler-monitor-backend/internal/domain/domains/domains.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"sort"
 	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 )
 
 var windowMap = map[string]int64{
@@ -82,11 +84,11 @@ func AggregateDomains(jobs []RawJob, nowMs, windowMs int64) []DomainSummary {
 		if j.Domain == "" {
 			continue
 		}
-		t, err := time.Parse(time.RFC3339, j.StartTime)
-		if err != nil {
+		tMs := datetime.ParseStringMs(j.StartTime)
+		if tMs < 0 {
 			continue
 		}
-		if t.UnixMilli() < cutoff {
+		if tMs < cutoff {
 			continue
 		}
 		agg, exists := byDomain[j.Domain]
@@ -109,9 +111,8 @@ func AggregateDomains(jobs []RawJob, nowMs, windowMs int64) []DomainSummary {
 		if j.CrawlMode == "update" {
 			agg.updateCount++
 		}
-		ts := t.UnixMilli()
-		if ts > agg.lastRunTs {
-			agg.lastRunTs = ts
+		if tMs > agg.lastRunTs {
+			agg.lastRunTs = tMs
 			s := j.StartTime
 			agg.lastRunAt = &s
 			st := j.Status
@@ -149,14 +150,10 @@ func AggregateDomains(jobs []RawJob, nowMs, windowMs int64) []DomainSummary {
 	sort.SliceStable(out, func(i, j int) bool {
 		var ti, tj int64
 		if out[i].LastRunAt != nil {
-			if t, err := time.Parse(time.RFC3339, *out[i].LastRunAt); err == nil {
-				ti = t.UnixMilli()
-			}
+			ti = datetime.ParseStringMs(*out[i].LastRunAt)
 		}
 		if out[j].LastRunAt != nil {
-			if t, err := time.Parse(time.RFC3339, *out[j].LastRunAt); err == nil {
-				tj = t.UnixMilli()
-			}
+			tj = datetime.ParseStringMs(*out[j].LastRunAt)
 		}
 		return ti > tj // desc
 	})
@@ -191,20 +188,15 @@ func JobsForDomain(jobs []RawJob, domain string, windowMs, nowMs int64) DomainDe
 		if j.Domain != domain {
 			continue
 		}
-		t, err := time.Parse(time.RFC3339, j.StartTime)
-		if err != nil {
-			continue
-		}
-		if t.UnixMilli() < cutoff {
+		tMs := datetime.ParseStringMs(j.StartTime)
+		if tMs < 0 || tMs < cutoff {
 			continue
 		}
 		filtered = append(filtered, j)
 	}
 	// Sort newest first.
 	sort.SliceStable(filtered, func(i, j int) bool {
-		ti, _ := time.Parse(time.RFC3339, filtered[i].StartTime)
-		tj, _ := time.Parse(time.RFC3339, filtered[j].StartTime)
-		return ti.UnixMilli() > tj.UnixMilli()
+		return datetime.ParseStringMs(filtered[i].StartTime) > datetime.ParseStringMs(filtered[j].StartTime)
 	})
 
 	// Build chain via previous_crawl_id starting from the most recent job.

--- a/apps-microservices/crawler-monitor-backend/internal/domain/systemstats/systemstats.go
+++ b/apps-microservices/crawler-monitor-backend/internal/domain/systemstats/systemstats.go
@@ -8,7 +8,8 @@ package systemstats
 import (
 	"errors"
 	"math"
-	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 )
 
 // WINDOW_MAP mirrors the JS WINDOW_MAP for system stats.
@@ -65,15 +66,11 @@ func AggregateJobStats(jobs []RawJob, nowMs, windowMs int64) JobStats {
 
 	var inWindow []RawJob
 	for _, j := range jobs {
-		t, err := time.Parse(time.RFC3339, j.StartTime)
-		if err != nil {
-			// Try without nanoseconds.
-			t, err = time.Parse("2006-01-02T15:04:05Z", j.StartTime)
-			if err != nil {
-				continue
-			}
+		tMs := datetime.ParseStringMs(j.StartTime)
+		if tMs < 0 {
+			continue
 		}
-		if t.UnixMilli() >= cutoff {
+		if tMs >= cutoff {
 			inWindow = append(inWindow, j)
 		}
 	}
@@ -109,10 +106,10 @@ func AggregateJobStats(jobs []RawJob, nowMs, windowMs int64) JobStats {
 			updateMode++
 		}
 		if status == "finished" && j.StartTime != "" && j.EndTime != "" {
-			st, err1 := time.Parse(time.RFC3339, j.StartTime)
-			et, err2 := time.Parse(time.RFC3339, j.EndTime)
-			if err1 == nil && err2 == nil {
-				d := et.UnixMilli() - st.UnixMilli()
+			stMs := datetime.ParseStringMs(j.StartTime)
+			etMs := datetime.ParseStringMs(j.EndTime)
+			if stMs >= 0 && etMs >= 0 {
+				d := etMs - stMs
 				if d >= 0 {
 					durationsMs = append(durationsMs, d)
 				}

--- a/apps-microservices/crawler-monitor-backend/internal/domain/timeline/timeline.go
+++ b/apps-microservices/crawler-monitor-backend/internal/domain/timeline/timeline.go
@@ -12,6 +12,8 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 )
 
 // windowDef holds the presets for each named window.
@@ -184,15 +186,5 @@ func ComputeTimeline(jobs []Job, windowKey string, opts ComputeOptions) (*Result
 
 // parseTimeMs parses an ISO timestamp string and returns UnixMilli, or -1 on error.
 func parseTimeMs(s string) int64 {
-	if s == "" {
-		return -1
-	}
-	// Try multiple formats matching JS Date.parse behaviour.
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05Z"} {
-		t, err := time.Parse(layout, s)
-		if err == nil {
-			return t.UnixMilli()
-		}
-	}
-	return -1
+	return datetime.ParseStringMs(s)
 }

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/alerts.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/alerts.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/alerts"
-	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/systemstats"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/replicahistory"
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/systemstats"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/store/redisstore"
 )
 
@@ -73,8 +74,9 @@ func alertsHandler(rs *redisstore.Client) http.HandlerFunc {
 }
 
 // rawJobToAlertJob converts a Redis raw job map to an alerts.Job.
+// start_time may be stored as ISO string or Unix-ms number (Python crawler).
 func rawJobToAlertJob(rj redisstore.RawJob) alerts.Job {
-	startTime, _ := rj["start_time"].(string)
+	startTime := datetime.AnyToISO(rj["start_time"])
 	status, _ := rj["status"].(string)
 	_ = strings.ToLower // ensure import used
 	oom := 0

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/domains.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/domains.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/domains"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/store/redisstore"
 	"github.com/go-chi/chi/v5"
@@ -22,9 +23,7 @@ func rawJobsToDomain(rawJobs []redisstore.RawJob) []domains.RawJob {
 		if v, ok := rj["domain"].(string); ok {
 			j.Domain = v
 		}
-		if v, ok := rj["start_time"].(string); ok {
-			j.StartTime = v
-		}
+		j.StartTime = datetime.AnyToISO(rj["start_time"])
 		if v, ok := rj["status"].(string); ok {
 			j.Status = v
 		}

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/system.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/system.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/systemstats"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/store/redisstore"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/ws"
@@ -34,12 +35,8 @@ func systemStatsHandler(rs *redisstore.Client) http.HandlerFunc {
 		jobs := make([]systemstats.RawJob, 0, len(rawJobs))
 		for _, rj := range rawJobs {
 			var j systemstats.RawJob
-			if v, ok := rj["start_time"].(string); ok {
-				j.StartTime = v
-			}
-			if v, ok := rj["end_time"].(string); ok {
-				j.EndTime = v
-			}
+			j.StartTime = datetime.AnyToISO(rj["start_time"])
+			j.EndTime = datetime.AnyToISO(rj["end_time"])
 			if v, ok := rj["status"].(string); ok {
 				j.Status = v
 			}

--- a/apps-microservices/crawler-monitor-backend/internal/httpapi/timeline.go
+++ b/apps-microservices/crawler-monitor-backend/internal/httpapi/timeline.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Hellopro-fr/crawler-monitor-backend/internal/datetime"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/domain/timeline"
 	"github.com/Hellopro-fr/crawler-monitor-backend/internal/store/redisstore"
 )
@@ -53,8 +54,9 @@ func timelineHandler(rs *redisstore.Client) http.HandlerFunc {
 }
 
 // rawJobToTimelineJob converts a Redis raw job map to a timeline.Job.
+// start_time may be stored as ISO string or Unix-ms number (Python crawler).
 func rawJobToTimelineJob(rj redisstore.RawJob) timeline.Job {
-	startTime, _ := rj["start_time"].(string)
+	startTime := datetime.AnyToISO(rj["start_time"])
 	status, _ := rj["status"].(string)
 	oom := 0
 	switch v := rj["oom_restart_count"].(type) {

--- a/apps-microservices/crawler-monitor-backend/internal/store/redisstore/jobs.go
+++ b/apps-microservices/crawler-monitor-backend/internal/store/redisstore/jobs.go
@@ -11,8 +11,10 @@ type RawJob map[string]any
 func (c *Client) ListJobs(ctx context.Context) ([]RawJob, error) {
 	var keys []string
 	var cursor uint64
+	// COUNT=10000 keeps SCAN non-blocking on large keyspaces while avoiding
+	// excessive round-trips for typical (~few thousand) job populations.
 	for {
-		batch, next, err := c.rdb.Scan(ctx, cursor, JobPrefix+"*", 100).Result()
+		batch, next, err := c.rdb.Scan(ctx, cursor, JobPrefix+"*", 10000).Result()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Symptomes en prod :
- /api/timeline retourne tous buckets a 0 malgre 2213 jobs
- /api/domains retourne liste vide (Domains 0)
- chargement bcp plus lent que Express

Causes :
1. time.Parse(time.RFC3339, ...) strict echoue sur les formats Python :
   - 2026-04-29T15:16:20.123456+00:00 (microsecondes vs nanosecondes)
   - 2026-04-29T15:16:20.123456 (datetime.utcnow().isoformat() naif) Resultat : tous les jobs filtres a la conversion start_time.
2. SCAN avec COUNT=100 fait des dizaines de round-trips la ou Express utilisait KEYS (1 round-trip).

Fix :
- Nouveau internal/datetime: ParseStringMs / ParseAnyMs / AnyToISO matchent Date.parse JS (multiple layouts ISO + Unix ms numerique).
- timeline / domains / alerts / systemstats : utilisent le parser tolerant.
- httpapi : conversions RawJob -> typed acceptent start_time number ou string.
- ListJobs SCAN COUNT 100 -> 10000 (rare round-trips, equivalent KEYS prod).