### PR TITLE
fix: correct MilvusConnector / TypesenseClient API in sync endpoints

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/sync.py
+++ b/apps-microservices/opti-moteur-front/app/router/sync.py
@@ -92,16 +92,16 @@ async def sync_health():
     health = {"status": "ok", "milvus": "?", "typesense": "?"}
 
     try:
-        col = milvus.collection
+        col = milvus.get_collection(settings.MILVUS_COLLECTION)
         n = col.num_entities
-        health["milvus"] = f"ok ({n} entities)"
+        health["milvus"] = f"ok ({n} entities, collection={settings.MILVUS_COLLECTION})"
     except Exception as e:
         health["milvus"] = f"error: {e}"
         health["status"] = "degraded"
 
     try:
-        info = typesense_client.collections[settings.TYPESENSE_COLLECTION].retrieve()
-        health["typesense"] = f"ok ({info.get('num_documents', 0)} docs)"
+        info = typesense_client.collection_stats(settings.TYPESENSE_COLLECTION)
+        health["typesense"] = f"ok ({info.get('num_documents', 0)} docs, collection={settings.TYPESENSE_COLLECTION})"
     except Exception as e:
         health["typesense"] = f"error: {e}"
         health["status"] = "degraded"

--- a/apps-microservices/opti-moteur-front/app/services/sync_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/sync_service.py
@@ -97,7 +97,7 @@ def _ts_export_ids(collection: str) -> set:
 
 def _milvus_get_ids() -> set:
     """Retourne le set des ids actuels en Milvus (id_produit_chunk)."""
-    col = milvus.collection
+    col = milvus.get_collection(settings.MILVUS_COLLECTION)
     iterator = col.query_iterator(
         expr=None,
         output_fields=["id_produit", "chunk_number"],
@@ -122,7 +122,7 @@ def _milvus_get_ids() -> set:
 
 def _milvus_get_recent(since_iso: str, limit: int = 0) -> List[Dict[str, Any]]:
     """Retourne les rows Milvus avec date_maj >= since_iso."""
-    col = milvus.collection
+    col = milvus.get_collection(settings.MILVUS_COLLECTION)
     expr = f'date_maj >= "{since_iso}"'
     iterator = col.query_iterator(
         expr=expr,


### PR DESCRIPTION
## Bug

Au test post-deploy de PR #546 :
\`\`\`
GET /sync/health
{
    \"status\": \"degraded\",
    \"milvus\": \"error: 'MilvusConnector' object has no attribute 'collection'\",
    \"typesense\": \"error: 'TypesenseClient' object has no attribute 'collections'\"
}
\`\`\`

## Cause

Mauvais attributs utilisés dans \`sync.py\` et \`sync_service.py\` :
- \`milvus.collection\` n'existe pas → bonne API : \`milvus.get_collection(name)\`
- \`typesense_client.collections[name]\` n'existe pas → bonne API : \`typesense_client.collection_stats(name)\`

## Fix

| Fichier | Avant | Après |
|---|---|---|
| \`app/router/sync.py\` | \`milvus.collection\` | \`milvus.get_collection(settings.MILVUS_COLLECTION)\` |
| \`app/router/sync.py\` | \`typesense_client.collections[name].retrieve()\` | \`typesense_client.collection_stats(name)\` |
| \`app/services/sync_service.py\` | \`milvus.collection\` (x2) | \`milvus.get_collection(settings.MILVUS_COLLECTION)\` (x2) |

## Test plan

- [ ] Re-build container : \`docker compose up -d --build opti-moteur-front\`
- [ ] \`curl http://localhost:8570/sync/health\` → \`status: ok\`, milvus + typesense OK
- [ ] Test sync incremental : \`POST /sync/incremental\` avec \`since\` récent → upserted > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)