### PR TITLE
feat(mcp-gateway): SSO error Slack notifier (LOGIN_SLACK_URL)

### DIFF
--- a/apps-microservices/mcp-gateway-service/cmd/server/main.go
+++ b/apps-microservices/mcp-gateway-service/cmd/server/main.go
@@ -199,12 +199,18 @@ func main() {
 			Scope:              "openid profile email",
 		}
 		ssoRepo := repository.NewSSOSessionRepo(database)
+		ssoSlack := sso.NewSlackNotifier(cfg.LoginSlackURL, cfg.SlackEnvLabel, cfg.GatewayPublicURL)
+		if cfg.LoginSlackURL != "" {
+			log.Printf("[main] SSO error notifications → LOGIN_SLACK_URL")
+		}
 		ssoHandlers := sso.NewHandlers(ssoClient, ssoRepo, userRepo, encryptor, cfg.SecureCookie).
 			WithStateKey([]byte(cfg.JWTSecret)).
-			WithGatewayPublicURL(cfg.GatewayPublicURL)
+			WithGatewayPublicURL(cfg.GatewayPublicURL).
+			WithSlack(ssoSlack)
 		ssoHandlers.RegisterHandlers(mux)
 		ssoMiddleware = sso.NewMiddleware(ssoClient, ssoRepo, userRepo, cfg.SecureCookie).
-			WithEncryptor(encryptor)
+			WithEncryptor(encryptor).
+			WithSlack(ssoSlack)
 
 		// Background reaper: drop sessions whose refresh window expired more
 		// than a day ago. Cheap (single DELETE) so we run it once an hour.

--- a/apps-microservices/mcp-gateway-service/internal/config/config.go
+++ b/apps-microservices/mcp-gateway-service/internal/config/config.go
@@ -94,6 +94,12 @@ type Config struct {
 	SSOClientID          string // SSO_CLIENT_ID — static override; when empty, auto-fetched via /internal/credentials
 	SSOClientSecret      string // SSO_CLIENT_SECRET — static override; when empty, auto-fetched
 	SSORedirectURI       string // SSO_REDIRECT_URI — defaults to ${GATEWAY_PUBLIC_URL}/sso/callback
+	// LoginSlackURL is a dedicated Slack incoming webhook for SSO error
+	// events (state mismatch, refresh failure, token exchange errors, denied
+	// users, tampered logout webhooks). Independent of SLACK_WEBHOOK_URL so
+	// login alerts can land in a different channel than the operational
+	// gateway alerts. Empty = SSO Slack notifications disabled.
+	LoginSlackURL string // LOGIN_SLACK_URL
 }
 
 func Load() *Config {
@@ -197,6 +203,7 @@ func Load() *Config {
 		SSOClientID:          os.Getenv("SSO_CLIENT_ID"),
 		SSOClientSecret:      os.Getenv("SSO_CLIENT_SECRET"),
 		SSORedirectURI:       os.Getenv("SSO_REDIRECT_URI"),
+		LoginSlackURL:        os.Getenv("LOGIN_SLACK_URL"),
 	}
 }
 

--- a/apps-microservices/mcp-gateway-service/internal/sso/handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/sso/handlers.go
@@ -37,6 +37,9 @@ type Handlers struct {
 	// (e.g. http://mcp-hellopro.com:8581). Used as post_logout_redirect_uri
 	// when bouncing the browser through account-service /logout.
 	gatewayPublicURL string
+	// slack is the optional dedicated SSO error notifier (LOGIN_SLACK_URL).
+	// nil = notifications disabled.
+	slack *SlackNotifier
 }
 
 // NewHandlers builds a Handlers struct. Nil dependencies are tolerated for
