### PR TITLE
fix(account-service-frontend): fall back to HP logo when branding log…

### DIFF
--- a/apps-microservices/account-service-frontend/src/views/LoginView.vue
+++ b/apps-microservices/account-service-frontend/src/views/LoginView.vue
@@ -30,7 +30,7 @@ const brandTitle = computed(() =>
 const subtitle = computed(() =>
   oauthMode.value ? 'Authentifiez-vous pour accéder à ce service.' : 'Accédez au tableau de bord.',
 )
-const logoUrl = computed(() => branding.value?.logo_url ?? '/images/servers/hp-logo.svg')
+const logoUrl = computed(() => branding.value?.logo_url || '/images/servers/hp-logo.svg')
 
 onMounted(async () => {
   if (!oauthMode.value) return


### PR DESCRIPTION
…o empty

EN: Switch nullish coalescing (??) to logical OR (||) so an empty string from /authorize/branding/{cid} also triggers the hp-logo.svg fallback, not just a missing field.

FR: Remplace l'opérateur de coalescence (??) par OU logique (||) afin qu'une chaîne vide retournée par /authorize/branding/{cid} déclenche aussi le fallback hp-logo.svg, pas seulement un champ absent.