### PR TITLE
refactor(account-service-backend): drop github.com prefix from module…

### DIFF
--- a/apps-microservices/account-service-backend/cmd/server/main.go
+++ b/apps-microservices/account-service-backend/cmd/server/main.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hellopro/account-service/internal/app"
-	"github.com/hellopro/account-service/internal/config"
+	"account-service/internal/app"
+	"account-service/internal/config"
 )
 
 const version = "0.1.0"

--- a/apps-microservices/account-service-backend/go.mod
+++ b/apps-microservices/account-service-backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/hellopro/account-service
+module account-service
 
 go 1.24.13
 

--- a/apps-microservices/account-service-backend/internal/api/admin_service_detail_test.go
+++ b/apps-microservices/account-service-backend/internal/api/admin_service_detail_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestAdminServices_RotateSecret(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/api/admin_service_handlers.go
+++ b/apps-microservices/account-service-backend/internal/api/admin_service_handlers.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type ServiceRepo interface {

--- a/apps-microservices/account-service-backend/internal/api/admin_service_handlers_test.go
+++ b/apps-microservices/account-service-backend/internal/api/admin_service_handlers_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 var errNotFound = errors.New("not found")

--- a/apps-microservices/account-service-backend/internal/api/admin_user_handlers.go
+++ b/apps-microservices/account-service-backend/internal/api/admin_user_handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type UserAdminRepo interface {

--- a/apps-microservices/account-service-backend/internal/api/admin_user_handlers_test.go
+++ b/apps-microservices/account-service-backend/internal/api/admin_user_handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeUserAdminRepo struct {

--- a/apps-microservices/account-service-backend/internal/api/audit_handlers.go
+++ b/apps-microservices/account-service-backend/internal/api/audit_handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type AuditRepo interface {

--- a/apps-microservices/account-service-backend/internal/api/audit_handlers_test.go
+++ b/apps-microservices/account-service-backend/internal/api/audit_handlers_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeAuditRepo struct {

--- a/apps-microservices/account-service-backend/internal/api/internal_credentials.go
+++ b/apps-microservices/account-service-backend/internal/api/internal_credentials.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 // NameLookup looks up an oauth2_clients row by its display name.

--- a/apps-microservices/account-service-backend/internal/api/internal_credentials_test.go
+++ b/apps-microservices/account-service-backend/internal/api/internal_credentials_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeNameLookup struct {

--- a/apps-microservices/account-service-backend/internal/api/me_handlers.go
+++ b/apps-microservices/account-service-backend/internal/api/me_handlers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/auth"
+	"account-service/internal/auth"
 )
 
 type ctxKey int

--- a/apps-microservices/account-service-backend/internal/api/me_handlers_test.go
+++ b/apps-microservices/account-service-backend/internal/api/me_handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/auth"
+	"account-service/internal/auth"
 )
 
 type fakeUserResolver struct {

--- a/apps-microservices/account-service-backend/internal/api/sessions.go
+++ b/apps-microservices/account-service-backend/internal/api/sessions.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type SessionRepo interface {

--- a/apps-microservices/account-service-backend/internal/api/sessions_test.go
+++ b/apps-microservices/account-service-backend/internal/api/sessions_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeSessionRepo struct {

--- a/apps-microservices/account-service-backend/internal/app/adapters.go
+++ b/apps-microservices/account-service-backend/internal/app/adapters.go
@@ -5,11 +5,11 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/hellopro/account-service/internal/api"
-	"github.com/hellopro/account-service/internal/crypto"
-	"github.com/hellopro/account-service/internal/db"
-	"github.com/hellopro/account-service/internal/logout"
-	"github.com/hellopro/account-service/internal/repository"
+	"account-service/internal/api"
+	"account-service/internal/crypto"
+	"account-service/internal/db"
+	"account-service/internal/logout"
+	"account-service/internal/repository"
 )
 
 // cryptoAdapter narrows *crypto.Cipher down to logout.Decrypter so the

--- a/apps-microservices/account-service-backend/internal/app/app.go
+++ b/apps-microservices/account-service-backend/internal/app/app.go
@@ -19,13 +19,13 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/hellopro/account-service/internal/api"
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/config"
-	"github.com/hellopro/account-service/internal/crypto"
-	"github.com/hellopro/account-service/internal/db"
-	"github.com/hellopro/account-service/internal/logout"
-	"github.com/hellopro/account-service/internal/repository"
+	"account-service/internal/api"
+	"account-service/internal/auth"
+	"account-service/internal/config"
+	"account-service/internal/crypto"
+	"account-service/internal/db"
+	"account-service/internal/logout"
+	"account-service/internal/repository"
 )
 
 // App owns every long-lived dependency built at boot. main() drives Run /

--- a/apps-microservices/account-service-backend/internal/app/repos.go
+++ b/apps-microservices/account-service-backend/internal/app/repos.go
@@ -3,7 +3,7 @@ package app
 import (
 	"gorm.io/gorm"
 
-	"github.com/hellopro/account-service/internal/repository"
+	"account-service/internal/repository"
 )
 
 // Repos is the bundle of GORM-backed repositories the rest of the app

--- a/apps-microservices/account-service-backend/internal/app/routes.go
+++ b/apps-microservices/account-service-backend/internal/app/routes.go
@@ -4,14 +4,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hellopro/account-service/internal/api"
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/authserver"
-	"github.com/hellopro/account-service/internal/config"
-	"github.com/hellopro/account-service/internal/crypto"
-	"github.com/hellopro/account-service/internal/health"
-	"github.com/hellopro/account-service/internal/logout"
-	"github.com/hellopro/account-service/internal/metrics"
+	"account-service/internal/api"
+	"account-service/internal/auth"
+	"account-service/internal/authserver"
+	"account-service/internal/config"
+	"account-service/internal/crypto"
+	"account-service/internal/health"
+	"account-service/internal/logout"
+	"account-service/internal/metrics"
 )
 
 // routeDeps is the closed set of values registerRoutes needs. Bundling the

--- a/apps-microservices/account-service-backend/internal/authserver/authorize.go
+++ b/apps-microservices/account-service-backend/internal/authserver/authorize.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type AuthorizeParams struct {

--- a/apps-microservices/account-service-backend/internal/authserver/authorize_handler_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/authorize_handler_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/auth"
+	"account-service/internal/db"
 )
 
 type fakeAuthCodeRepo struct {

--- a/apps-microservices/account-service-backend/internal/authserver/authorize_params_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/authorize_params_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestParseAuthorizeParams_Required(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/authserver/branding.go
+++ b/apps-microservices/account-service-backend/internal/authserver/branding.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type ClientLookup interface {

--- a/apps-microservices/account-service-backend/internal/authserver/branding_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/branding_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeClientLookup struct {

--- a/apps-microservices/account-service-backend/internal/authserver/handler.go
+++ b/apps-microservices/account-service-backend/internal/authserver/handler.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/auth"
+	"account-service/internal/db"
 )
 
 type AuthCodeRepo interface {

--- a/apps-microservices/account-service-backend/internal/authserver/introspect.go
+++ b/apps-microservices/account-service-backend/internal/authserver/introspect.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/auth"
+	"account-service/internal/db"
 )
 
 type Revoker interface {

--- a/apps-microservices/account-service-backend/internal/authserver/introspect_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/introspect_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/auth"
+	"account-service/internal/db"
 )
 
 type fakeRevoke struct {

--- a/apps-microservices/account-service-backend/internal/authserver/register.go
+++ b/apps-microservices/account-service-backend/internal/authserver/register.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type ClientCreator interface {

--- a/apps-microservices/account-service-backend/internal/authserver/register_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/register_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeClientCreator struct {

--- a/apps-microservices/account-service-backend/internal/authserver/token_authcode_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/token_authcode_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeConsumeAuthCode struct {

--- a/apps-microservices/account-service-backend/internal/authserver/token_endpoint.go
+++ b/apps-microservices/account-service-backend/internal/authserver/token_endpoint.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/auth"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/auth"
+	"account-service/internal/db"
 )
 
 type AuthCodeConsumer interface {

--- a/apps-microservices/account-service-backend/internal/authserver/token_refresh_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/token_refresh_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeRotator struct {

--- a/apps-microservices/account-service-backend/internal/logout/broadcast.go
+++ b/apps-microservices/account-service-backend/internal/logout/broadcast.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type Decrypter interface {

--- a/apps-microservices/account-service-backend/internal/logout/broadcast_test.go
+++ b/apps-microservices/account-service-backend/internal/logout/broadcast_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type captureRepo struct {

--- a/apps-microservices/account-service-backend/internal/logout/queue.go
+++ b/apps-microservices/account-service-backend/internal/logout/queue.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type EventRepo interface {

--- a/apps-microservices/account-service-backend/internal/logout/queue_test.go
+++ b/apps-microservices/account-service-backend/internal/logout/queue_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 type fakeRepo struct {

--- a/apps-microservices/account-service-backend/internal/repository/audit_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/audit_repo.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 

--- a/apps-microservices/account-service-backend/internal/repository/audit_repo_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/audit_repo_test.go
@@ -5,7 +5,7 @@ package repository
 import (
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestAuditInsertAndList(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/repository/authcode_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/authcode_repo.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 

--- a/apps-microservices/account-service-backend/internal/repository/authcode_repo_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/authcode_repo_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestAuthCodeSingleUse(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/repository/logout_event_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/logout_event_repo.go
@@ -3,7 +3,7 @@ package repository
 import (
 	"time"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 

--- a/apps-microservices/account-service-backend/internal/repository/logout_event_repo_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/logout_event_repo_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestLogoutEventEnqueueAndPickPending(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/repository/oauth2_client_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/oauth2_client_repo.go
@@ -2,7 +2,7 @@ package repository
 
 import (
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 

--- a/apps-microservices/account-service-backend/internal/repository/oauth2_client_repo_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/oauth2_client_repo_test.go
@@ -5,7 +5,7 @@ package repository
 import (
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func TestOAuth2ClientCRUD(t *testing.T) {

--- a/apps-microservices/account-service-backend/internal/repository/refresh_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/refresh_repo.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 

--- a/apps-microservices/account-service-backend/internal/repository/refresh_repo_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/refresh_repo_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 )
 
 func newRefresh(sid, hash string) *db.OAuth2RefreshToken {

--- a/apps-microservices/account-service-backend/internal/repository/testhelp_test.go
+++ b/apps-microservices/account-service-backend/internal/repository/testhelp_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 	"gorm.io/gorm"
 )

--- a/apps-microservices/account-service-backend/internal/repository/user_repo.go
+++ b/apps-microservices/account-service-backend/internal/repository/user_repo.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hellopro/account-service/internal/db"
+	"account-service/internal/db"
 	"gorm.io/gorm"
 )
 


### PR DESCRIPTION
… path

EN: Rename Go module from github.com/hellopro/account-service to plain account-service so imports read account-service/internal/db instead of the full URL. The module never lived on github.com — the prefix was a historical default that bought nothing local. Shorter import lines, same code, no behavioural change.

47 .go files updated; build, vet, and full test suite all pass; service boots clean.

FR: Renomme le module Go de github.com/hellopro/account-service vers account-service tout court pour que les imports lisent account-service/internal/db au lieu de l'URL complète. Le module n'a jamais vécu sur github.com — le préfixe était un défaut historique qui n'apportait rien en local. Lignes d'import plus courtes, même code, aucun changement comportemental.

47 fichiers .go mis à jour ; build, vet et la suite de tests complète passent ; le service boote proprement.