### PR TITLE
feat: sync Typesense quotidien Milvus -> Typesense (cron Ecritel + API VM)

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/api_router.py
+++ b/apps-microservices/opti-moteur-front/app/router/api_router.py
@@ -5,9 +5,11 @@ from .search import router as search_router
 from .search_text import router as search_text_router
 from .ingest import router as ingest_router
 from .admin import router as admin_router
+from .sync import router as sync_router
 
 api_router = APIRouter()
 api_router.include_router(search_router)
 api_router.include_router(search_text_router)
 api_router.include_router(ingest_router)
 api_router.include_router(admin_router)
+api_router.include_router(sync_router)

--- a/apps-microservices/opti-moteur-front/app/router/sync.py
+++ b/apps-microservices/opti-moteur-front/app/router/sync.py
@@ -1,0 +1,109 @@
+"""Routes de synchronisation incrementale Milvus -> Typesense."""
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Header
+from pydantic import BaseModel, Field
+
+from app.services.sync_service import sync_incremental
+
+
+router = APIRouter(prefix="/sync", tags=["Sync"])
+
+
+# Token jetable pour authentifier les appels du cron Ecritel.
+# À changer en prod via env var SYNC_TOKEN.
+import os
+SYNC_TOKEN = os.getenv("SYNC_TOKEN", "hp_sync_2026_04_30_xZ7q")
+
+
+class SyncRequest(BaseModel):
+    since: Optional[str] = Field(
+        None,
+        description="ISO datetime: filtre date_maj >= since. Default = 24h ago.",
+        example="2026-05-04T00:00:00",
+    )
+    ts_collection: Optional[str] = Field(
+        None,
+        description="Collection Typesense cible. Default = settings.TYPESENSE_COLLECTION.",
+    )
+    delete_orphans: bool = Field(
+        True,
+        description="Si True, supprime de Typesense les produits plus en Milvus.",
+    )
+    batch_size: int = Field(1000, ge=100, le=10000)
+
+
+class SyncResponse(BaseModel):
+    ts_collection: str
+    since_iso: str
+    milvus_recent_rows: int
+    ts_upserted: int
+    ts_upsert_errors: int
+    ts_orphans_deleted: int
+    duration_s: float
+    ts_docs_before: int
+    ts_docs_after: int
+
+
+@router.post(
+    "/incremental",
+    response_model=SyncResponse,
+    summary="Sync incremental Milvus -> Typesense (cron quotidien Ecritel)",
+)
+async def sync_incremental_endpoint(
+    req: SyncRequest,
+    x_sync_token: Optional[str] = Header(None, description="Token de securite (header)"),
+):
+    """
+    Endpoint appele par le cron PHP Ecritel quotidiennement.
+
+    Effet :
+      1. Upsert les produits Milvus modifies depuis `since` (= NEW + UPDATED)
+      2. Supprime les orphelins Typesense (= DELETED en Milvus)
+
+    Securite : header `X-Sync-Token` requis.
+    Duree typique : 5-30 minutes selon le volume de modifs.
+    """
+    if x_sync_token != SYNC_TOKEN:
+        raise HTTPException(status_code=403, detail="Invalid or missing X-Sync-Token header")
+
+    try:
+        result = sync_incremental(
+            since_iso=req.since,
+            ts_collection=req.ts_collection,
+            delete_orphans=req.delete_orphans,
+            batch_size=req.batch_size,
+        )
+        return SyncResponse(**result)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Sync failed: {str(e)}")
+
+
+@router.get(
+    "/health",
+    summary="Healthcheck du sync (verifie Milvus + Typesense)",
+)
+async def sync_health():
+    """Verifie que Milvus et Typesense sont accessibles."""
+    from app.core.milvus_connector import milvus
+    from app.core.typesense_client import typesense_client
+    from app.core.credentials import settings
+
+    health = {"status": "ok", "milvus": "?", "typesense": "?"}
+
+    try:
+        col = milvus.collection
+        n = col.num_entities
+        health["milvus"] = f"ok ({n} entities)"
+    except Exception as e:
+        health["milvus"] = f"error: {e}"
+        health["status"] = "degraded"
+
+    try:
+        info = typesense_client.collections[settings.TYPESENSE_COLLECTION].retrieve()
+        health["typesense"] = f"ok ({info.get('num_documents', 0)} docs)"
+    except Exception as e:
+        health["typesense"] = f"error: {e}"
+        health["status"] = "degraded"
+
+    return health

