### PR TITLE
fix(synonyms): no pluralize stopwords + filter 1-letter tokens

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
@@ -65,25 +65,37 @@ def _extract_tokens(cat_name: str, keep_stopwords: bool) -> List[str]:
     keep_stopwords = True  : garde tous les tokens (utile pour matcher
       les concatenations utilisateur type "fauteuildebureau").
       "Fauteuil de bureau"  -> ["fauteuil", "de", "bureau"]
+
+    Filtre len >= 2 dans les deux cas pour eviter les artefacts d'apostrophes
+    (ex: "Cartouches d'encre" -> token "d" isole -> deviendrait "ds" apres
+    pluralization, polluant le synonyme).
     """
     norm = _normalize(cat_name)
     # Supprime tout ce qui est entre parentheses (specs techniques).
     norm = re.sub(r"\([^)]*\)", " ", norm)
     raw = re.findall(r"[a-z0-9]+", norm)
     if keep_stopwords:
-        return [t for t in raw if len(t) >= 1 and not t.isdigit()]
+        # FIX (PR #550) : len >= 2 au lieu de >= 1 pour eviter "d" -> "ds"
+        return [t for t in raw if len(t) >= 2 and not t.isdigit()]
     return [
         t for t in raw
         if len(t) >= 2 and t not in _STOPWORDS_FR and not t.isdigit()
     ]
 
 
-def _sing_plur_forms(token: str) -> List[str]:
+def _sing_plur_forms(token: str, is_stopword: bool = False) -> List[str]:
     """
     Retourne le token + ses variantes singulier/pluriel (heuristique FR).
     Utilise pour couvrir les cas "minipelle" (singulier) vs "Mini-pelles"
     (pluriel dans le nom de categorie).
+
+    FIX (PR #550) : si is_stopword=True, retourne [token] sans pluralization.
+    Evite les artefacts type "et" -> "ets", "pour" -> "pours", "de" -> "des"
+    qui generent des synonymes invalides "cable ets adaptateur",
+    "support pours ecran", "table des travail", etc.
     """
+    if is_stopword:
+        return [token]
     forms = {token}
     # pluriel -> singulier
     if token.endswith("aux") and len(token) >= 5:
@@ -127,7 +139,13 @@ def _build_variants(tokens: List[str]) -> Set[str]:
         return set()
 
     # Pour chaque token, ses formes s/p
-    token_forms = [_sing_plur_forms(t) for t in tokens]
+    # FIX (PR #550) : ne pluralise pas les stopwords FR (et, pour, de, ...)
+    # pour eviter des variantes parasites du type "cable ets adaptateur"
+    # ("et" -> "ets") ou "support pours ecran" ("pour" -> "pours").
+    token_forms = [
+        _sing_plur_forms(t, is_stopword=(t in _STOPWORDS_FR))
+        for t in tokens
+    ]
 
     variants: Set[str] = set()
     for combo in product(*token_forms):


### PR DESCRIPTION
## Summary

Fix qualite des variantes generees par `auto_generate_synonyms` (endpoint `POST /admin/synonyms/auto-generate`).

3 ciblages dans `apps-microservices/opti-moteur-front/app/services/synonyms_service.py` :

- **`_extract_tokens(keep_stopwords=True)`** : passe le filtre de `len >= 1` a `len >= 2`. Empeche le `d` solitaire de `d encre` de survivre et de devenir `ds` apres pluralization.
- **`_sing_plur_forms`** : nouveau parametre `is_stopword`. Si True, retourne `[token]` sans appliquer la regle de pluralization heuristique.
- **`_build_variants`** : detecte les stopwords FR via `t in _STOPWORDS_FR` et propage `is_stopword` a `_sing_plur_forms`.

## Bugs detectes en dry_run avant fix

Sur 1987 synonymes generes pour 2000 categories :

| Categorie | Variante invalide generee |
|---|---|
| `Cartouches d'encre informatiques` | `cartouche ds encre informatique` |
| `Cables et adaptateurs` | `cable ets adaptateur` |
| `Support pour ecran` | `support pours ecran` |
| `Tables de travail` | `table des travail` |
| `Equipements pour serveur` | `equipements pours serveur` |

## Comportement apres fix

| Categorie | Variantes generees (sample) |
|---|---|
| `Cartouches d'encre informatiques` | `cartouche encre informatique`, `cartouche-encre-informatique`, `cartoucheencreinformatique` ... |
| `Cables et adaptateurs` | `cable et adaptateur`, `cables et adaptateurs`, `cableetadaptateur` ... |
| `Support pour ecran` | `support pour ecran`, `supports pour ecrans`, `supportpourecran` ... |
| `Tables de travail` | `table de travail`, `tables de travail`, `tabledetravail` ... |

Les variantes correctes (sans stopwords pluralises) restent intactes.

## Test plan

- [x] Dry run validate sur la VM (avant push reel) :
  ```bash
  curl -s -X POST "http://localhost:8570/admin/synonyms/auto-generate?dry_run=true" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); [print(e['cat'],'->',e['variants']) for e in d['examples']]"
  ```
- [x] Verifier que les categories testees ci-dessus ne contiennent plus `ets`, `pours`, `des` (stopword + s), ni `ds` (apostrophe orpheline).
- [ ] Push reel via `POST /admin/synonyms/auto-generate` (sans dry_run).
- [ ] Verifier nb_synonyms_pushed sur Typesense via `GET /admin/synonyms`.

## Notes

- Aucun changement de signature publique : `_sing_plur_forms` ajoute un parametre optionnel avec default `False`.
- Pas de changement du cap `max_facet_values=2000` (3092 categories Typesense, donc ~1092 non couvertes). Sera traite dans une PR separee si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