@@ -58,6 +61,60 @@ func (h *Handlers) WithStateKey(key []byte) *Handlers {
 func (h *Handlers) WithGatewayPublicURL(u string) *Handlers {
 	h.gatewayPublicURL = strings.TrimRight(u, "/")
 	return h
+}
+
+// WithSlack attaches a Slack notifier used to forward SSO error events to a
+// dedicated webhook (LOGIN_SLACK_URL). Pass nil to disable notifications.
+func (h *Handlers) WithSlack(s *SlackNotifier) *Handlers {
+	h.slack = s
+	return h
+}
+
+// notify is a nil-safe shorthand that fills the request-scoped fields on
+// the event (path, query, IP, UA) before forwarding to the Slack notifier.
+func (h *Handlers) notify(r *http.Request, ev SSOErrorEvent) {
+	if h.slack == nil {
+		return
+	}
+	if ev.RequestPath == "" {
+		ev.RequestPath = r.URL.Path
+	}
+	if ev.Query == "" {
+		ev.Query = sanitiseQuery(r.URL.RawQuery)
+	}
+	if ev.ClientIP == "" {
+		ev.ClientIP = clientIP(r)
+	}
+	if ev.UserAgent == "" {
+		ev.UserAgent = r.UserAgent()
+	}
+	h.slack.Notify(ev)
+}
+
+// sanitiseQuery shortens code= / state= / refresh_token= values so they don't
+// fill Slack messages with credential-shaped strings. Keeps the prefix as
+// evidence the param was present without leaking the full secret.
+func sanitiseQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "&")
+	for i, p := range parts {
+		eq := strings.IndexByte(p, '=')
+		if eq < 0 {
+			continue
+		}
+		key := p[:eq]
+		val := p[eq+1:]
+		switch key {
+		case "code", "state", "refresh_token", "access_token", "client_secret", "token":
+			if len(val) > 12 {
+				val = val[:12] + "…"
+			}
+			parts[i] = key + "=" + val
+		}
+	}
+	return strings.Join(parts, "&")
 }
 
 // RegisterHandlers mounts /sso/login, /sso/callback, /logout, and the
@@ -122,12 +179,14 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	cookieVal, err := GetPendingCookie(r)
 	if err != nil {
+		h.notify(r, SSOErrorEvent{Kind: "no_pending_login", Reason: err.Error()})
 		http.Error(w, "no pending login", http.StatusBadRequest)
 		return
 	}
 	pending, err := VerifyPendingState(h.stateKey, cookieVal)
 	if err != nil {
 		log.Printf("[sso] callback: pending state invalid: %v", err)
+		h.notify(r, SSOErrorEvent{Kind: "pending_state_invalid", Reason: err.Error()})
 		http.Error(w, "login expired or tampered, please retry", http.StatusBadRequest)
 		return
 	}
@@ -136,17 +195,31 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	if errCode := q.Get("error"); errCode != "" {
 		desc := q.Get("error_description")
+		h.notify(r, SSOErrorEvent{
+			Kind:   "authorization_error",
+			Reason: errCode + ": " + desc,
+		})
 		http.Error(w, fmt.Sprintf("authorization failed: %s — %s", errCode, desc), http.StatusUnauthorized)
 		return
 	}
 	code := q.Get("code")
 	state := q.Get("state")
 	if code == "" || state == "" {
+		h.notify(r, SSOErrorEvent{Kind: "missing_code_or_state", Reason: "code or state empty"})
 		http.Error(w, "missing code or state", http.StatusBadRequest)
 		return
 	}
 	if state != pending.State {
 		log.Printf("[sso] callback: state mismatch (query=%s pending=%s return_to=%s)", state, pending.State, pending.ReturnTo)
+		h.notify(r, SSOErrorEvent{
+			Kind:   "state_mismatch",
+			Reason: "query state did not match pending state",
+			ExtraFields: map[string]string{
+				"query_state":   state,
+				"pending_state": pending.State,
+				"return_to":     pending.ReturnTo,
+			},
+		})
 		http.Error(w, "state mismatch", http.StatusBadRequest)
 		return
 	}
