### PR TITLE
fix(frontends): survive backend container recreation; healthcheck IPv4

### DIFF
--- a/apps-microservices/account-service-frontend/Dockerfile
+++ b/apps-microservices/account-service-frontend/Dockerfile
@@ -17,5 +17,5 @@ RUN printf 'proxy_http_version 1.1;\nproxy_set_header Host $host;\nproxy_set_hea
     && touch /var/run/nginx.pid && chown appuser:appgroup /var/run/nginx.pid
 USER appuser
 EXPOSE 8601
-HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8601/ || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1:8601/ || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps-microservices/account-service-frontend/nginx.conf
+++ b/apps-microservices/account-service-frontend/nginx.conf
@@ -1,8 +1,3 @@
-upstream account_backend {
-    server account-service-backend:8600;
-    keepalive 32;
-}
-
 server {
     listen 8601;
     server_name _;
@@ -12,19 +7,27 @@ server {
 
     root /usr/share/nginx/html;
 
+    # Re-resolve account-service-backend on every request via Docker's internal
+    # DNS (127.0.0.11). Without this, nginx caches the upstream IP at startup
+    # and returns 502 forever when the backend container restarts with a new
+    # IP. The variable in proxy_pass is the documented trick that forces
+    # nginx to resolve at request time instead of config-load time.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    set $account_backend "account-service-backend:8600";
+
     # SPA fallback
     location / { try_files $uri $uri/ /index.html; }
 
     # Backend-proxied paths
-    location /api/         { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /authorize    { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /token        { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /token/revoke { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /introspect   { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /register     { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /.well-known/ { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location /internal/    { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
-    location = /logout     { proxy_pass http://account_backend; include /etc/nginx/proxy.inc; }
+    location /api/         { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /authorize    { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /token        { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /token/revoke { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /introspect   { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /register     { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /.well-known/ { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location /internal/    { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
+    location = /logout     { proxy_pass http://$account_backend; include /etc/nginx/proxy.inc; }
 
     # Static caching for built assets
     location ~* \.(js|css|woff2?|svg|png|jpg|jpeg|webp|ico)$ {

--- a/apps-microservices/mcp-gateway-frontend/Dockerfile
+++ b/apps-microservices/mcp-gateway-frontend/Dockerfile
@@ -18,5 +18,5 @@ RUN chown -R appuser:appgroup /var/cache/nginx /var/log/nginx /usr/share/nginx/h
     && touch /var/run/nginx.pid && chown appuser:appgroup /var/run/nginx.pid
 USER appuser
 EXPOSE 8581
-HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8581/ || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1:8581/ || exit 1
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
EN: Two related Docker quality-of-life fixes.

1. account-service-frontend nginx.conf cached the upstream IP at config load time via a static `upstream { server account-service-backend; }` block, so every recreate of account-service-backend (new container = new IP) left the SPA stuck returning 502 until the frontend itself was restarted. Switched to the same resolver+variable pattern mcp-gateway-frontend already uses (Docker DNS at 127.0.0.11, valid=10s, variable in proxy_pass), which forces nginx to resolve at request time.

2. Both frontend Dockerfiles healthchecked `wget http://localhost:port/`. busybox wget tries IPv6 (::1) first; nginx in the alpine image binds only IPv4, so the probe fails with "Connection refused" forever and the container shows up as "unhealthy" even though it serves traffic normally. Switched the healthcheck URLs to 127.0.0.1 so the IPv4 path is taken directly.

FR: Deux correctifs de confort Docker liés.

1. Le nginx.conf d'account-service-frontend mettait en cache l'IP de l'upstream à la lecture de la config via un bloc statique `upstream { server account-service-backend; }` ; chaque recreate d'account-service-backend (nouveau conteneur = nouvelle IP) laissait donc le SPA renvoyer 502 jusqu'à ce qu'on redémarre le frontend lui-même. Bascule sur le même pattern resolver+variable que mcp-gateway-frontend utilise déjà (DNS Docker à 127.0.0.11, valid=10s, variable dans proxy_pass), qui force nginx à résoudre au moment de la requête.

2. Les deux Dockerfiles frontends sondaient `wget http://localhost:port/`. busybox wget tente d'abord IPv6 (::1) ; le nginx de l'image alpine n'écoute qu'en IPv4, donc la sonde échoue avec "Connection refused" en permanence et le conteneur apparaît comme "unhealthy" alors qu'il sert le trafic normalement. Bascule les URL des healthchecks sur 127.0.0.1 pour prendre la route IPv4 directement.