### PR TITLE
feat(mcp-gateway): SSO errors land on /login with retry UI

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/views/LoginView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/LoginView.vue
@@ -39,14 +39,33 @@
           <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">Connexion</h2>
           <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">Connectez-vous pour accéder au tableau de bord</p>
 
+          <!-- SSO callback failure UI (state mismatch, expired pending, etc.).
+               Shown only when /sso/callback bounced the browser back here with
+               ?error=...&error_description=... — clicking "Réessayer" re-enters
+               the OAuth flow via /sso/login. -->
+          <div v-if="authStore.ssoMode && ssoErrorKind" class="space-y-4">
+            <div class="p-3 bg-error-50 dark:bg-error-500/15 border border-error-200 dark:border-error-500/30 rounded-md text-sm text-error-600 dark:text-error-400">
+              <p class="font-medium">Connexion impossible</p>
+              <p class="mt-1">{{ ssoErrorMessage }}</p>
+              <p class="mt-2 text-xs opacity-75">Code : {{ ssoErrorKind }}</p>
+            </div>
+            <button
+              type="button"
+              class="w-full py-2.5 px-4 bg-brand-500 text-white font-medium rounded-md hover:bg-brand-600"
+              @click="retrySsoLogin"
+            >
+              Réessayer
+            </button>
+          </div>
+
           <div
-            v-if="errorMessage"
+            v-if="errorMessage && !ssoErrorKind"
             class="mb-4 p-3 bg-error-50 dark:bg-error-500/15 border border-error-200 dark:border-error-500/30 rounded-md text-sm text-error-600 dark:text-error-400"
           >
             {{ errorMessage }}
           </div>
 
-          <form @submit.prevent="handleLogin">
+          <form v-if="!authStore.ssoMode || !ssoErrorKind" @submit.prevent="handleLogin">
             <div class="mb-4">
               <label for="username" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Nom d'utilisateur
@@ -112,8 +131,37 @@ const authStore = useAuthStore()
 const username = ref('')
 const password = ref('')
 const errorMessage = ref('')
+const ssoErrorKind = ref('')
+const ssoErrorMessage = ref('')
 
-// In SSO mode the form never renders. Two cases:
+function defaultErrorMessage(kind: string): string {
+  switch (kind) {
+    case 'state_mismatch':
+      return 'Le jeton d\'état ne correspond pas. Merci de vous reconnecter.'
+    case 'pending_state_invalid':
+      return 'La session de connexion a expiré. Merci de réessayer.'
+    case 'no_pending_login':
+      return 'Aucune session de connexion en cours, merci de réessayer.'
+    case 'user_blocked':
+      return 'Accès refusé. Contactez un administrateur.'
+    case 'token_exchange_failed':
+      return 'Échange du jeton avec le serveur d\'authentification impossible.'
+    case 'invalid_token_payload':
+      return 'Le jeton d\'authentification est invalide.'
+    default:
+      return 'Erreur d\'authentification : ' + kind
+  }
+}
+
+function retrySsoLogin() {
+  authStore.redirectToLogin('/')
+}
+
+// In SSO mode the form never renders. Three cases:
+//  - The query carries ?error=... (the backend /sso/callback bounced here
+//    after a failure). Render the error and a "Réessayer" button instead of
+//    auto-restarting the OAuth dance — otherwise we'd loop on persistent
+//    failures.
 //  - User already has a valid gw_session cookie (e.g., logged in via account-
 //    service then deep-linked to /login). Skip the OAuth dance and push
 //    straight to the home route.
@@ -121,11 +169,16 @@ const errorMessage = ref('')
 //
 // route.query.redirect is intentionally ignored — /login is a fresh landing
 // surface; carrying a stale redirect across the OAuth round trip turned out
