### PR TITLE
fix(frontends): hide protected layout until auth resolved

### DIFF
--- a/apps-microservices/account-service-frontend/src/App.vue
+++ b/apps-microservices/account-service-frontend/src/App.vue
@@ -15,7 +15,17 @@ import { useRoute } from 'vue-router'
 import ThemeProvider from './components/layout/ThemeProvider.vue'
 import SidebarProvider from './components/layout/SidebarProvider.vue'
 import AdminLayout from './components/layout/AdminLayout.vue'
+import { useAuthStore } from './stores/auth'
 
 const route = useRoute()
-const useAdminLayout = computed(() => route.meta.requiresAuth !== false)
+const authStore = useAuthStore()
+
+// Only render the AdminLayout (header + sidebar) once both (a) the resolved
+// route opts in to auth AND (b) the user is actually authenticated. Defaulting
+// to !== false caused a layout flash on first paint because Vue Router commits
+// the START_LOCATION before beforeEach finishes, so the sidebar/header
+// painted briefly before the guard redirected to /login.
+const useAdminLayout = computed(
+  () => route.meta.requiresAuth === true && authStore.isAuthenticated,
+)
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/App.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/App.vue
@@ -19,14 +19,24 @@ import AppLayout from '@/components/layout/AppLayout.vue';
 import DocsLayout from '@/components/layout/DocsLayout.vue';
 import ThemeProvider from '@/components/layout/ThemeProvider.vue';
 import SidebarProvider from '@/components/layout/SidebarProvider.vue';
+import { useAuthStore } from '@/stores/auth';
 
 const route = useRoute();
+const authStore = useAuthStore();
 
 const isDocsLayout = computed(() => {
   return route.meta.layout === 'docs';
 });
 
+// Render the protected AppLayout only when (a) the resolved route opts in
+// AND (b) the user is actually authenticated. The first-load flash of the
+// header + sidebar that appeared on mcp.hellopro.eu came from
+// `requiresAuth !== false` defaulting to true on the empty start-location
+// route — Vue Router commits the START_LOCATION before beforeEach finishes,
+// so AppLayout painted briefly before the guard redirected to /sso/login.
+// Anchoring on isAuthenticated suppresses the chrome until checkSession
+// lands a user.
 const showLayout = computed(() => {
-  return route.meta.requiresAuth !== false;
+  return route.meta.requiresAuth === true && authStore.isAuthenticated;
 });
 </script>


### PR DESCRIPTION
EN: First-paint of mcp.hellopro.eu and login.hellopro.eu briefly showed the header + sidebar before the router guard redirected unauthenticated users to /sso/login (or /login) — a visible flash of chrome the user never had a session for. Root cause: `route.meta.requiresAuth !== false` defaults to true on Vue Router's empty START_LOCATION, so the protected AppLayout / AdminLayout painted before beforeEach finished. Tighten both gates: render the layout only when (a) the resolved route explicitly opts in (`requiresAuth === true`) AND (b) the user is actually authenticated. Initial paint is now blank → /sso/login redirect, which matches user expectations and avoids the flash.

FR: Le premier rendu de mcp.hellopro.eu et login.hellopro.eu affichait brièvement le header + la sidebar avant que le guard du router ne redirige les utilisateurs non authentifiés vers /sso/login (ou /login) — un flash visible d'éléments d'interface auxquels l'utilisateur n'avait pas encore de session. Cause racine : `route.meta.requiresAuth !== false` vaut true par défaut sur la START_LOCATION vide de Vue Router, donc le AppLayout / AdminLayout protégé peignait avant la fin de beforeEach. Resserre les deux conditions : rend le layout seulement quand (a) la route résolue opte explicitement (`requiresAuth === true`) ET (b) l'utilisateur est réellement authentifié. Le premier rendu est désormais blanc → redirection vers /sso/login, ce qui colle aux attentes et évite le flash.