### PR TITLE
feat: automatisation synonymes Typesense (daily + weekly cron Ecritel)

### DIFF
--- a/site/script/annuaire/moteur_solr.sh
+++ b/site/script/annuaire/moteur_solr.sh
@@ -26,3 +26,12 @@ $LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/scr
 #   2. Supprime les orphelins Typesense (DELETED en Milvus)
 # Email de notification a la fin (succes ou echec).
 $LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=hp_cron_2026_04_30_xZ7q"&
+
+# === Synonymes Typesense ===
+# Quotidien : sync_synonyms_daily.php pull le cache local depuis l'API VM.
+# Hebdo (lundi) : auto_generate_synonyms_weekly.php regenere les synonymes
+# depuis le catalogue Typesense. La logique daily/weekly est dans le script.
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/typesense/sync_synonyms_daily.php?token=hp_synsync_2026_04_30_xZ7q"&
+if [ $(date +%u) -eq 1 ]; then
+    $LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/typesense/auto_generate_synonyms_weekly.php?token=hp_syngen_2026_04_30_xZ7q"&
+fi

--- a/site/script/rag/sync_typesense_daily.php
+++ b/site/script/rag/sync_typesense_daily.php
@@ -4,17 +4,24 @@
  * =========================
  * Script cron quotidien sur Ecritel (cf moteur_solr.sh / crontab Linkbynet).
  *
- * Appelle l'API VM `/sync/incremental` pour :
- *   1. Upserter dans Typesense les produits modifies en Milvus depuis 24h
- *      (couvre NEW + UPDATED via le champ date_maj)
- *   2. Supprimer de Typesense les produits qui ne sont plus en Milvus
+ * Effectue 2 etapes en chaine :
+ *   ETAPE 1 : POST /sync/incremental
+ *     - Upserter dans Typesense les produits modifies en Milvus depuis 24h
+ *       (couvre NEW + UPDATED via le champ date_maj)
+ *     - Supprimer de Typesense les produits qui ne sont plus en Milvus
+ *
+ *   ETAPE 2 : POST /admin/synonyms/auto-generate (ajout 2026-05-06)
+ *     - Regenere les synonymes pour les nouvelles categories ingerees a
+ *       l'etape 1. Sans ca, les nouvelles categories n'ont pas leurs
+ *       variantes (mini-pelle / minipelle / mini pelle).
+ *     - Si l'etape 1 a echoue, on saute l'etape 2.
  *
  * Usage cron (dans moteur_solr.sh) :
  *   wget https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=XXX
  *
  * Effet attendu :
- *   - Duree : 5-30 min selon volume modifs
- *   - Email de notification a la fin (succes ou echec)
+ *   - Duree totale : 5-35 min selon volume modifs
+ *   - Email de notification a la fin (succes ou echec) avec stats des 2 etapes
  *
  * Inspire de nettoyage_produits_supprimes_milvus.php (meme pattern api_call cURL).
  */
@@ -34,6 +41,9 @@ require_once($_SERVER['DOCUMENT_ROOT'] . "fonctions/fonctions_generales.php");
 
 // URL de l'API VM (le service opti-moteur-front qui expose POST /sync/incremental)
 define('SYNC_API_URL', 'https://api.hellopro.eu/optimoteur-service/sync/incremental');
+
+// URL de l'API VM pour l'auto-generation des synonymes (etape 2)
+define('AUTO_GEN_SYNONYMS_URL', 'https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate');
 
 // Token d'auth (header X-Sync-Token). Doit matcher SYNC_TOKEN dans app/router/sync.py
 // CHANGER avant de mettre en prod.
@@ -170,8 +180,8 @@ try {
         exit(1);
     }
 
-    // SUCCES
-    echo "\n[SUCCES] Sync termine\n";
+    // SUCCES ETAPE 1
+    echo "\n[SUCCES ETAPE 1] Sync termine\n";
     echo "  TS Collection      : " . ($result['ts_collection'] ?? '?') . "\n";
     echo "  Since              : " . ($result['since_iso'] ?? '?') . "\n";
     echo "  Milvus recent rows : " . ($result['milvus_recent_rows'] ?? 0) . "\n";