--- a/apps-microservices/opti-moteur-front/app/services/sync_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/sync_service.py
@@ -1,0 +1,258 @@
+"""
+Sync incremental Milvus -> Typesense.
+
+Pour chaque appel :
+  1. Upsert (insert/update) les produits Milvus modifies depuis `since`
+     (champ date_maj). Couvre les NOUVEAUX et les MAJ.
+  2. Supprime de Typesense les produits qui ne sont plus en Milvus
+     (= orphelins, comparaison full ids).
+
+Retourne stats pour monitoring.
+"""
+import json
+import logging
+import shutil
+import time
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Any
+
+import requests
+from app.core.credentials import settings
+from app.core.milvus_connector import milvus
+from app.core.typesense_client import typesense_client
+from app.services.ingestion_service import _row_to_doc, MILVUS_OUTPUT_FIELDS
+
+logger = logging.getLogger(__name__)
+
+
+def _ts_url(path: str) -> str:
+    proto = settings.TYPESENSE_PROTOCOL or "http"
+    host = settings.TYPESENSE_HOST
+    port = settings.TYPESENSE_PORT
+    return f"{proto}://{host}:{port}{path}"
+
+
+def _ts_headers() -> Dict[str, str]:
+    return {
+        "X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY,
+        "Content-Type": "application/json",
+    }
+
+
+def _ts_doc_count(collection: str) -> int:
+    try:
+        r = requests.get(_ts_url(f"/collections/{collection}"), headers=_ts_headers(), timeout=10)
+        return r.json().get("num_documents", 0)
+    except Exception:
+        return 0
+
+
+def _ts_flush_upsert(collection: str, jsonl_batch: List[str]) -> tuple[int, int]:
+    if not jsonl_batch:
+        return 0, 0
+    body = "\n".join(jsonl_batch).encode("utf-8")
+    url = _ts_url(f"/collections/{collection}/documents/import?action=upsert")
+    try:
+        r = requests.post(
+            url,
+            headers={
+                "X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY,
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+            data=body,
+            timeout=300,
+        )
+        r.raise_for_status()
+        text = r.text
+    except Exception as e:
+        logger.error(f"ts_flush_upsert error: {e}")
+        return 0, len(jsonl_batch)
+    ok = text.count('"success":true')
+    err = text.count('"success":false')
+    return ok, err
+
+
+def _ts_export_ids(collection: str) -> set:
+    """Export tous les `id` actuels dans Typesense."""
+    url = _ts_url(f"/collections/{collection}/documents/export?include_fields=id")
+    r = requests.get(
+        url,
+        headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY},
+        stream=True,
+        timeout=600,
+    )
+    r.raise_for_status()
+    ids = set()
+    for line in r.iter_lines():
+        if not line:
+            continue
+        try:
+            d = json.loads(line.decode("utf-8"))
+            if "id" in d:
+                ids.add(d["id"])
+        except Exception:
+            continue
+    return ids
+
+
+def _milvus_get_ids() -> set:
+    """Retourne le set des ids actuels en Milvus (id_produit_chunk)."""
+    col = milvus.collection
+    iterator = col.query_iterator(
+        expr=None,
+        output_fields=["id_produit", "chunk_number"],
+        batch_size=2000,
+    )
+    ids = set()
+    while True:
+        try:
+            batch = iterator.next()
+        except StopIteration:
+            break
+        if not batch:
+            break
+        for row in batch:
+            pid = row.get("id_produit")
+            ch = int(row.get("chunk_number", 0) or 0)
+            if pid:
+                ids.add(f"{pid}_{ch}")
+    iterator.close()
+    return ids
+
+
+def _milvus_get_recent(since_iso: str, limit: int = 0) -> List[Dict[str, Any]]:
+    """Retourne les rows Milvus avec date_maj >= since_iso."""
+    col = milvus.collection
+    expr = f'date_maj >= "{since_iso}"'
+    iterator = col.query_iterator(
+        expr=expr,
+        output_fields=MILVUS_OUTPUT_FIELDS,
+        batch_size=500,
+    )
+    rows = []
+    while True:
+        try:
+            batch = iterator.next()
+        except StopIteration:
+            break
+        if not batch:
+            break
+        for row in batch:
+            rows.append(row)
+        if limit and len(rows) >= limit:
+            break
+    iterator.close()
+    return rows
+
+
+def sync_incremental(
+    since_iso: Optional[str] = None,
+    ts_collection: Optional[str] = None,
+    delete_orphans: bool = True,
+    batch_size: int = 1000,
+) -> Dict[str, Any]:
+    """
+    Sync incremental Milvus -> Typesense.
+
+    Args:
+      since_iso : "2026-05-04T00:00:00" pour filtrer date_maj >= since.
+                  Default : 24h ago.
+      ts_collection : default = settings.TYPESENSE_COLLECTION (produits_prod)
+      delete_orphans : True pour supprimer les produits plus en Milvus
+      batch_size : upsert batch size
+
+    Returns:
+      {
+        "ts_collection": "produits_prod",
+        "since_iso": "2026-05-04T00:00:00",
+        "milvus_recent_rows": 1234,
+        "ts_upserted": 1230,
+        "ts_upsert_errors": 4,
+        "ts_orphans_deleted": 56,
+        "duration_s": 123.45,
+        "ts_docs_before": 2271240,
+        "ts_docs_after": 2271184,
+      }
+    """
+    if since_iso is None:
+        since_iso = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
+
+    coll = ts_collection or settings.TYPESENSE_COLLECTION
+    start = time.time()
+
+    docs_before = _ts_doc_count(coll)
+    logger.info(f"sync_incremental start | coll={coll} since={since_iso} docs={docs_before}")
+
+    # Etape 1 : upsert les modifs recentes
+    rows = _milvus_get_recent(since_iso)
+    logger.info(f"  Milvus recent rows : {len(rows)}")
+
+    ts_upserted = 0
+    ts_errors = 0
+    if rows:
+        buffer = []
+        for row in rows:
+            try:
+                doc = _row_to_doc(row)
+                buffer.append(json.dumps(doc, ensure_ascii=False))
+            except Exception as e:
+                logger.warning(f"row_to_doc error: {e}")
+                ts_errors += 1
+                continue
+            if len(buffer) >= batch_size:
+                ok, err = _ts_flush_upsert(coll, buffer)
+                ts_upserted += ok
+                ts_errors += err
+                buffer = []
+        if buffer:
+            ok, err = _ts_flush_upsert(coll, buffer)
+            ts_upserted += ok
+            ts_errors += err
+
+    upsert_elapsed = time.time() - start
+    logger.info(f"  Upsert done : {ts_upserted} ok, {ts_errors} err in {upsert_elapsed:.1f}s")
+
+    # Etape 2 : supprimer les orphelins (en Typesense mais plus en Milvus)
+    deleted = 0
+    if delete_orphans:
+        logger.info("  Computing orphans...")
+        ts_ids = _ts_export_ids(coll)
+        milvus_ids = _milvus_get_ids()
+        orphans = ts_ids - milvus_ids
+        logger.info(f"  TS ids: {len(ts_ids)}, Milvus ids: {len(milvus_ids)}, orphans: {len(orphans)}")
+
+        if orphans:
+            orphan_list = list(orphans)
+            for i in range(0, len(orphan_list), 100):
+                batch = orphan_list[i:i + 100]
+                filter_expr = f"id:= [{','.join(batch)}]"
+                url = _ts_url(f"/collections/{coll}/documents")
+                try:
+                    r = requests.delete(
+                        url,
+                        headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_API_KEY},
+                        params={"filter_by": filter_expr, "batch_size": "100"},
+                        timeout=60,
+                    )
+                    r.raise_for_status()
+                    deleted += r.json().get("num_deleted", 0)
+                except Exception as e:
+                    logger.warning(f"delete batch err: {e}")
+
+    docs_after = _ts_doc_count(coll)
+    elapsed = time.time() - start
+    logger.info(f"sync_incremental DONE in {elapsed:.1f}s | "
+                f"upserted={ts_upserted} deleted={deleted} "
+                f"docs={docs_before}->{docs_after}")
+
+    return {
+        "ts_collection": coll,
+        "since_iso": since_iso,
+        "milvus_recent_rows": len(rows),
+        "ts_upserted": ts_upserted,
+        "ts_upsert_errors": ts_errors,
+        "ts_orphans_deleted": deleted,
+        "duration_s": round(elapsed, 2),
+        "ts_docs_before": docs_before,
+        "ts_docs_after": docs_after,
+    }