@@ -154,6 +227,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	tok, err := h.client.ExchangeCode(r.Context(), code, pending.Verifier, h.client.RedirectURI)
 	if err != nil {
 		log.Printf("[sso] callback: token exchange failed: %v", err)
+		h.notify(r, SSOErrorEvent{Kind: "token_exchange_failed", Reason: err.Error()})
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
@@ -161,6 +235,11 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	sub, email, name, err := ParseAccessTokenIdentity(tok.AccessToken)
 	if err != nil || email == "" {
 		log.Printf("[sso] callback: cannot parse identity from access token: %v", err)
+		reason := "missing email claim"
+		if err != nil {
+			reason = err.Error()
+		}
+		h.notify(r, SSOErrorEvent{Kind: "invalid_token_payload", Reason: reason})
 		http.Error(w, "invalid token payload", http.StatusBadGateway)
 		return
 	}
@@ -168,26 +247,36 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	user, err := h.users.UpsertOnLogin(email, name)
 	if err != nil {
 		log.Printf("[sso] callback: upsert user failed: %v", err)
+		h.notify(r, SSOErrorEvent{Kind: "upsert_failed", Reason: err.Error(), UserEmail: email, Sub: sub})
 		http.Error(w, "failed to provision user", http.StatusInternalServerError)
 		return
 	}
 	if user != nil && !user.IsAllowed {
+		h.notify(r, SSOErrorEvent{
+			Kind:      "user_blocked",
+			Reason:    "user authenticated but is_allowed=false",
+			UserEmail: email,
+			Sub:       sub,
+		})
 		http.Error(w, "Access denied. Contact an administrator.", http.StatusForbidden)
 		return
 	}
 
 	sid, err := NewSessionID()
 	if err != nil {
+		h.notify(r, SSOErrorEvent{Kind: "session_id_gen_failed", Reason: err.Error(), UserEmail: email})
 		http.Error(w, "session error", http.StatusInternalServerError)
 		return
 	}
 	accessEnc, err := h.encryptor.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
+		h.notify(r, SSOErrorEvent{Kind: "encrypt_access_failed", Reason: err.Error(), UserEmail: email})
 		http.Error(w, "encryption error", http.StatusInternalServerError)
 		return
 	}
 	refreshEnc, err := h.encryptor.Encrypt([]byte(tok.RefreshToken))
 	if err != nil {
+		h.notify(r, SSOErrorEvent{Kind: "encrypt_refresh_failed", Reason: err.Error(), UserEmail: email})
 		http.Error(w, "encryption error", http.StatusInternalServerError)
 		return
 	}
@@ -213,6 +302,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.repo.Create(row); err != nil {
 		log.Printf("[sso] callback: persist session failed: %v", err)
+		h.notify(r, SSOErrorEvent{Kind: "session_persist_failed", Reason: err.Error(), UserEmail: email, Sub: sub})
 		http.Error(w, "session error", http.StatusInternalServerError)
 		return
 	}