@@ -179,24 +189,86 @@ try {
     echo "  TS upsert errors   : " . ($result['ts_upsert_errors'] ?? 0) . "\n";
     echo "  TS orphans deleted : " . ($result['ts_orphans_deleted'] ?? 0) . "\n";
     echo "  Duration (API)     : " . ($result['duration_s'] ?? 0) . "s\n";
-    echo "  Duration (total)   : {$elapsed}s\n";
     echo "  TS docs before     : " . ($result['ts_docs_before'] ?? 0) . "\n";
     echo "  TS docs after      : " . ($result['ts_docs_after'] ?? 0) . "\n";
 
-    // Email de notification (succes)
+    // =========================================================================
+    // ETAPE 2 : Auto-generate synonymes (apres ingestion reussie)
+    // =========================================================================
+    $synonyms_result = null;
+    $synonyms_error = null;
+
+    echo "\n==========================================\n";
+    echo "ETAPE 2 : Auto-generate synonymes\n";
+    echo "==========================================\n";
+    echo "[INFO] Appel API VM /admin/synonyms/auto-generate...\n";
+
+    try {
+        $syn_response = api_call(
+            AUTO_GEN_SYNONYMS_URL,
+            'POST',
+            null  // pas de body (les params sont en query string si besoin)
+        );
+        $syn_http = $syn_response['http_code'];
+        $syn_body = $syn_response['body'];
+        $synonyms_result = json_decode($syn_body, true);
+
+        if ($syn_http !== 200 || !$synonyms_result) {
+            $synonyms_error = "HTTP $syn_http : $syn_body";
+            echo "[WARN ETAPE 2] $synonyms_error\n";
+        } else {
+            echo "[SUCCES ETAPE 2]\n";
+            echo "  Categories scannees    : " . ($synonyms_result['nb_categories'] ?? 0) . "\n";
+            echo "  Synonymes generes      : " . ($synonyms_result['nb_synonyms_generated'] ?? 0) . "\n";
+            echo "  Synonymes pushes       : " . ($synonyms_result['nb_synonyms_pushed'] ?? 0) . "\n";
+            echo "  Erreurs                : " . ($synonyms_result['nb_errors'] ?? 0) . "\n";
+        }
+    } catch (Exception $e) {
+        $synonyms_error = $e->getMessage();
+        echo "[EXCEPTION ETAPE 2] $synonyms_error\n";
+    }
+
+    $elapsed = round(microtime(true) - $start_time, 2);
+    echo "\n  Duration (total)   : {$elapsed}s\n";
+
+    // =========================================================================
+    // EMAIL DE NOTIFICATION (succes etape 1 + status etape 2)
+    // =========================================================================
+    $syn_status = $synonyms_error
+        ? "<span style='color:red'>WARN: $synonyms_error</span>"
+        : sprintf("OK (%d pushes)", $synonyms_result['nb_synonyms_pushed'] ?? 0);
+
     $subject = sprintf(
-        "[Script][Sync] OK Typesense - %d upserted, %d deleted",
+        "[Script][Sync] OK Typesense - %d upserted, %d deleted, syn:%s",
         $result['ts_upserted'] ?? 0,
-        $result['ts_orphans_deleted'] ?? 0
+        $result['ts_orphans_deleted'] ?? 0,
+        $synonyms_error ? "ERR" : "OK"
     );
-    $message = "<h2>Sync Typesense quotidien - SUCCES</h2>";
+
+    $message = "<h2>Sync Typesense quotidien - SUCCES ETAPE 1</h2>";
+    $message .= "<h3>Etape 1 : Sync incremental</h3>";
     $message .= "<table border='1' cellpadding='5' cellspacing='0'>";
     foreach ($result as $k => $v) {
         $message .= "<tr><td><strong>$k</strong></td><td>$v</td></tr>";
     }
-    $message .= "<tr><td><strong>Total elapsed</strong></td><td>{$elapsed}s</td></tr>";
     $message .= "</table>";
 
+    $message .= "<h3>Etape 2 : Auto-generate synonymes</h3>";
+    if ($synonyms_error) {
+        $message .= "<p style='color:red'><strong>ECHEC :</strong> "
+                  . htmlspecialchars($synonyms_error) . "</p>";
+    } elseif ($synonyms_result) {
+        $message .= "<table border='1' cellpadding='5' cellspacing='0'>";
+        foreach (['nb_categories', 'nb_synonyms_generated', 'nb_synonyms_pushed', 'nb_errors'] as $k) {
+            $v = $synonyms_result[$k] ?? 0;
+            $message .= "<tr><td><strong>$k</strong></td><td>$v</td></tr>";
+        }
+        $message .= "</table>";
+    } else {
+        $message .= "<p>Aucune donnee.</p>";
+    }
+
+    $message .= "<p><strong>Total elapsed:</strong> {$elapsed}s</p>";
     envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
 
 } catch (Exception $e) {

--- a/site/script/typesense/auto_generate_synonyms_weekly.php
+++ b/site/script/typesense/auto_generate_synonyms_weekly.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * =============================================================================
+ * auto_generate_synonyms_weekly.php
+ * -----------------------------------------------------------------------------
+ * Script cron HEBDOMADAIRE : declenche la regeneration automatique des
+ * synonymes Typesense a partir de TOUTES les categories de la collection.
+ *
+ * Pattern : Ecritel -> API VM (comme l'ingestion / le sync_typesense_daily).
+ *
+ * URL appelee :
+ *   https://script.hellopro.fr/script/typesense/auto_generate_synonyms_weekly.php?token=XXX
+ *
+ * Endpoint VM appele :
+ *   POST https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate
+ *
+ * Logique cote VM (synonyms_service.auto_generate_synonyms) :
+ *   - Scan toutes les categories ingerees dans Typesense
+ *   - Pour chaque categorie multi-tokens, genere les variantes :
+ *     "Mini-pelles" -> minipelle, mini pelle, mini-pelle, minispelles, etc.
+ *   - Push comme synonymes multi-way Typesense
+ *
+ * Apres ce script, lancer aussi sync_synonyms_daily.php pour pull le cache
+ * local PHP front. Mais le cron quotidien le fera de toute facon.
+ *
+ * Frequence : HEBDO suffit (les categories ne changent pas tous les jours).
+ * Cron suggere (lundi 4h, apres weekend tranquille) :
+ *   0 4 * * 1 wget /script/typesense/auto_generate_synonyms_weekly.php?token=XXX
+ *
+ * Email de notification a la fin (succes ou erreur).
+ * =============================================================================
+ */
+
+ini_set("memory_limit", "512M");
+set_time_limit(0);
+
+require_once($_SERVER['DOCUMENT_ROOT'] . "include/connexion.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "include/functions.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "fonctions/fonctions_hellopro.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "fonctions/fonctions_generales.php");
+
+// =============================================================================
+// CONFIG
+// =============================================================================
+define('AUTO_GEN_API_URL', 'https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate');
+define('NOTIFICATION_EMAIL', 'tandriatsiferantsoa@hellopro.fr');
+define('HTTP_TOKEN', 'hp_syngen_2026_04_30_xZ7q');
+
+// =============================================================================
+// SECURITE : token jetable
+// =============================================================================
+if (!isset($_GET['token']) || $_GET['token'] !== HTTP_TOKEN) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    echo "FORBIDDEN - token manquant ou invalide\n";
+    exit;
+}
+
+// =============================================================================
+// PARAMS
+// =============================================================================
+$dry_run = isset($_GET['dry_run']) && $_GET['dry_run'] === '1';
+
+// Headers HTTP
+header('Content-Type: text/plain; charset=utf-8');
+header('Cache-Control: no-store');
+@ob_implicit_flush(true);
+while (@ob_end_flush()) {}
+
+// =============================================================================
+// FONCTION : appel API
+// =============================================================================
+function api_call($url, $method = 'POST', $data = null) {
+    $ch = curl_init();
+    $options = [
+        CURLOPT_URL            => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 600, // 10 min max (auto-generate sur 4500+ cat)
+        CURLOPT_CONNECTTIMEOUT => 30,
+        CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false,
+    ];
+
+    if ($method === 'POST') {
+        $options[CURLOPT_POST] = true;
+        if ($data !== null) {
+            $options[CURLOPT_POSTFIELDS] = json_encode($data);
+        }
+    }
+
+    curl_setopt_array($ch, $options);
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curl_error = curl_error($ch);
+    curl_close($ch);
+
+    if ($response === false) {
+        throw new Exception("Erreur cURL: " . $curl_error);
+    }
+    return ['http_code' => $http_code, 'body' => $response];
+}
+
+// =============================================================================
+// LANCEMENT
+// =============================================================================
+$start_time = microtime(true);
+
+echo "==========================================\n";
+echo "Auto-generate synonyms weekly - " . date('Y-m-d H:i:s') . "\n";
+echo "==========================================\n";
+echo "API URL : " . AUTO_GEN_API_URL . "\n";
+echo "Dry run : " . ($dry_run ? 'YES' : 'NO') . "\n";
+echo "==========================================\n\n";
+
+$url = AUTO_GEN_API_URL;
+if ($dry_run) {
+    $url .= '?dry_run=true';
+}
+
+try {
+    echo "[INFO] Appel API VM (peut prendre quelques minutes)...\n";
+    $response = api_call($url, 'POST');
+    $http_code = $response['http_code'];
+    $body = $response['body'];
+    $result = json_decode($body, true);
+
+    $elapsed = round(microtime(true) - $start_time, 2);
+
+    if ($http_code !== 200 || !$result) {
+        // ECHEC
+        echo "\n[ERREUR] HTTP $http_code\n";
+        echo "Body: $body\n";
+
+        $subject = "[Script][Synonyms] ECHEC auto-generate hebdo";
+        $message = "<h2>Echec auto-generate synonymes</h2>";
+        $message .= "<p><strong>HTTP code:</strong> $http_code</p>";
+        $message .= "<p><strong>Duree:</strong> {$elapsed}s</p>";
+        $message .= "<p><strong>Body:</strong></p><pre>" . htmlspecialchars($body) . "</pre>";
+        envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+        exit(1);
+    }
+
+    // SUCCES
+    echo "\n[SUCCES] Auto-generate termine\n";
+    echo "  Categories scannees      : " . ($result['nb_categories'] ?? 0) . "\n";
+    echo "  Synonymes generes        : " . ($result['nb_synonyms_generated'] ?? 0) . "\n";
+    echo "  Synonymes pushes Typesense: " . ($result['nb_synonyms_pushed'] ?? 0) . "\n";
+    echo "  Erreurs                  : " . ($result['nb_errors'] ?? 0) . "\n";
+    echo "  Dry run                  : " . (($result['dry_run'] ?? false) ? 'YES' : 'NO') . "\n";
+    echo "  Duree                    : {$elapsed}s\n";
+
+    if (!empty($result['examples'])) {
+        echo "\n  Exemples (10 premiers) :\n";
+        foreach (array_slice($result['examples'], 0, 5) as $ex) {
+            echo "    - " . substr($ex['cat'], 0, 40) . " -> " . count($ex['variants']) . " variantes\n";
+        }
+    }
+
+    // Email de notification
+    $subject = sprintf(
+        "[Script][Synonyms] OK auto-generate - %d synonymes pushes",
+        $result['nb_synonyms_pushed'] ?? 0
+    );
+    $message = "<h2>Auto-generate synonymes hebdo - SUCCES</h2>";
+    $message .= "<table border='1' cellpadding='5' cellspacing='0'>";
+    $message .= "<tr><td><strong>Categories scannees</strong></td><td>" . ($result['nb_categories'] ?? 0) . "</td></tr>";
+    $message .= "<tr><td><strong>Synonymes generes</strong></td><td>" . ($result['nb_synonyms_generated'] ?? 0) . "</td></tr>";
+    $message .= "<tr><td><strong>Synonymes pushes Typesense</strong></td><td>" . ($result['nb_synonyms_pushed'] ?? 0) . "</td></tr>";
+    $message .= "<tr><td><strong>Erreurs</strong></td><td>" . ($result['nb_errors'] ?? 0) . "</td></tr>";
+    $message .= "<tr><td><strong>Duree</strong></td><td>{$elapsed}s</td></tr>";
+    $message .= "</table>";
+
+    if (!empty($result['examples'])) {
+        $message .= "<h3>Exemples</h3><ul>";
+        foreach (array_slice($result['examples'], 0, 10) as $ex) {
+            $message .= "<li><strong>" . htmlspecialchars($ex['cat']) . "</strong> : "
+                     . count($ex['variants']) . " variantes ("
+                     . htmlspecialchars(implode(", ", array_slice($ex['variants'], 0, 5)))
+                     . "...)</li>";
+        }
+        $message .= "</ul>";
+    }
+
+    envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+
+} catch (Exception $e) {
+    $elapsed = round(microtime(true) - $start_time, 2);
+    echo "\n[EXCEPTION] " . $e->getMessage() . "\n";
+
+    $subject = "[Script][Synonyms] EXCEPTION auto-generate";
+    $message = "<h2>Exception lors de auto-generate synonymes</h2>";
+    $message .= "<p><strong>Erreur:</strong> " . htmlspecialchars($e->getMessage()) . "</p>";
+    $message .= "<p><strong>Duree:</strong> {$elapsed}s</p>";
+    envoyer_mail_scripts($subject, '', NOTIFICATION_EMAIL, $message, 0);
+    exit(2);
+}
+
+echo "\n==========================================\n";
+echo "Done in " . round(microtime(true) - $start_time, 2) . "s\n";
+echo "==========================================\n";

--- a/site/script/typesense/sync_synonyms.sh
+++ b/site/script/typesense/sync_synonyms.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# =============================================================================
+# sync_synonyms.sh
+# -----------------------------------------------------------------------------
+# Wrapper Linkbynet pour le cron des synonymes Typesense.
+#
+# Quotidien : sync_synonyms_daily.php (pull cache depuis API VM)
+# Hebdo (lundi) : auto_generate_synonyms_weekly.php (regenere depuis Typesense)
+#
+# Pattern : Ecritel -> API VM (comme moteur_solr.sh)
+#
+# Cron suggere :
+#   0 3 * * *   /script/typesense/sync_synonyms.sh   # tous les jours 3h
+#
+# Le script gere lui-meme la logique daily/weekly via [ $(date +%u) -eq 1 ].
+# =============================================================================
+
+LAUNCHER=/usr/local/linkbynet/scripts/cron/launcher.sh
+
+# === DAILY : Sync cache local PHP front depuis API VM ===
+$LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/typesense/sync_synonyms_daily.php?token=hp_synsync_2026_04_30_xZ7q"&
+
+# === WEEKLY (Lundi) : Auto-generate synonymes depuis catalogue Typesense ===
+# Lance uniquement le lundi (jour 1 = lundi en POSIX). Si nouvelle ingestion
+# en cours de semaine, lancer manuellement le script via curl.
+if [ $(date +%u) -eq 1 ]; then
+    $LAUNCHER /usr/local/linkbynet/scripts/cron/wget "https://script.hellopro.fr/script/typesense/auto_generate_synonyms_weekly.php?token=hp_syngen_2026_04_30_xZ7q"&
+fi

--- a/site/script/typesense/sync_synonyms_daily.php
+++ b/site/script/typesense/sync_synonyms_daily.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * =============================================================================
+ * sync_synonyms_daily.php
+ * -----------------------------------------------------------------------------
+ * Script cron QUOTIDIEN : pull les synonymes Typesense (auto + manual deja
+ * pushed) depuis l'API VM et les stocke localement dans le cache PHP front.
+ *
+ * Pattern : Ecritel -> API VM (comme l'ingestion).
+ *
+ * Origine : etait dans site/annuaire_hp/fonctions/sync_synonyms.php (mauvais
+ * dossier = repertoire du front PHP). Deplace 2026-05-06 V4.
+ *
+ * URL appelee :
+ *   https://script.hellopro.fr/script/typesense/sync_synonyms_daily.php?token=XXX
+ *
+ * Endpoint VM appele :
+ *   GET https://api.hellopro.eu/optimoteur-service/admin/synonyms
+ *
+ * Ecrit dans :
+ *   $_SERVER['DOCUMENT_ROOT']/fichiers_communs_bo_front/hellopro_fr/typesense_synonyms.json
+ *
+ * Utilise par :
+ *   site/annuaire_hp/fonctions/fonctions_annuaire_hp.php :: load_synonyms_index()
+ *
+ * Comportement en cas d'erreur :
+ *   - curl echoue -> output ERROR + exit 1 (garde l'ancien fichier)
+ *   - JSON invalide -> output ERROR + exit 1 (garde l'ancien fichier)
+ *   - moins de 10 synonymes recus -> output ERROR (suspect de corruption)
+ *   - fichier ecrit atomiquement (mv final) -> 0 risque de lecture partielle
+ *
+ * Cron suggere (1x / jour a 3h30 du matin, apres l'ingestion) :
+ *   0 3 * * * /script/annuaire/moteur_solr.sh
+ *   30 3 * * * wget /script/typesense/sync_synonyms_daily.php?token=XXX
+ * =============================================================================
+ */
+
+header('Content-Type: text/plain; charset=UTF-8');
+
+// =============================================================================
+// SECURITE : token jetable
+// =============================================================================
+define('HTTP_TOKEN', 'hp_synsync_2026_04_30_xZ7q');
+
+if (!isset($_GET['token']) || $_GET['token'] !== HTTP_TOKEN) {
+    http_response_code(403);
+    echo "FORBIDDEN - token manquant ou invalide\n";
+    exit;
+}
+
+// =============================================================================
+// CONFIG
+// =============================================================================
+$SYNONYMS_URL = 'https://api.hellopro.eu/optimoteur-service/admin/synonyms';
+$CACHE_FILE   = $_SERVER['DOCUMENT_ROOT'] . 'fichiers_communs_bo_front/hellopro_fr/typesense_synonyms.json';
+$CACHE_DIR    = dirname($CACHE_FILE);
+$CACHE_TMP    = $CACHE_FILE . '.tmp.' . getmypid();
+$TIMEOUT_SEC  = 30;
+
+$t0 = microtime(true);
+
+function log_line($level, $msg)
+{
+    echo '[' . date('Y-m-d\TH:i:s') . "] [$level] $msg\n";
+    @flush();
+}
+
+log_line('INFO', "GET $SYNONYMS_URL");
+log_line('INFO', "Target: $CACHE_FILE");
+
+// =============================================================================
+// PREREQUIS DOSSIER
+// =============================================================================
+if (!is_dir($CACHE_DIR)) {
+    if (!@mkdir($CACHE_DIR, 0755, true)) {
+        log_line('ERROR', "Dossier inexistant et mkdir echoue : $CACHE_DIR");
+        http_response_code(500);
+        exit(1);
+    }
+}
+
+// =============================================================================
+// DOWNLOAD via curl
+// =============================================================================
+$ch = curl_init($SYNONYMS_URL);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_TIMEOUT        => $TIMEOUT_SEC,
+    CURLOPT_CONNECTTIMEOUT => 10,
+    CURLOPT_FAILONERROR    => true,
+    CURLOPT_SSL_VERIFYPEER => false,
+    CURLOPT_SSL_VERIFYHOST => false,
+]);
+$raw     = curl_exec($ch);
+$errno   = curl_errno($ch);
+$errstr  = curl_error($ch);
+$http    = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$total_t = curl_getinfo($ch, CURLINFO_TOTAL_TIME);
+curl_close($ch);
+
+if ($errno !== 0 || $raw === false) {
+    log_line('ERROR', "curl echoue (errno=$errno, http=$http) : $errstr");
+    http_response_code(502);
+    exit(1);
+}
+
+log_line('INFO', sprintf("download OK en %.2fs (%d bytes, http=%d)", $total_t, strlen($raw), $http));
+
+// =============================================================================
+// VALIDATION JSON
+// =============================================================================
+$data = @json_decode($raw, true);
+if (!is_array($data) || !isset($data['synonyms']) || !is_array($data['synonyms'])) {
+    log_line('ERROR', "JSON invalide ou structure inattendue (pas de cle 'synonyms')");
+    http_response_code(502);
+    exit(1);
+}
+
+$nb = count($data['synonyms']);
+if ($nb < 10) {
+    log_line('ERROR', "Seulement $nb synonymes recus (sanity check : attendu >= 10)");
+    http_response_code(502);
+    exit(1);
+}
+
+log_line('INFO', "JSON valide : $nb entrees synonymes");
+
+// =============================================================================
+// ECRITURE ATOMIQUE
+// =============================================================================
+if (file_put_contents($CACHE_TMP, $raw) === false) {
+    log_line('ERROR', "echec ecriture tmp : $CACHE_TMP");
+    http_response_code(500);
+    exit(1);
+}
+
+if (!@rename($CACHE_TMP, $CACHE_FILE)) {
+    log_line('ERROR', "echec rename $CACHE_TMP -> $CACHE_FILE");
+    @unlink($CACHE_TMP);
+    http_response_code(500);
+    exit(1);
+}
+
+@chmod($CACHE_FILE, 0644);
+
+$size = filesize($CACHE_FILE);
+$dt   = microtime(true) - $t0;
+log_line('OK', sprintf("synonymes synchronises : $nb entrees, %d bytes, total=%.2fs", $size, $dt));
+exit(0);


### PR DESCRIPTION
## Summary

Met en place l'automatisation complète des synonymes Typesense :
- **Daily auto-generate** chaîné dans le sync incremental (génère les variantes pour les nouvelles catégories)
- **Daily cache pull** depuis API VM vers cache local PHP front
- **Weekly backup** auto-generate (au cas où le daily échoue)

Réorganise les fichiers : déplace les scripts synonymes du mauvais dossier (`site/annuaire_hp/fonctions/` = répertoire front PHP) vers `site/script/typesense/`.

## Architecture

```
Crontab Linkbynet 03:00
  └─ moteur_solr.sh (modifié)
       ├─ V1 Solr ingestion
       ├─ V2 Solr ingestion (core0)
       ├─ Typesense sync incremental :
       │   1️⃣  POST /sync/incremental (ingest 24h modifs + delete orphelins)
       │   2️⃣  POST /admin/synonyms/auto-generate (régénère synonymes)
       │   📧 Email récap des 2 étapes
       ├─ Typesense cache local :
       │   GET /admin/synonyms → écrit cache local PHP front
       └─ Si LUNDI : auto_generate_synonyms_weekly.php (backup hebdo)
```

## Nouveaux fichiers (site/script/typesense/)

| Fichier | Rôle |
|---|---|
| `sync_synonyms.sh` | Wrapper Linkbynet (daily + weekly) |
| `sync_synonyms_daily.php` | Daily : pull cache local depuis API VM (GET `/admin/synonyms`) |
| `auto_generate_synonyms_weekly.php` | Hebdo (lundi) : déclenche `POST /admin/synonyms/auto-generate` (backup) |

## Modifiés

| Fichier | Modif |
|---|---|
| `site/script/rag/sync_typesense_daily.php` | Chaine POST `/admin/synonyms/auto-generate` après sync incremental réussi. Email récap des 2 étapes. |
| `site/script/annuaire/moteur_solr.sh` | Ajout 2 lignes wget (daily synonyms + weekly backup) |

## Synonymes manuels — pas changé

`typesense_synonyms_manual.json` reste géré manuellement (édition + commit). Les 47 entrées B2B (medical, chariot/transpalette, etc.) sont mergées au runtime PHP via `load_synonyms_index()`.

## Tokens (à changer avant prod)

| Token | Usage |
|---|---|
| `hp_synsync_2026_04_30_xZ7q` | `sync_synonyms_daily.php` |
| `hp_syngen_2026_04_30_xZ7q` | `auto_generate_synonyms_weekly.php` |

## Test plan

### Sur la VM (après merge)

- [ ] `git pull origin features/poc`
- [ ] Restart `optimoteur-service` (déjà fait à la PR #546, mais re-checker)
- [ ] `curl -X POST https://api.hellopro.eu/optimoteur-service/admin/synonyms/auto-generate?dry_run=true` → vérifier output JSON

### Sur Ecritel (après merge + déploiement PHP)

- [ ] Test wrapper Ecritel synonymes auto-generate :
  ```bash
  curl "https://script.hellopro.fr/script/typesense/auto_generate_synonyms_weekly.php?token=hp_syngen_2026_04_30_xZ7q&dry_run=1"
  ```
- [ ] Test wrapper Ecritel sync cache :
  ```bash
  curl "https://script.hellopro.fr/script/typesense/sync_synonyms_daily.php?token=hp_synsync_2026_04_30_xZ7q"
  ```
- [ ] Test sync_typesense_daily.php (chainage avec auto-generate) :
  ```bash
  curl "https://script.hellopro.fr/script/rag/sync_typesense_daily.php?token=hp_cron_2026_04_30_xZ7q&since=2026-05-06T11:00:00"
  ```
- [ ] Vérifier email contient les 2 étapes

### Validation comportement
- [ ] Cache local `typesense_synonyms.json` mis à jour après sync_synonyms_daily
- [ ] Synonymes auto pushed dans Typesense après auto-generate
- [ ] Email récap reçu avec stats des 2 étapes

## Note

Anciens fichiers `site/annuaire_hp/fonctions/sync_synonyms.{sh,php}` n'étaient PAS dans git (jamais commités, sans doute uploadés manuellement sur Ecritel à un moment donné). Pas de DEL git, juste à **supprimer manuellement côté prod si présents** pour éviter la confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)