--- a/site/script/annuaire/moteur_solr.sh
+++ b/site/script/annuaire/moteur_solr.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Cron quotidien d'ingestion Solr (lance par crontab Linkbynet).
+#
+# 2026-04-30 : ajout core0 (V2 = text_fr) en parallele du V1 historique.
+# Le V2 utilise un wrapper HTTP qui appelle 02_alimente_core_v2.php en mode
+# CLI simule (full-reindex par defaut).
+#
+# Tant que le swap V2 -> V1 n'est pas fait (cf 04_swap_cores.sh), on alimente
+# les 2 cores en parallele : V1 (hellopro_produit) reste actif pour le trafic
+# par defaut, V2 (core0) est utilise par les requetes ?core_v2=1 et tests.
+
+# === V1 (legacy, core hellopro_produit) ===
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget https://script.hellopro.fr/script/annuaire/mt_solr/alimente_core_hellopro_produit.php&
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget https://script.hellopro.fr/script/annuaire/mt_solr/alimente_core_hellopro_societe.php&
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget https://script.hellopro.fr/script/annuaire/mt_solr/alimente_core_hellopro_di.php&
+
+# === V2 (core0, text_fr stemmer) ===
+# Wrapper HTTP qui execute 02_alimente_core_v2.php avec --full-reindex.
+# Le wrapper est dans /script/annuaire/mt_solr/v2/ (avec les autres scripts V2).
+# Token jetable hardcode dans le wrapper (a changer avant prod).
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/annuaire/mt_solr/v2/alimente_core_v2_http.php?token=hp_v2_2026_04_30_xZ7q"&
+
+# === Sync Typesense quotidien (Milvus -> Typesense via API VM) ===
+# Appelle l'API VM /sync/incremental qui :
+#   1. Upsert produits Milvus modifies depuis 24h (NEW + UPDATED)
+#   2. Supprime les orphelins Typesense (DELETED en Milvus)
+# Email de notification a la fin (succes ou echec).
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=hp_cron_2026_04_30_xZ7q"&