@@ -329,6 +419,10 @@ func (h *Handlers) handleSSOLogoutWebhook(w http.ResponseWriter, r *http.Request
 	sig := r.Header.Get("X-Account-Signature")
 	if err := VerifyWebhookSignature([]byte(h.client.ClientSecret), body, sig); err != nil {
 		log.Printf("[sso] webhook signature rejected: %v", err)
+		h.notify(r, SSOErrorEvent{
+			Kind:   "webhook_signature_invalid",
+			Reason: err.Error(),
+		})
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/apps-microservices/mcp-gateway-service/internal/sso/middleware.go
+++ b/apps-microservices/mcp-gateway-service/internal/sso/middleware.go
@@ -42,6 +42,9 @@ type Middleware struct {
 	// request re-reads the row (now with the rotated tokens) and skips the
 	// refresh altogether.
 	refreshLocks sync.Map // map[string]*sync.Mutex
+
+	// slack is the optional dedicated SSO error notifier. nil = disabled.
+	slack *SlackNotifier
 }
 
 // NewMiddleware constructs the middleware. Pass nils when wiring up at boot
@@ -55,6 +58,13 @@ func NewMiddleware(client *Client, repo *repository.SSOSessionRepo, users userRe
 // rest. Required: SSO mode rejects boot without ENCRYPTION_KEY.
 func (m *Middleware) WithEncryptor(e *crypto.Encryptor) *Middleware {
 	m.encryptor = e
+	return m
+}
+
+// WithSlack attaches a Slack notifier used to forward middleware-level SSO
+// error events (refresh failures, etc.) to LOGIN_SLACK_URL.
+func (m *Middleware) WithSlack(s *SlackNotifier) *Middleware {
+	m.slack = s
 	return m
 }
 
@@ -137,6 +147,17 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 					lock.Unlock()
 					m.refreshLocks.Delete(sid)
 					log.Printf("[sso] refresh failed for sid=%s: %v", sid, err)
+					if m.slack != nil {
+						m.slack.Notify(SSOErrorEvent{
+							Kind:        "refresh_failed",
+							Reason:      err.Error(),
+							UserEmail:   fresh.Email,
+							Sub:         fresh.Sub,
+							ClientIP:    clientIP(r),
+							UserAgent:   r.UserAgent(),
+							RequestPath: r.URL.Path,
+						})
+					}
 					_ = m.repo.Delete(sid)
 					ClearSessionCookie(w, m.secureCk)
 					m.unauthorized(w, r, "refresh failed")

--- a/apps-microservices/mcp-gateway-service/internal/sso/slack.go
+++ b/apps-microservices/mcp-gateway-service/internal/sso/slack.go
@@ -1,0 +1,130 @@
+package sso
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// SSOErrorEvent is the payload the SlackNotifier serialises into a Slack
+// incoming-webhook message. Every field is optional except Kind so callers
+// can fill in only what is relevant for the error site.
+type SSOErrorEvent struct {
+	Kind         string // short id: "state_mismatch", "refresh_failed", "token_exchange", "user_blocked", "webhook_signature", ...
+	Reason       string // free-form details (error message, mismatch values, etc.)
+	UserEmail    string // when known (post token-exchange or post repo lookup)
+	Sub          string // account-service `sub` claim, when known
+	ClientIP     string // best-effort, may include forwarded chain
+	UserAgent    string // browser UA when applicable
+	RequestPath  string // r.URL.Path of the failing request
+	Query        string // sanitised query (state= / code= shortened)
+	ExtraFields  map[string]string // free-form key/value extras
+}
+
+// SlackNotifier posts SSO error events to a dedicated Slack incoming webhook
+// (LOGIN_SLACK_URL). Designed so login alerts can land in a different
+// channel than the operational SLACK_WEBHOOK_URL traffic. When webhookURL
+// is empty the notifier is a no-op so production deployments without the
+// flag set behave exactly as before.
+type SlackNotifier struct {
+	webhookURL string
+	envLabel   string // optional prefix (e.g. "prod", "staging") shown in the message
+	gatewayURL string // included in payload to make multi-deploy alerts disambiguable
+	httpClient *http.Client
+}
+
+// NewSlackNotifier returns a notifier targeting webhookURL. envLabel and
+// gatewayURL are decorative — they help oncall identify which deployment
+// emitted the alert. Pass empty strings if not relevant.
+func NewSlackNotifier(webhookURL, envLabel, gatewayURL string) *SlackNotifier {
+	return &SlackNotifier{
+		webhookURL: strings.TrimSpace(webhookURL),
+		envLabel:   envLabel,
+		gatewayURL: gatewayURL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Notify posts the event in the background. Non-blocking by design — handler
+// hot paths must never wait on Slack delivery. Errors are logged at WARN
+// level; the notifier never returns an error to the caller.
+func (n *SlackNotifier) Notify(ev SSOErrorEvent) {
+	if n == nil || n.webhookURL == "" {
+		return
+	}
+	go n.deliver(ev)
+}
+
+func (n *SlackNotifier) deliver(ev SSOErrorEvent) {
+	payload := map[string]any{
+		"text":        n.formatTitle(ev),
+		"attachments": []map[string]any{n.formatAttachment(ev)},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("[sso][slack] marshal failed: %v", err)
+		return
+	}
+	req, err := http.NewRequest(http.MethodPost, n.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("[sso][slack] build request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		log.Printf("[sso][slack] post: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		log.Printf("[sso][slack] webhook returned %d", resp.StatusCode)
+	}
+}
+
+func (n *SlackNotifier) formatTitle(ev SSOErrorEvent) string {
+	parts := []string{"SSO error"}
+	if n.envLabel != "" {
+		parts = append(parts, "["+n.envLabel+"]")
+	}
+	if ev.Kind != "" {
+		parts = append(parts, ev.Kind)
+	}
+	return strings.Join(parts, " ")
+}
+
+func (n *SlackNotifier) formatAttachment(ev SSOErrorEvent) map[string]any {
+	fields := []map[string]any{}
+	add := func(k, v string) {
+		if v == "" {
+			return
+		}
+		fields = append(fields, map[string]any{"title": k, "value": v, "short": true})
+	}
+	add("Kind", ev.Kind)
+	add("Reason", ev.Reason)
+	add("Path", ev.RequestPath)
+	add("Query", ev.Query)
+	add("User", ev.UserEmail)
+	add("Sub", ev.Sub)
+	add("Client IP", ev.ClientIP)
+	if ev.UserAgent != "" {
+		add("User-Agent", truncate(ev.UserAgent, 200))
+	}
+	add("Gateway", n.gatewayURL)
+	add("Env", n.envLabel)
+	add("Time", time.Now().UTC().Format(time.RFC3339))
+	for k, v := range ev.ExtraFields {
+		add(k, v)
+	}
+	color := "#cc3333"
+	return map[string]any{
+		"color":  color,
+		"text":   fmt.Sprintf("%s — %s", ev.Kind, ev.Reason),
+		"fields": fields,
+	}
+}

--- a/apps-microservices/mcp-gateway-service/internal/sso/slack_test.go
+++ b/apps-microservices/mcp-gateway-service/internal/sso/slack_test.go
@@ -1,0 +1,48 @@
+package sso
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSlackNotifier_Post(t *testing.T) {
+	var hits atomic.Int32
+	var lastBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		b, _ := io.ReadAll(r.Body)
+		lastBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewSlackNotifier(srv.URL, "test-env", "https://gw.example")
+	n.Notify(SSOErrorEvent{
+		Kind:     "state_mismatch",
+		Reason:   "query state did not match pending",
+		ClientIP: "1.2.3.4",
+	})
+	// Notify is non-blocking — wait briefly for the goroutine.
+	time.Sleep(150 * time.Millisecond)
+	if hits.Load() != 1 {
+		t.Fatalf("expected 1 hit, got %d", hits.Load())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(lastBody, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := payload["text"]; !ok {
+		t.Fatal("missing text field")
+	}
+}
+
+func TestSlackNotifier_Disabled(t *testing.T) {
+	n := NewSlackNotifier("", "", "")
+	// Must not panic, must not block.
+	n.Notify(SSOErrorEvent{Kind: "x"})
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2331,6 +2331,10 @@ services:
       - ACCOUNT_INTERNAL_TOKEN=${ACCOUNT_INTERNAL_TOKEN}
       - SSO_CLIENT_NAME=${MCP_SSO_CLIENT_NAME:-mcp-gateway}
       - SSO_REDIRECT_URI=${MCP_SSO_REDIRECT_URI}
+      # Dedicated Slack webhook for SSO error events (state mismatch, refresh
+      # failure, blocked users, tampered logout webhooks). Independent of
+      # SLACK_WEBHOOK_URL so login alerts can land in their own channel.
+      - LOGIN_SLACK_URL=${LOGIN_SLACK_URL}
     volumes:
       - /mnt/data/docker/images/mcp_server:/data/uploads
     # depends_on:


### PR DESCRIPTION
EN: Add a dedicated, asynchronous Slack notifier that fires on every SSO error path so login alerts can land in their own channel, independent of SLACK_WEBHOOK_URL. New env LOGIN_SLACK_URL — empty keeps the notifier disabled (existing deployments unchanged).

Wired into every error return in /sso/callback (no_pending_login, pending_state_invalid, authorization_error, missing_code_or_state, state_mismatch, token_exchange_failed, invalid_token_payload, upsert_failed, user_blocked, session_id_gen_failed, encrypt_*_failed, session_persist_failed), the back-channel logout webhook (webhook_signature_invalid), and the middleware refresh path (refresh_failed). Each event carries kind, reason, request path, sanitised query, client IP, user-agent, plus user/sub/extras when known. Sensitive query params (code, state, refresh_token, …) are truncated to a 12-char prefix so secret-shaped strings don't end up in Slack.

Goroutine-dispatched so handler hot paths never wait on Slack delivery; failures log at WARN but never fail the request.

FR: Ajoute un notifier Slack dédié, asynchrone, qui se déclenche sur chaque erreur SSO afin que les alertes login puissent atterrir dans leur propre canal, indépendant de SLACK_WEBHOOK_URL. Nouvel env LOGIN_SLACK_URL — vide laisse le notifier désactivé (déploiements existants inchangés).

Câblé dans chaque retour d'erreur de /sso/callback (no_pending_login, pending_state_invalid, authorization_error, missing_code_or_state, state_mismatch, token_exchange_failed, invalid_token_payload, upsert_failed, user_blocked, session_id_gen_failed, encrypt_*_failed, session_persist_failed), le webhook de logout back-channel (webhook_signature_invalid), et le path refresh du middleware (refresh_failed). Chaque événement porte kind, reason, path, query assainie, IP client, user-agent, plus user/sub/extras quand connus. Les paramètres de query sensibles (code, state, refresh_token, …) sont tronqués à un préfixe de 12 caractères pour ne pas mettre des chaînes en forme de secret dans Slack.

Dispatché en goroutine pour que les hot paths des handlers n'attendent jamais la livraison Slack ; les échecs sont logués en WARN mais ne font jamais échouer la requête.