### PR TITLE
chore(account-service-backend): wire MCP_FALLBACK_* break-glass creds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2411,6 +2411,12 @@ services:
       JWT_AUDIENCE: ${JWT_AUDIENCE}
       AUTH_URL: ${AUTH_URL}
       ADMIN_EMAILS: ${GATEWAY_DOCS_ADMIN_EMAILS}
+      # Break-glass fallback credentials reused from the mcp-gateway env so a
+      # single set of values governs login across both services. Empty =
+      # fallback disabled and only hellopro.fr auth is honoured.
+      FALLBACK_USER: ${MCP_FALLBACK_USER}
+      FALLBACK_PASS: ${MCP_FALLBACK_PASS}
+      FALLBACK_EMAIL: ${MCP_FALLBACK_EMAIL}
       OAUTH2_DEFAULT_TOKEN_TTL: ${OAUTH2_DEFAULT_TOKEN_TTL:-60}
       OAUTH2_DEFAULT_REFRESH_TTL: ${OAUTH2_DEFAULT_REFRESH_TTL:-2592000}
       OAUTH2_AUTH_CODE_TTL: ${OAUTH2_AUTH_CODE_TTL:-600}


### PR DESCRIPTION
EN: account-service-backend already reads FALLBACK_USER/FALLBACK_PASS/ FALLBACK_EMAIL but they were never plumbed through docker-compose. Map them to the existing MCP_FALLBACK_* env vars so a single value set governs the break-glass credential across mcp-gateway-service and account-service-backend. Empty = fallback disabled and only hellopro.fr auth is honoured.

FR: account-service-backend lit déjà FALLBACK_USER/FALLBACK_PASS/ FALLBACK_EMAIL mais ces variables n'avaient jamais été câblées dans docker-compose. Les mappe sur les env MCP_FALLBACK_* existantes pour qu'un seul jeu de valeurs gouverne les credentials break-glass à travers mcp-gateway-service et account-service-backend. Vide = fallback désactivé, seule l'auth hellopro.fr est honorée.