--- a/site/script/rag/sync_typesense_daily.php
+++ b/site/script/rag/sync_typesense_daily.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * sync_typesense_daily.php
+ * =========================
+ * Script cron quotidien sur Ecritel (cf moteur_solr.sh / crontab Linkbynet).
+ *
+ * Appelle l'API VM `/sync/incremental` pour :
+ *   1. Upserter dans Typesense les produits modifies en Milvus depuis 24h
+ *      (couvre NEW + UPDATED via le champ date_maj)
+ *   2. Supprimer de Typesense les produits qui ne sont plus en Milvus
+ *
+ * Usage cron (dans moteur_solr.sh) :
+ *   wget https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=XXX
+ *
+ * Effet attendu :
+ *   - Duree : 5-30 min selon volume modifs
+ *   - Email de notification a la fin (succes ou echec)
+ *
+ * Inspire de nettoyage_produits_supprimes_milvus.php (meme pattern api_call cURL).
+ */
+
+// Memory + timeout
+ini_set("memory_limit", "-1");
+set_time_limit(0);
+
+require_once($_SERVER['DOCUMENT_ROOT'] . "include/connexion.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "include/functions.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "fonctions/fonctions_hellopro.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "fonctions/fonctions_generales.php");
+
+// =============================================================================
+// CONFIG
+// =============================================================================
+
+// URL de l'API VM (le service opti-moteur-front qui expose POST /sync/incremental)
+define('SYNC_API_URL', 'https://api.hellopro.eu/optimoteur-service/sync/incremental');
+
+// Token d'auth (header X-Sync-Token). Doit matcher SYNC_TOKEN dans app/router/sync.py
+// CHANGER avant de mettre en prod.
+define('SYNC_TOKEN', 'hp_sync_2026_04_30_xZ7q');
+
+// Mail destinataire pour la notification
+define('NOTIFICATION_EMAIL', 'tandriatsiferantsoa@hellopro.fr');
+
+// Securite : token d'access HTTP pour eviter les declenchements externes
+// (different du SYNC_TOKEN utilise pour l'API VM)
+define('HTTP_TOKEN', 'hp_cron_2026_04_30_xZ7q');
+
+// =============================================================================
+// SECURITE : verifier le token HTTP
+// =============================================================================
+if (!isset($_GET['token']) || $_GET['token'] !== HTTP_TOKEN) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    echo "FORBIDDEN - token manquant ou invalide\n";
+    exit;
+}
+
+// =============================================================================
+// PARAMS
+// =============================================================================
+
+// Filtrer date_maj depuis quand ? Default = hier (24h ago)
+$since = isset($_GET['since']) ? trim($_GET['since']) : date('Y-m-d\TH:i:s', strtotime('-1 day'));
+
+// Collection Typesense cible (default = produits_prod)
+$ts_collection = isset($_GET['ts_collection']) ? trim($_GET['ts_collection']) : 'produits_prod';
+
+// Activer la suppression d'orphelins ? (default true)
+$delete_orphans = !(isset($_GET['no_delete']) && $_GET['no_delete'] === '1');
+
+// Headers HTTP : flush au fur et a mesure pour suivi cron
+header('Content-Type: text/plain; charset=utf-8');
+header('Cache-Control: no-store');
+header('X-Accel-Buffering: no');
+@ob_implicit_flush(true);
+while (@ob_end_flush()) {}
+
+// =============================================================================
+// FONCTION : appel API
+// =============================================================================
+function api_call($url, $method = 'POST', $data = null, $headers = []) {
+    $ch = curl_init();
+
+    $default_headers = ['Content-Type: application/json'];
+    $all_headers = array_merge($default_headers, $headers);
+
+    $options = [
+        CURLOPT_URL            => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 1800, // 30 min max (sync long possible)
+        CURLOPT_CONNECTTIMEOUT => 30,
+        CURLOPT_HTTPHEADER     => $all_headers,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS      => 3,
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false,
+    ];
+
+    if ($method === 'POST') {
+        $options[CURLOPT_POST] = true;
+        if ($data !== null) {
+            $options[CURLOPT_POSTFIELDS] = json_encode($data);
+        }
+    }
+
+    curl_setopt_array($ch, $options);
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curl_error = curl_error($ch);
+    curl_close($ch);
+
+    if ($response === false) {
+        throw new Exception("Erreur cURL: " . $curl_error);
+    }
+
+    return ['http_code' => $http_code, 'body' => $response];
+}
+
+// =============================================================================
+// LANCEMENT
+// =============================================================================
+
+$start_time = microtime(true);
+
+echo "==========================================\n";
+echo "Sync Typesense Daily - " . date('Y-m-d H:i:s') . "\n";
+echo "==========================================\n";
+echo "API URL       : " . SYNC_API_URL . "\n";
+echo "Since         : $since\n";
+echo "TS Collection : $ts_collection\n";
+echo "Delete orphans: " . ($delete_orphans ? 'YES' : 'NO') . "\n";
+echo "==========================================\n\n";
+
+$payload = [
+    'since'          => $since,
+    'ts_collection'  => $ts_collection,
+    'delete_orphans' => $delete_orphans,
+    'batch_size'     => 1000,
+];
+
+try {
+    echo "[INFO] Appel API VM...\n";
+    $response = api_call(
+        SYNC_API_URL,
+        'POST',
+        $payload,
+        ['X-Sync-Token: ' . SYNC_TOKEN]
+    );
+
+    $http_code = $response['http_code'];
+    $body = $response['body'];
+    $result = json_decode($body, true);
+
+    $elapsed = round(microtime(true) - $start_time, 2);
+
+    if ($http_code !== 200 || !$result) {
+        // ECHEC
+        echo "\n[ERREUR] HTTP $http_code\n";
+        echo "Body: $body\n";
+
+        $subject = "[Script][Sync] ECHEC sync Typesense quotidien";
+        $message = "<h2>Echec du sync Typesense</h2>";
+        $message .= "<p><strong>HTTP code:</strong> $http_code</p>";
+        $message .= "<p><strong>Duree:</strong> {$elapsed}s</p>";
+        $message .= "<p><strong>Body:</strong></p><pre>" . htmlspecialchars($body) . "</pre>";
+        $message .= "<p><strong>Payload:</strong></p><pre>" . json_encode($payload, JSON_PRETTY_PRINT) . "</pre>";
+
+        envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+        exit(1);
+    }
+
+    // SUCCES
+    echo "\n[SUCCES] Sync termine\n";
+    echo "  TS Collection      : " . ($result['ts_collection'] ?? '?') . "\n";
+    echo "  Since              : " . ($result['since_iso'] ?? '?') . "\n";
+    echo "  Milvus recent rows : " . ($result['milvus_recent_rows'] ?? 0) . "\n";
+    echo "  TS upserted        : " . ($result['ts_upserted'] ?? 0) . "\n";
+    echo "  TS upsert errors   : " . ($result['ts_upsert_errors'] ?? 0) . "\n";
+    echo "  TS orphans deleted : " . ($result['ts_orphans_deleted'] ?? 0) . "\n";
+    echo "  Duration (API)     : " . ($result['duration_s'] ?? 0) . "s\n";
+    echo "  Duration (total)   : {$elapsed}s\n";
+    echo "  TS docs before     : " . ($result['ts_docs_before'] ?? 0) . "\n";
+    echo "  TS docs after      : " . ($result['ts_docs_after'] ?? 0) . "\n";
+
+    // Email de notification (succes)
+    $subject = sprintf(
+        "[Script][Sync] OK Typesense - %d upserted, %d deleted",
+        $result['ts_upserted'] ?? 0,
+        $result['ts_orphans_deleted'] ?? 0
+    );
+    $message = "<h2>Sync Typesense quotidien - SUCCES</h2>";
+    $message .= "<table border='1' cellpadding='5' cellspacing='0'>";
+    foreach ($result as $k => $v) {
+        $message .= "<tr><td><strong>$k</strong></td><td>$v</td></tr>";
+    }
+    $message .= "<tr><td><strong>Total elapsed</strong></td><td>{$elapsed}s</td></tr>";
+    $message .= "</table>";
+
+    envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+
+} catch (Exception $e) {
+    $elapsed = round(microtime(true) - $start_time, 2);
+    echo "\n[EXCEPTION] " . $e->getMessage() . "\n";
+
+    $subject = "[Script][Sync] EXCEPTION sync Typesense";
+    $message = "<h2>Exception lors du sync Typesense</h2>";
+    $message .= "<p><strong>Erreur:</strong> " . htmlspecialchars($e->getMessage()) . "</p>";
+    $message .= "<p><strong>Duree:</strong> {$elapsed}s</p>";
+    envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+    exit(2);
+}
+
+echo "\n==========================================\n";
+echo "Done in " . round(microtime(true) - $start_time, 2) . "s\n";
+echo "==========================================\n";


