### PR TITLE
feat: ingestion incrémentale Milvus -> Typesense par lots contrôlés

### DIFF
--- a/apps-microservices/opti-moteur-front/vm/delete_orphans.py
+++ b/apps-microservices/opti-moteur-front/vm/delete_orphans.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+delete_orphans.py
+==================
+Supprime les produits qui sont dans Typesense `produits_prod` mais qui
+ne sont PLUS dans Milvus (= produits supprimés/désactivés depuis la
+dernière ingestion).
+
+Le script `ingest_full_milvus.py` ne fait que UPSERT, il n'efface jamais.
+Sans ce script, Typesense accumule des "orphelins" au fil du temps.
+
+Stratégie :
+  1. Liste tous les `id` (= "{id_produit}_{chunk_number}") dans Milvus
+  2. Liste tous les `id` dans Typesense
+  3. Diff : Typesense - Milvus = orphelins à supprimer
+  4. Suppression batch via Typesense API delete_by_filter
+
+Usage :
+    cd /home/devhp/RAG-HP-PUB/apps-microservices/opti-moteur-front
+    export $(grep -E '^(ZILLIZ_|MILVUS_|TYPESENSE_)' .env | xargs)
+    export MILVUS_HOST="$ZILLIZ_URI"
+    export MILVUS_PORT="$ZILLIZ_PORT"
+    export MILVUS_USER="$ZILLIZ_USER"
+    export MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+    export TS_HOST="localhost"
+    export TS_PORT="8108"
+    export TS_API_KEY="hp_poc_2026"
+    export TS_COLLECTION="produits_prod"
+
+    cd vm
+    python3 delete_orphans.py
+
+Mode dry-run (compte sans supprimer) :
+    DRY_RUN=1 python3 delete_orphans.py
+"""
+import os
+import sys
+import time
+import requests
+from pymilvus import connections, Collection, utility
+
+# ========== CONFIG ==========
+MILVUS_HOST       = os.getenv("MILVUS_HOST")
+MILVUS_PORT       = os.getenv("MILVUS_PORT", "19530")
+MILVUS_USER       = os.getenv("MILVUS_USER", "")
+MILVUS_PASSWORD   = os.getenv("MILVUS_PASSWORD", "")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "produits_3")
+
+TS_HOST       = os.getenv("TS_HOST", "localhost")
+TS_PORT       = os.getenv("TS_PORT", "8108")
+TS_KEY        = os.getenv("TS_API_KEY", "hp_poc_2026")
+TS_COLLECTION = os.getenv("TS_COLLECTION", "produits_prod")
+
+DRY_RUN = os.getenv("DRY_RUN", "0") == "1"
+DELETE_BATCH_SIZE = int(os.getenv("DELETE_BATCH_SIZE", "100"))
+
+
+def get_milvus_ids():
+    """Retourne le set des `id_produit_chunk` actuels en Milvus."""
+    print(f"[INFO] Connexion Milvus {MILVUS_HOST}:{MILVUS_PORT}...")
+    kwargs = {"alias": "default", "host": MILVUS_HOST, "port": MILVUS_PORT}
+    if MILVUS_USER:
+        kwargs["user"] = MILVUS_USER
+        kwargs["password"] = MILVUS_PASSWORD
+    connections.connect(**kwargs)
+
+    if not utility.has_collection(MILVUS_COLLECTION):
+        print(f"[ERREUR] Collection Milvus '{MILVUS_COLLECTION}' introuvable")
+        sys.exit(1)
+
+    col = Collection(MILVUS_COLLECTION)
+    col.load()
+    print(f"[OK] Milvus '{MILVUS_COLLECTION}' charge : {col.num_entities} entities")
+
+    ids = set()
+    iterator = col.query_iterator(
+        expr=None,
+        output_fields=["id_produit", "chunk_number"],
+        batch_size=1000,
+    )
+    n = 0
+    start = time.time()
+    while True:
+        try:
+            batch = iterator.next()
+        except StopIteration:
+            break
+        if not batch:
+            break
+        for row in batch:
+            pid = row.get("id_produit")
+            ch = int(row.get("chunk_number", 0) or 0)
+            if pid:
+                ids.add(f"{pid}_{ch}")
+            n += 1
+        if n % 10000 == 0:
+            elapsed = time.time() - start
+            print(f"  ... {n} ids chargés ({elapsed:.0f}s)")
+
+    iterator.close()
+    col.release()
+    connections.disconnect("default")
+    print(f"[OK] {len(ids)} ids distincts dans Milvus")
+    return ids
+
+
+def get_typesense_ids():
+    """Retourne le set des `id` actuels dans Typesense produits_prod."""
+    print(f"[INFO] Export Typesense {TS_HOST}:{TS_PORT}/{TS_COLLECTION}...")
+    url = f"http://{TS_HOST}:{TS_PORT}/collections/{TS_COLLECTION}/documents/export?include_fields=id"
+    r = requests.get(
+        url,
+        headers={"X-TYPESENSE-API-KEY": TS_KEY},
+        stream=True,
+        timeout=600,
+    )
+    r.raise_for_status()
+
+    ids = set()
+    n = 0
+    start = time.time()
+    for line in r.iter_lines():
+        if not line:
+            continue
+        try:
+            import json
+            d = json.loads(line.decode("utf-8"))
+            if "id" in d:
+                ids.add(d["id"])
+                n += 1
+                if n % 50000 == 0:
+                    elapsed = time.time() - start
+                    print(f"  ... {n} ids chargés ({elapsed:.0f}s)")
+        except Exception:
+            continue
+    print(f"[OK] {len(ids)} ids distincts dans Typesense")
+    return ids
+
+
+def delete_orphans(orphan_ids):
+    """Supprime les ids orphelins par batch (Typesense delete_by_filter par id IN ...)."""
+    if not orphan_ids:
+        print("[OK] Aucun orphelin a supprimer")
+        return 0, 0
+
+    print(f"[INFO] Suppression de {len(orphan_ids)} orphelins...")
+    if DRY_RUN:
+        print("[DRY-RUN] Pas de suppression effective.")
+        # Afficher quelques exemples
+        sample = list(orphan_ids)[:10]
+        print(f"  Exemples : {sample}")
+        return 0, len(orphan_ids)
+
+    deleted = 0
+    errors = 0
+    orphan_list = list(orphan_ids)
+    for i in range(0, len(orphan_list), DELETE_BATCH_SIZE):
+        batch = orphan_list[i:i + DELETE_BATCH_SIZE]
+        # Typesense delete_by_filter : `id:= [id1,id2,id3]`
+        filter_expr = f"id:= [{','.join(batch)}]"
+        url = f"http://{TS_HOST}:{TS_PORT}/collections/{TS_COLLECTION}/documents"
+        try:
+            r = requests.delete(
+                url,
+                headers={"X-TYPESENSE-API-KEY": TS_KEY},
+                params={"filter_by": filter_expr, "batch_size": str(DELETE_BATCH_SIZE)},
+                timeout=60,
+            )
+            r.raise_for_status()
+            res = r.json()
+            deleted += res.get("num_deleted", 0)
+            if (i // DELETE_BATCH_SIZE) % 50 == 0:
+                print(f"  ... {deleted}/{len(orphan_ids)} supprimes")
+        except Exception as e:
+            print(f"[WARN] delete batch error: {e}")
+            errors += len(batch)
+
+    return deleted, errors
+
+
+def main():
+    if not MILVUS_HOST:
+        print("[ERREUR] MILVUS_HOST manquant"); sys.exit(1)
+
+    print(f"=== Suppression d'orphelins Typesense ===")
+    print(f"Source Milvus : {MILVUS_COLLECTION}")
+    print(f"Cible Typesense : {TS_COLLECTION}")
+    print(f"DRY_RUN : {DRY_RUN}")
+    print()
+
+    milvus_ids = get_milvus_ids()
+    typesense_ids = get_typesense_ids()
+
+    orphans = typesense_ids - milvus_ids
+    only_in_milvus = milvus_ids - typesense_ids
+
+    print()
+    print(f"=== Diff ===")
+    print(f"  Dans Milvus uniquement     : {len(only_in_milvus)} (= a ingerer via ingest_full_milvus.py)")
+    print(f"  Dans Typesense uniquement  : {len(orphans)} (= orphelins a supprimer)")
+    print(f"  Dans les deux              : {len(milvus_ids & typesense_ids)}")
+    print()
+
+    if orphans:
+        deleted, errors = delete_orphans(orphans)
+        print(f"[DONE] {deleted} orphelins supprimes, {errors} erreurs")
+    else:
+        print("[OK] Pas d'orphelins, Typesense est synchronise.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps-microservices/opti-moteur-front/vm/ingest_full_milvus.py
+++ b/apps-microservices/opti-moteur-front/vm/ingest_full_milvus.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+ingest_full_milvus.py
+======================
+Ingestion COMPLÈTE de tous les produits Milvus -> Typesense `produits_prod`.
+
+Différence vs ingest_by_categories.py :
+  - Pas besoin de fournir la liste de catégories
+  - Itère sur TOUS les produits Milvus sans filtre catégorie
+  - Cible produits_prod par défaut (collection prod)
+
+Usage :
+    cd /home/devhp/RAG-HP-PUB/apps-microservices/opti-moteur-front
+
+    # Charger les creds depuis le .env du service
+    export $(grep -E '^(ZILLIZ_|MILVUS_|TYPESENSE_)' .env | xargs)
+
+    # Renommer pour matcher les noms attendus
+    export MILVUS_HOST="$ZILLIZ_URI"
+    export MILVUS_PORT="$ZILLIZ_PORT"
+    export MILVUS_USER="$ZILLIZ_USER"
+    export MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+    export MILVUS_COLLECTION="produits_3"
+    export TS_HOST="localhost"
+    export TS_PORT="8108"
+    export TS_API_KEY="hp_poc_2026"
+    export TS_COLLECTION="produits_prod"   # IMPORTANT : cibler la collection prod
+
+    # Lancer (estimation : 2-4h selon volume Milvus, ~2.6M chunks)
+    cd vm
+    nohup python3 -u ingest_full_milvus.py > /tmp/ingest_full.log 2>&1 &
+    echo "PID: $!"
+
+    # Monitoring
+    tail -f /tmp/ingest_full.log
+    curl -s -H "X-TYPESENSE-API-KEY: hp_poc_2026" \\
+      http://localhost:8108/collections/produits_prod \\
+      | python3 -c 'import sys,json; print("docs:", json.load(sys.stdin)["num_documents"])'
+
+Reprise après interruption :
+    Re-lancer la même commande. L'upsert dédoublonne sur `id`.
+"""
+import json
+import os
+import shutil
+import sys
+import time
+import requests
+import typesense
+from pymilvus import connections, Collection, utility
+
+# ========== CONFIG ==========
+MILVUS_HOST       = os.getenv("MILVUS_HOST")
+MILVUS_PORT       = os.getenv("MILVUS_PORT", "19530")
+MILVUS_USER       = os.getenv("MILVUS_USER", "")
+MILVUS_PASSWORD   = os.getenv("MILVUS_PASSWORD", "")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "produits_3")
+
+TS_HOST       = os.getenv("TS_HOST", "localhost")
+TS_PORT       = os.getenv("TS_PORT", "8108")
+TS_KEY        = os.getenv("TS_API_KEY", "hp_poc_2026")
+TS_COLLECTION = os.getenv("TS_COLLECTION", "produits_prod")  # PROD par défaut
+
+TS_BATCH = int(os.getenv("TS_BATCH", "1000"))
+DISK_THRESHOLD_GB = float(os.getenv("DISK_THRESHOLD_GB", "3.0"))
+
+# Filtre optionnel (laisse vide pour tout prendre)
+EXTRA_FILTER = os.getenv("EXTRA_FILTER", "")
+
+FIELDS = [
+    "id_produit", "nom_produit", "text",
+    "categorie", "id_categorie",
+    "fournisseur", "id_fournisseur", "marque", "fabricant",
+    "etat", "affichage", "statut",
+    "prix_ht", "prix_ttc", "stock", "delai_livraison",
+    "ean", "sku", "reference",
+    "date_ajout", "date_maj",
+    "chunk_number", "total_chunks",
+    "embedding",
+]
+
+
+# ========== HELPERS ==========
+def disk_free_gb(path="/"):
+    return shutil.disk_usage(path).free / (1024**3)
+
+
+def ts_doc_count(collection):
+    try:
+        r = requests.get(
+            f"http://{TS_HOST}:{TS_PORT}/collections/{collection}",
+            headers={"X-TYPESENSE-API-KEY": TS_KEY}, timeout=5,
+        )
+        return r.json().get("num_documents", 0)
+    except Exception:
+        return 0
+
+
+def parse_price(v):
+    if not v: return None
+    try:
+        return float(str(v).replace(",", ".").replace(" ", "").replace(" ", ""))
+    except (ValueError, TypeError):
+        return None
+
+
+def row_to_doc(row):
+    doc = {
+        "id":              f"{row['id_produit']}_{int(row.get('chunk_number', 0) or 0)}",
+        "id_produit":      str(row.get("id_produit", "")),
+        "nom_produit":     (row.get("nom_produit") or "")[:500],
+        "text":            (row.get("text") or "")[:2000],
+        "categorie":       row.get("categorie") or "",
+        "id_categorie":    str(row.get("id_categorie") or ""),
+        "fournisseur":     row.get("fournisseur") or "",
+        "id_fournisseur":  str(row.get("id_fournisseur") or ""),
+        "marque":          row.get("marque") or "",
+        "fabricant":       row.get("fabricant") or "",
+        "etat":            row.get("etat") or "",
+        "affichage":       row.get("affichage") or "",
+        "statut":          row.get("statut") or "",
+        "stock":           row.get("stock") or "",
+        "delai_livraison": row.get("delai_livraison") or "",
+        "ean":             row.get("ean") or "",
+        "sku":             row.get("sku") or "",
+        "reference":       row.get("reference") or "",
+        "date_ajout":      row.get("date_ajout") or "",
+        "date_maj":        row.get("date_maj") or "",
+        "chunk_number":    int(row.get("chunk_number", 0) or 0),
+        "total_chunks":    int(row.get("total_chunks", 1) or 1),
+        "embedding":       list(row["embedding"]),
+    }
+    ph = parse_price(row.get("prix_ht"))
+    if ph is not None: doc["prix_ht"] = ph
+    pt = parse_price(row.get("prix_ttc"))
+    if pt is not None: doc["prix_ttc"] = pt
+    return doc
+
+
+def ts_flush(jsonl_batch):
+    if not jsonl_batch:
+        return 0, 0
+    body = "\n".join(jsonl_batch).encode("utf-8")
+    url = f"http://{TS_HOST}:{TS_PORT}/collections/{TS_COLLECTION}/documents/import?action=upsert"
+    try:
+        r = requests.post(
+            url,
+            headers={
+                "X-TYPESENSE-API-KEY": TS_KEY,
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+            data=body,
+            timeout=300,
+        )
+        r.raise_for_status()
+        text = r.text
+    except Exception as e:
+        print(f"\n[WARN] flush error: {e}", file=sys.stderr)
+        return 0, len(jsonl_batch)
+    ok = text.count('"success":true')
+    err = text.count('"success":false')
+    return ok, err
+
+
+# ========== MAIN ==========
+def main():
+    if not MILVUS_HOST:
+        print("[ERREUR] MILVUS_HOST manquant"); sys.exit(1)
+
+    print(f"[INFO] Milvus      : {MILVUS_HOST}:{MILVUS_PORT}")
+    print(f"[INFO] Source      : {MILVUS_COLLECTION}")
+    print(f"[INFO] Typesense   : {TS_HOST}:{TS_PORT}")
+    print(f"[INFO] Cible coll. : {TS_COLLECTION}")
+    print(f"[INFO] EXTRA_FILTER: {EXTRA_FILTER!r}")
+
+    # Health checks
+    try:
+        h = requests.get(f"http://{TS_HOST}:{TS_PORT}/health", timeout=5).json()
+        print(f"[OK] Typesense health: {h}")
+    except Exception as e:
+        print(f"[ERREUR] Typesense unreachable: {e}"); sys.exit(1)
+
+    docs0 = ts_doc_count(TS_COLLECTION)
+    if docs0 == 0:
+        print(f"[WARN] Collection '{TS_COLLECTION}' vide ou inexistante. La creer d'abord ?")
+        print(f"       Voir scripts/ingest_by_categories.py qui cree la collection si absente.")
+        ans = input("Continuer quand meme ? (o/N) ").strip().lower()
+        if ans not in ("o", "oui", "y", "yes"):
+            sys.exit(1)
+
+    # Connexion Milvus
+    print(f"[INFO] Connexion Milvus...")
+    kwargs = {"alias": "default", "host": MILVUS_HOST, "port": MILVUS_PORT}
+    if MILVUS_USER:
+        kwargs["user"] = MILVUS_USER
+        kwargs["password"] = MILVUS_PASSWORD
+    connections.connect(**kwargs)
+
+    if not utility.has_collection(MILVUS_COLLECTION):
+        print(f"[ERREUR] Collection Milvus '{MILVUS_COLLECTION}' introuvable")
+        sys.exit(1)
+
+    col = Collection(MILVUS_COLLECTION)
+    col.load()
+    n_total = col.num_entities
+    print(f"[OK] Milvus '{MILVUS_COLLECTION}' chargee : {n_total} entities")
+
+    try:
+        disk0 = disk_free_gb("/")
+        print(f"[BASELINE] Disque libre: {disk0:.1f} GB | Docs Typesense: {docs0}")
+        print("=" * 90)
+
+        global_start = time.time()
+        global_chunks = 0
+        global_ok = 0
+        global_err = 0
+
+        # Iteration TOUT Milvus (avec filter optionnel)
+        # Le query_iterator pagine automatiquement par batch de 500
+        expr = EXTRA_FILTER if EXTRA_FILTER else ""
+
+        try:
+            iterator = col.query_iterator(
+                expr=expr if expr else None,
+                output_fields=FIELDS,
+                batch_size=500,
+            )
+        except Exception as e:
+            print(f"[ERREUR] query_iterator failed: {e}")
+            sys.exit(1)
+
+        ts_buffer = []
+        last_print = time.time()
+
+        while True:
+            try:
+                batch = iterator.next()
+            except StopIteration:
+                break
+            if not batch:
+                break
+
+            for row in batch:
+                try:
+                    doc = row_to_doc(row)
+                except Exception as e:
+                    print(f"\n[WARN] row_to_doc error: {e}")
+                    global_err += 1
+                    continue
+                ts_buffer.append(json.dumps(doc, ensure_ascii=False))
+                global_chunks += 1
+                if len(ts_buffer) >= TS_BATCH:
+                    ok, err = ts_flush(ts_buffer)
+                    global_ok += ok
+                    global_err += err
+                    ts_buffer = []
+
+            # Print progress every 30s
+            now = time.time()
+            if now - last_print > 30:
+                last_print = now
+                disk_now = disk_free_gb("/")
+                docs_now = ts_doc_count(TS_COLLECTION)
+                elapsed = now - global_start
+                rate = global_ok / max(elapsed, 1)
+                eta_min = (n_total - global_chunks) / max(rate, 1) / 60
+                print(f"  [{elapsed/60:5.1f}min] chunks={global_chunks:>7} "
+                      f"ok={global_ok:>7} err={global_err:>4} "
+                      f"rate={rate:>4.0f} docs/s | TS={docs_now:>7} "
+                      f"disk={disk_now:>5.1f}GB | ETA {eta_min:.0f}min")
+
+                # Garde-fou disque
+                if disk_now < DISK_THRESHOLD_GB:
+                    print(f"\n[STOP] Disque < {DISK_THRESHOLD_GB} GB, arret preventif.")
+                    break
+
+        # Flush final
+        if ts_buffer:
+            ok, err = ts_flush(ts_buffer)
+            global_ok += ok
+            global_err += err
+
+        try:
+            iterator.close()
+        except Exception:
+            pass
+
+        # Resume
+        elapsed = time.time() - global_start
+        disk_final = disk_free_gb("/")
+        docs_final = ts_doc_count(TS_COLLECTION)
+        print("\n" + "=" * 90)
+        print(f"[DONE] {global_ok} chunks ingeres en {elapsed/60:.1f} min ({global_err} erreurs)")
+        print(f"       Debit  : {global_ok/max(elapsed,1):.0f} docs/s")
+        print(f"       Docs TS: {docs0} -> {docs_final} (+{docs_final-docs0})")
+        print(f"       Disque : {disk0:.1f} -> {disk_final:.1f} GB (-{disk0-disk_final:.2f})")
+
+    finally:
+        col.release()
+        connections.disconnect("default")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps-microservices/opti-moteur-front/vm/list_missing_categories.py
+++ b/apps-microservices/opti-moteur-front/vm/list_missing_categories.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+list_missing_categories.py
+===========================
+Liste les categories de Milvus qui n'ont PAS encore ete ingerees dans Typesense
+(= toutes les categories Milvus MOINS celles deja dans batch 1 + batch 2).
+
+Outputs :
+  - categories_missing.txt          : 1 categorie par ligne (input pour ingest_by_categories.py)
+  - categories_missing_chunks_NN.txt : split en lots de N categories (default 100)
+
+Usage :
+    cd /home/devhp/RAG-HP-PUB/apps-microservices/opti-moteur-front
+    export $(grep -E '^(ZILLIZ_|MILVUS_)' .env | xargs)
+    export MILVUS_HOST="$ZILLIZ_URI" MILVUS_PORT="$ZILLIZ_PORT"
+    export MILVUS_USER="$ZILLIZ_USER" MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+    export MILVUS_COLLECTION="produits_3"
+
+    cd vm
+    python3 list_missing_categories.py
+
+    # Avec taille de chunk personnalisee
+    CHUNK_SIZE=50 python3 list_missing_categories.py
+"""
+import os
+import sys
+import time
+from pymilvus import connections, Collection, utility
+
+
+MILVUS_HOST       = os.getenv("MILVUS_HOST")
+MILVUS_PORT       = os.getenv("MILVUS_PORT", "19530")
+MILVUS_USER       = os.getenv("MILVUS_USER", "")
+MILVUS_PASSWORD   = os.getenv("MILVUS_PASSWORD", "")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "produits_3")
+
+# Repo root (parent de apps-microservices)
+REPO_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "..", ".."
+))
+RUBRIQUES_DIR = os.path.join(REPO_ROOT, "rubriques")
+
+# Fichiers existants des batches deja ingeres
+EXISTING_FILES = [
+    os.path.join(RUBRIQUES_DIR, "categories_from_roots.txt"),     # Batch 1
+    os.path.join(RUBRIQUES_DIR, "categories_from_roots_2.txt"),   # Batch 2
+]
+
+OUTPUT_FILE = os.path.join(RUBRIQUES_DIR, "categories_missing.txt")
+CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "100"))
+
+
+def load_existing_categories():
+    """Charge les categories deja ingerees (batch 1 + 2)."""
+    existing = set()
+    for path in EXISTING_FILES:
+        if not os.path.exists(path):
+            print(f"[WARN] {path} introuvable, on continue sans")
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    existing.add(line)
+        print(f"[OK] {path} : {len(existing)} categories cumulees")
+    return existing
+
+
+def get_all_milvus_categories():
+    """Retourne le set des categories distinctes presentes en Milvus."""
+    if not MILVUS_HOST:
+        print("[ERREUR] MILVUS_HOST manquant"); sys.exit(1)
+
+    print(f"[INFO] Connexion Milvus {MILVUS_HOST}:{MILVUS_PORT}...")
+    kwargs = {"alias": "default", "host": MILVUS_HOST, "port": MILVUS_PORT}
+    if MILVUS_USER:
+        kwargs["user"] = MILVUS_USER
+        kwargs["password"] = MILVUS_PASSWORD
+    connections.connect(**kwargs)
+
+    if not utility.has_collection(MILVUS_COLLECTION):
+        print(f"[ERREUR] Collection '{MILVUS_COLLECTION}' introuvable")
+        sys.exit(1)
+
+    col = Collection(MILVUS_COLLECTION)
+    col.load()
+    print(f"[OK] Milvus '{MILVUS_COLLECTION}' charge : {col.num_entities} entities")
+
+    print(f"[INFO] Itère sur tous les produits pour collecter les categories distinctes...")
+    cats = set()
+    iterator = col.query_iterator(
+        expr="categorie != ''",
+        output_fields=["categorie"],
+        batch_size=2000,
+    )
+    n = 0
+    start = time.time()
+    while True:
+        try:
+            batch = iterator.next()
+        except StopIteration:
+            break
+        if not batch:
+            break
+        for row in batch:
+            c = row.get("categorie")
+            if c:
+                cats.add(c.strip())
+            n += 1
+        if n % 50000 == 0:
+            print(f"  ... {n} rows iteres, {len(cats)} categories distinctes")
+
+    iterator.close()
+    col.release()
+    connections.disconnect("default")
+
+    elapsed = time.time() - start
+    print(f"[OK] {len(cats)} categories distinctes en Milvus (en {elapsed:.0f}s)")
+    return cats
+
+
+def split_into_chunks(items, chunk_size):
+    """Decoupe une liste en chunks de taille chunk_size."""
+    items = sorted(items)
+    chunks = []
+    for i in range(0, len(items), chunk_size):
+        chunks.append(items[i:i + chunk_size])
+    return chunks
+
+
+def main():
+    print("=== List missing categories (Milvus -> Typesense) ===\n")
+
+    # 1. Categories deja ingerees
+    existing = load_existing_categories()
+    print(f"[OK] Total categories deja ingerees (batch 1 + 2) : {len(existing)}\n")
+
+    # 2. Toutes categories Milvus
+    all_milvus = get_all_milvus_categories()
+    print()
+
+    # 3. Diff
+    missing = all_milvus - existing
+    extra = existing - all_milvus  # categories ingerees qui n'existent plus en Milvus
+
+    print(f"=== Diff ===")
+    print(f"  Categories Milvus           : {len(all_milvus)}")
+    print(f"  Categories deja ingerees    : {len(existing)}")
+    print(f"  Categories communes         : {len(all_milvus & existing)}")
+    print(f"  MANQUANTES (a ingerer)      : {len(missing)}")
+    print(f"  Plus en Milvus (deprecated) : {len(extra)}")
+    print()
+
+    if not missing:
+        print("[OK] Toutes les categories Milvus sont deja ingerees. Rien a faire.")
+        return
+
+    # 4. Ecriture du fichier global
+    os.makedirs(RUBRIQUES_DIR, exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        f.write(f"# Categories manquantes a ingerer (Milvus - batch1 - batch2)\n")
+        f.write(f"# Genere : {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"# Total : {len(missing)} categories\n\n")
+        for c in sorted(missing):
+            f.write(c + "\n")
+    print(f"[OK] Fichier ecrit : {OUTPUT_FILE}")
+
+    # 5. Split en chunks
+    chunks = split_into_chunks(missing, CHUNK_SIZE)
+    print(f"\n[INFO] Decoupage en {len(chunks)} chunks de {CHUNK_SIZE} categories")
+
+    for i, chunk in enumerate(chunks, 1):
+        chunk_file = os.path.join(
+            RUBRIQUES_DIR,
+            f"categories_missing_chunk_{i:03d}_of_{len(chunks):03d}.txt"
+        )
+        with open(chunk_file, "w", encoding="utf-8") as f:
+            f.write(f"# Chunk {i}/{len(chunks)} - {len(chunk)} categories\n\n")
+            for c in chunk:
+                f.write(c + "\n")
+        print(f"  - {chunk_file} ({len(chunk)} cat.)")
+
+    print(f"\n[NEXT STEPS]")
+    print(f"  Lancer un chunk a la fois avec ingest_by_categories.py :")
+    print(f"")
+    print(f"  export CATEGORIES_FILE={RUBRIQUES_DIR}/categories_missing_chunk_001_of_{len(chunks):03d}.txt")
+    print(f"  export TS_COLLECTION=produits_prod   # collection prod")
+    print(f"  python3 ingest_by_categories.py")
+    print(f"")
+    print(f"  Une fois le chunk 001 termine, passer au 002, etc.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps-microservices/opti-moteur-front/vm/run_chunk.sh
+++ b/apps-microservices/opti-moteur-front/vm/run_chunk.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# run_chunk.sh
+# =============
+# Lance l'ingestion d'UN chunk de categories avec :
+#   - Garde-fou disque (DISK_THRESHOLD_GB)
+#   - Logs daté dans /tmp/
+#   - Trap Ctrl+C pour arret propre
+#   - Affichage clair de la progression
+#
+# Usage :
+#   ./run_chunk.sh categories_missing_chunk_001_of_023.txt
+#   ./run_chunk.sh categories_missing_chunk_001_of_023.txt produits_prod
+#
+# Pour arreter pendant l'execution :
+#   Ctrl+C OU kill -SIGTERM <PID>
+
+set -e
+
+# === ARGS ===
+CHUNK_FILE="${1:-}"
+TS_COLLECTION="${2:-produits_prod}"
+
+if [ -z "$CHUNK_FILE" ]; then
+    echo "[ERREUR] Usage: $0 <chunk_file.txt> [ts_collection]"
+    echo ""
+    echo "Exemples :"
+    echo "  $0 ../../../rubriques/categories_missing_chunk_001_of_023.txt"
+    echo "  $0 ../../../rubriques/categories_missing_chunk_001_of_023.txt produits_prod"
+    exit 1
+fi
+
+if [ ! -f "$CHUNK_FILE" ]; then
+    echo "[ERREUR] Fichier $CHUNK_FILE introuvable"
+    exit 1
+fi
+
+# === CONFIG ===
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISK_THRESHOLD_GB="${DISK_THRESHOLD_GB:-3.0}"
+CHUNK_NAME="$(basename "$CHUNK_FILE" .txt)"
+LOG_FILE="/tmp/ingest_${CHUNK_NAME}_$(date +%Y%m%d_%H%M%S).log"
+PIDFILE="/tmp/ingest_${CHUNK_NAME}.pid"
+
+# === HEALTH CHECKS ===
+echo "=========================================="
+echo "Run chunk : $CHUNK_FILE"
+echo "Collection: $TS_COLLECTION"
+echo "Log file  : $LOG_FILE"
+echo "Disk min  : $DISK_THRESHOLD_GB GB"
+echo "=========================================="
+
+# Verifier l'espace disque AVANT
+disk_now=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+echo "[INFO] Espace disque actuel : ${disk_now} GB"
+if [ "$disk_now" -lt "$(echo "$DISK_THRESHOLD_GB" | cut -d. -f1)" ]; then
+    echo "[ERREUR] Espace disque (${disk_now} GB) < seuil ($DISK_THRESHOLD_GB GB). ABORT."
+    exit 2
+fi
+
+# Verifier env vars Milvus + Typesense
+for var in MILVUS_HOST MILVUS_PORT TS_HOST TS_PORT TS_API_KEY; do
+    if [ -z "${!var}" ]; then
+        echo "[ERREUR] Variable $var manquante. Source .env d'abord :"
+        echo "  cd /home/devhp/RAG-HP-PUB/apps-microservices/opti-moteur-front"
+        echo "  export \$(grep -E '^(ZILLIZ_|MILVUS_|TS_)' .env | xargs)"
+        echo "  export MILVUS_HOST=\$ZILLIZ_URI MILVUS_PORT=\$ZILLIZ_PORT"
+        echo "  export MILVUS_USER=\$ZILLIZ_USER MILVUS_PASSWORD=\$ZILLIZ_PASSWORD"
+        exit 3
+    fi
+done
+
+# === LANCEMENT ===
+nb_cats=$(grep -cv "^#" "$CHUNK_FILE" | grep -v "^$" | wc -l)
+echo "[INFO] $nb_cats categories dans ce chunk"
+echo ""
+
+# Trap Ctrl+C : kill le PID enfant proprement
+cleanup() {
+    if [ -f "$PIDFILE" ]; then
+        local pid=$(cat "$PIDFILE")
+        echo ""
+        echo "[CLEANUP] Stopping PID $pid..."
+        kill -SIGTERM "$pid" 2>/dev/null || true
+        sleep 2
+        kill -SIGKILL "$pid" 2>/dev/null || true
+        rm -f "$PIDFILE"
+    fi
+    echo "[CLEANUP] Done. Log : $LOG_FILE"
+}
+trap cleanup EXIT INT TERM
+
+# Lancer en background mais wait sur lui
+export CATEGORIES_FILE="$CHUNK_FILE"
+export TS_COLLECTION="$TS_COLLECTION"
+export DISK_THRESHOLD_GB="$DISK_THRESHOLD_GB"
+
+python3 -u "$SCRIPT_DIR/ingest_by_categories.py" > "$LOG_FILE" 2>&1 &
+PID=$!
+echo $PID > "$PIDFILE"
+echo "[INFO] PID enfant : $PID"
+echo "[INFO] Pour suivre en direct : tail -f $LOG_FILE"
+echo "[INFO] Pour arreter : Ctrl+C OU kill $PID"
+echo ""
+
+# Suivi en tail -f tant que le process tourne
+tail -f "$LOG_FILE" &
+TAIL_PID=$!
+
+wait $PID 2>/dev/null
+EXIT_CODE=$?
+
+kill $TAIL_PID 2>/dev/null || true
+rm -f "$PIDFILE"
+
+echo ""
+echo "=========================================="
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "[DONE] Chunk termine avec succes"
+else
+    echo "[ERREUR] Chunk termine avec code $EXIT_CODE"
+fi
+
+# Stats finales
+disk_after=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+echo "[INFO] Disque libre : ${disk_now} GB -> ${disk_after} GB (-$((disk_now - disk_after)) GB)"
+echo "[INFO] Log complet  : $LOG_FILE"
+echo "=========================================="
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Ajoute 4 scripts dans `apps-microservices/opti-moteur-front/vm/` pour compléter l'ingestion Typesense `produits_prod` sur tous les produits Milvus, avec contrôle d'espace disque et reprise possible.

## Scripts ajoutés

### 1. `list_missing_categories.py`
Identifie les catégories Milvus pas encore ingérées (en soustrayant batch 1 `categories_from_roots.txt` + batch 2 `categories_from_roots_2.txt`). Génère :
- `rubriques/categories_missing.txt` (liste globale)
- `rubriques/categories_missing_chunk_NNN_of_NNN.txt` (lots de 100)

### 2. `run_chunk.sh`
Wrapper qui lance `ingest_by_categories.py` sur **un chunk** avec :
- Garde-fou disque (`DISK_THRESHOLD_GB=3.0` par défaut)
- Trap Ctrl+C pour arrêt propre + cleanup PID enfant
- Log daté dans `/tmp/ingest_<chunk>_<date>.log`
- Suivi `tail -f` en parallèle

### 3. `ingest_full_milvus.py`
Alternative : itère sur **TOUT Milvus** sans filtre catégorie. Cible `produits_prod` par défaut. À utiliser uniquement pour une ingestion blanche depuis 0.

### 4. `delete_orphans.py`
Compare ids Milvus vs Typesense, supprime les orphelins. Mode `DRY_RUN=1` pour compter sans supprimer.

## Test plan

### Sur la VM (`/home/devhp/RAG-HP-PUB`)

- [ ] `git pull origin features/poc` (après merge de cette PR)
- [ ] `cd apps-microservices/opti-moteur-front && export $(grep -E '^(ZILLIZ_|MILVUS_|TYPESENSE_)' .env | xargs)`
- [ ] `export MILVUS_HOST=$ZILLIZ_URI MILVUS_PORT=$ZILLIZ_PORT MILVUS_USER=$ZILLIZ_USER MILVUS_PASSWORD=$ZILLIZ_PASSWORD MILVUS_COLLECTION=produits_3 TS_HOST=localhost TS_PORT=8108 TS_API_KEY=hp_poc_2026`
- [ ] Lancer `python3 vm/list_missing_categories.py` → vérifier le compte de catégories manquantes
- [ ] Lancer un premier chunk : `cd vm && ./run_chunk.sh ../../../rubriques/categories_missing_chunk_001_of_NNN.txt produits_prod`
- [ ] Vérifier l'incrémentation des docs Typesense : `curl -s -H "X-TYPESENSE-API-KEY: hp_poc_2026" http://localhost:8108/collections/produits_prod | python3 -c 'import sys,json; print(json.load(sys.stdin)["num_documents"])'`
- [ ] Si OK, enchaîner les chunks suivants
- [ ] Une fois tous les chunks faits : `DRY_RUN=1 python3 vm/delete_orphans.py` puis sans dry-run

### Contrôles pendant l'exécution
- [ ] Espace disque : `df -h /` (la borne `DISK_THRESHOLD_GB=3.0` arrête auto si <3GB)
- [ ] Arrêt propre : `Ctrl+C` (cleanup PID enfant) ou `kill $(cat /tmp/ingest_<chunk>.pid)`
- [ ] Reprise : relancer le même chunk → upsert idempotent, pas de doublon

## Notes

- Branche prod = `features/poc` (mémorisé dans `GUIDE_REPRISE_V4.md`)
- Aucune modification du code existant — uniquement de nouveaux fichiers dans `vm/`
- Les credentials viennent de `.env` (déjà en place pour batch 1+2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)