-// to surface state-mismatch and post-logout-loop edge cases. Users that need
-// a deep link should point at the protected route directly; the global
-// router guard will then preserve the URL through /sso/login.
+// to surface state-mismatch and post-logout-loop edge cases.
 onMounted(async () => {
   if (!authStore.ssoMode) return
+  const errKind = (route.query.error as string) || ''
+  const errDesc = (route.query.error_description as string) || ''
+  if (errKind) {
+    ssoErrorKind.value = errKind
+    ssoErrorMessage.value = errDesc || defaultErrorMessage(errKind)
+    return
+  }
   const valid = await authStore.checkSession()
   if (valid) {
     router.push('/')
@@ -133,6 +186,7 @@ onMounted(async () => {
   }
   authStore.redirectToLogin('/')
 })
+
 
 async function handleLogin() {
   errorMessage.value = ''

--- a/apps-microservices/mcp-gateway-service/internal/sso/handlers.go
+++ b/apps-microservices/mcp-gateway-service/internal/sso/handlers.go
@@ -91,6 +91,18 @@ func (h *Handlers) notify(r *http.Request, ev SSOErrorEvent) {
 	h.slack.Notify(ev)
 }
 
+// redirectError 303s the browser back to /login with error + error_description
+// query params so LoginView can render a user-friendly error UI instead of a
+// raw plain-text 4xx page. Used from every error site in /sso/callback.
+func (h *Handlers) redirectError(w http.ResponseWriter, r *http.Request, kind, message string) {
+	q := url.Values{}
+	q.Set("error", kind)
+	if message != "" {
+		q.Set("error_description", message)
+	}
+	http.Redirect(w, r, "/login?"+q.Encode(), http.StatusSeeOther)
+}
+
 // sanitiseQuery shortens code= / state= / refresh_token= values so they don't
 // fill Slack messages with credential-shaped strings. Keeps the prefix as
 // evidence the param was present without leaking the full secret.
@@ -180,14 +192,14 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	cookieVal, err := GetPendingCookie(r)
 	if err != nil {
 		h.notify(r, SSOErrorEvent{Kind: "no_pending_login", Reason: err.Error()})
-		http.Error(w, "no pending login", http.StatusBadRequest)
+		h.redirectError(w, r, "no_pending_login", "Aucune session de connexion en cours, merci de réessayer.")
 		return
 	}
 	pending, err := VerifyPendingState(h.stateKey, cookieVal)
 	if err != nil {
 		log.Printf("[sso] callback: pending state invalid: %v", err)
 		h.notify(r, SSOErrorEvent{Kind: "pending_state_invalid", Reason: err.Error()})
-		http.Error(w, "login expired or tampered, please retry", http.StatusBadRequest)
+		h.redirectError(w, r, "pending_state_invalid", "La connexion a expiré ou a été altérée, merci de réessayer.")
 		return
 	}
 	ClearPendingCookie(w, h.secureCk)
@@ -199,14 +211,14 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 			Kind:   "authorization_error",
 			Reason: errCode + ": " + desc,
 		})
-		http.Error(w, fmt.Sprintf("authorization failed: %s — %s", errCode, desc), http.StatusUnauthorized)
+		h.redirectError(w, r, errCode, desc)
 		return
 	}
 	code := q.Get("code")
 	state := q.Get("state")
 	if code == "" || state == "" {
 		h.notify(r, SSOErrorEvent{Kind: "missing_code_or_state", Reason: "code or state empty"})
-		http.Error(w, "missing code or state", http.StatusBadRequest)
+		h.redirectError(w, r, "missing_code_or_state", "La réponse d'authentification est incomplète.")
 		return
 	}
 	if state != pending.State {
@@ -220,7 +232,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 				"return_to":     pending.ReturnTo,
 			},
 		})
-		http.Error(w, "state mismatch", http.StatusBadRequest)
+		h.redirectError(w, r, "state_mismatch", "Le jeton d'état ne correspond pas. Merci de réessayer.")
 		return
 	}
 
@@ -228,7 +240,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("[sso] callback: token exchange failed: %v", err)
 		h.notify(r, SSOErrorEvent{Kind: "token_exchange_failed", Reason: err.Error()})
-		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		h.redirectError(w, r, "token_exchange_failed", "Échange du jeton avec le serveur d'authentification impossible.")
 		return
 	}
 
@@ -240,7 +252,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 			reason = err.Error()
 		}
 		h.notify(r, SSOErrorEvent{Kind: "invalid_token_payload", Reason: reason})
-		http.Error(w, "invalid token payload", http.StatusBadGateway)
+		h.redirectError(w, r, "invalid_token_payload", "Le jeton d'authentification est invalide.")
 		return
 	}
 