### PR DESCRIPTION
## Summary

Met en place le sync quotidien automatique Milvus → Typesense pour maintenir la collection `produits_prod` à jour, sans intervention manuelle.

## Architecture

```
Crontab Linkbynet (Ecritel)
  └─ moteur_solr.sh
       └─ wget https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=XXX
            ├─ Param check (token HTTP)
            └─ POST https://api.hellopro.eu/optimoteur-service/sync/incremental
                 ├─ X-Sync-Token check
                 └─ sync_service.sync_incremental()
                      1. Milvus query : date_maj >= 24h ago
                      2. Upsert dans Typesense (NEW + UPDATED)
                      3. Delete orphans (DELETED en Milvus)
                      4. Return stats
            └─ Email notification (succès ou erreur)
```

## Fichiers

| Fichier | Rôle |
|---|---|
| `apps-microservices/opti-moteur-front/app/services/sync_service.py` | NOUVEAU. Logique sync incremental |
| `apps-microservices/opti-moteur-front/app/router/sync.py` | NOUVEAU. Endpoints `POST /sync/incremental` + `GET /sync/health` |
| `apps-microservices/opti-moteur-front/app/router/api_router.py` | MODIFIE. Ajout sync_router |
| `site/script/rag/sync_typesense_daily.php` | NOUVEAU. Script PHP Ecritel (cron quotidien) |
| `site/script/annuaire/moteur_solr.sh` | MODIFIE. Ajout ligne wget vers le PHP daily |

Pattern PHP Ecritel inspiré de l'existant `nettoyage_produits_supprimes_milvus.php`.

## Sécurité

2 niveaux de tokens (à changer avant prod) :

| Token | Path | Usage |
|---|---|---|
| `hp_cron_2026_04_30_xZ7q` | `sync_typesense_daily.php:51` | Auth HTTP du cron Ecritel (`?token=XXX`) |
| `hp_sync_2026_04_30_xZ7q` | `sync.py:17` ET `sync_typesense_daily.php:47` | Auth API VM (header `X-Sync-Token`) — DOIT MATCHER |

## Test plan

### Sur la VM (après merge)

- [ ] `git pull origin features/poc`
- [ ] `cd apps-microservices/opti-moteur-front`
- [ ] **Restart du service** (lifespan FastAPI charge les routes au startup) :
  ```bash
  ./run.sh   # ou docker compose restart si en Docker
  ```
- [ ] Health check : `curl https://api.hellopro.eu/optimoteur-service/sync/health`
- [ ] Test manuel direct (without PHP wrapper) :
  ```bash
  curl -X POST https://api.hellopro.eu/optimoteur-service/sync/incremental \
    -H "X-Sync-Token: hp_sync_2026_04_30_xZ7q" \
    -H "Content-Type: application/json" \
    -d '{"since": "2026-05-06T11:00:00", "ts_collection": "produits_prod"}'
  ```

### Sur Ecritel (après merge + déploiement PHP)

- [ ] Test PHP wrapper :
  ```bash
  curl "https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=hp_cron_2026_04_30_xZ7q&since=2026-05-06T11:00:00"
  ```
- [ ] Vérifier réception email de notification

### Validation comportement
- [ ] Email reçu avec stats (upserted, deleted, duration)
- [ ] Compteur Typesense `produits_prod` cohérent avant/après
- [ ] Pas de produits orphelins après plusieurs runs
- [ ] Token incorrect → HTTP 403 (test sécurité)

## Notes

- Branche cible : `features/poc`
- Le cron Linkbynet existant déclenche `moteur_solr.sh` quotidiennement → la nouvelle ligne wget tournera automatiquement
- Pas de modification de la logique existante : juste 5 fichiers dont 2 modifs minimes
- L'endpoint `/sync/health` permet de monitorer Milvus + Typesense indépendamment

🤖 Generated with [Claude Code](https://claude.com/claude-code)