@@ -248,7 +260,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("[sso] callback: upsert user failed: %v", err)
 		h.notify(r, SSOErrorEvent{Kind: "upsert_failed", Reason: err.Error(), UserEmail: email, Sub: sub})
-		http.Error(w, "failed to provision user", http.StatusInternalServerError)
+		h.redirectError(w, r, "upsert_failed", "Provisionnement de l'utilisateur impossible.")
 		return
 	}
 	if user != nil && !user.IsAllowed {
@@ -258,26 +270,26 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 			UserEmail: email,
 			Sub:       sub,
 		})
-		http.Error(w, "Access denied. Contact an administrator.", http.StatusForbidden)
+		h.redirectError(w, r, "user_blocked", "Accès refusé. Contactez un administrateur.")
 		return
 	}
 
 	sid, err := NewSessionID()
 	if err != nil {
 		h.notify(r, SSOErrorEvent{Kind: "session_id_gen_failed", Reason: err.Error(), UserEmail: email})
-		http.Error(w, "session error", http.StatusInternalServerError)
+		h.redirectError(w, r, "session_id_gen_failed", "Erreur interne lors de la création de la session.")
 		return
 	}
 	accessEnc, err := h.encryptor.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
 		h.notify(r, SSOErrorEvent{Kind: "encrypt_access_failed", Reason: err.Error(), UserEmail: email})
-		http.Error(w, "encryption error", http.StatusInternalServerError)
+		h.redirectError(w, r, "encrypt_access_failed", "Erreur de chiffrement du jeton d'accès.")
 		return
 	}
 	refreshEnc, err := h.encryptor.Encrypt([]byte(tok.RefreshToken))
 	if err != nil {
 		h.notify(r, SSOErrorEvent{Kind: "encrypt_refresh_failed", Reason: err.Error(), UserEmail: email})
-		http.Error(w, "encryption error", http.StatusInternalServerError)
+		h.redirectError(w, r, "encrypt_refresh_failed", "Erreur de chiffrement du jeton de rafraîchissement.")
 		return
 	}
 
@@ -303,7 +315,7 @@ func (h *Handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if err := h.repo.Create(row); err != nil {
 		log.Printf("[sso] callback: persist session failed: %v", err)
 		h.notify(r, SSOErrorEvent{Kind: "session_persist_failed", Reason: err.Error(), UserEmail: email, Sub: sub})
-		http.Error(w, "session error", http.StatusInternalServerError)
+		h.redirectError(w, r, "session_persist_failed", "Erreur lors de la persistance de la session.")
 		return
 	}
 


### PR DESCRIPTION
EN: Replace the raw plain-text 4xx pages from /sso/callback (and the back-channel logout webhook) with 303 redirects to /login?error=KIND& error_description=MESSAGE. LoginView now reads those query params, hides the form when an error is set, and renders an error block plus a "Réessayer" button — clicking it kicks the OAuth flow back through /sso/login. This means a user that hits state_mismatch / pending_state_ invalid / token_exchange_failed / user_blocked / etc. now sees a real French message on the gateway's "front door" instead of a stark plain-text response, and Slack still receives the same SSOErrorEvent (LOGIN_SLACK_URL) for ops visibility. Critically, the auto-redirect to /sso/login on mount is suppressed when an error param is present, so persistent failures don't loop the browser through the OAuth dance.

FR: Remplace les pages 4xx en texte brut de /sso/callback (et du webhook de logout back-channel) par des redirections 303 vers /login?error=KIND& error_description=MESSAGE. LoginView lit désormais ces paramètres de query, cache le formulaire quand une erreur est positionnée, et affiche un bloc d'erreur plus un bouton "Réessayer" — cliquer dessus relance le flux OAuth via /sso/login. Concrètement, un utilisateur qui tombe sur state_mismatch / pending_state_invalid / token_exchange_failed / user_blocked / etc. voit désormais un vrai message français sur la "porte d'entrée" du gateway au lieu d'une réponse brute, et Slack continue de recevoir le même SSOErrorEvent (LOGIN_SLACK_URL) pour la visibilité ops. Important : l'auto-redirection vers /sso/login au montage est supprimée quand un paramètre error est présent, donc les échecs persistants ne font plus boucler le navigateur dans la danse OAuth.