### PR TITLE
chore(synonyms): bump max_facet_values 2000 -> 5000

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/synonyms_service.py
@@ -196,8 +196,13 @@ def _slug_id(s: str) -> str:
 def _list_categories(collection: str) -> List[str]:
     """
     Retourne la liste des noms de categories distincts dans la collection
-    via un facet query 'match all'. Cap a 2000 categories (HelloPro tourne
-    autour de 8300 rubriques en BDD mais toutes ne sont pas ingerees).
+    via un facet query 'match all'. Cap a 5000 categories (HelloPro tourne
+    autour de 8300 rubriques en BDD mais toutes ne sont pas ingerees, et
+    Typesense produits_prod en contient ~3100 actuellement).
+
+    Note : max_facet_values Typesense est plafonne a 10000 cote serveur
+    (facet_values_max_count), 5000 laisse une marge x2 pour la croissance
+    sans degrader les perfs (facet sur 1.5M docs ~ 50-100ms).
     """
     params = {
         "collection": collection,
@@ -205,7 +210,7 @@ def _list_categories(collection: str) -> List[str]:
         "query_by": "categorie",
         "per_page": 1,
         "facet_by": "categorie",
-        "max_facet_values": 2000,
+        "max_facet_values": 5000,
     }
     try:
         res = typesense_client.multi_search({"searches": [params]})


### PR DESCRIPTION
## Summary

Bump `max_facet_values` de 2000 a 5000 dans `_list_categories` (`apps-microservices/opti-moteur-front/app/services/synonyms_service.py`).

## Pourquoi

`Typesense produits_prod` contient actuellement **3092 categories distinctes** (verifie en prod via facet query). Le cap actuel a 2000 laisse **~1092 categories sans synonymes auto-generes** (35% de couverture manquante).

Bump a 5000 :
- Couvre les 3092 actuelles avec marge x1.6
- Tolere une croissance jusqu'a 8300 rubriques BDD HelloPro sans nouvelle PR
- Reste sous le plafond Typesense `facet_values_max_count=10000` cote serveur
- Pas d'impact perf notable : facet sur 1.5M docs ~ 50-100 ms, et l'endpoint `/admin/synonyms/auto-generate` n'est appele que de maniere hebdomadaire (cron Ecritel `auto_generate_synonyms_weekly.php`)

## Contexte sequentiel

Suit la PR #550 (qui corrigeait la qualite des variantes generees). Cette PR-ci elargit la couverture pour pousser pour la 1ere fois ~3000 synonymes (au lieu de 1987) en Typesense.

## Test plan

- [ ] Sur la VM apres merge :
  ```bash
  git pull origin features/poc
  docker compose up -d --build opti-moteur-front
  ```
- [ ] Dry run : verifier `nb_categories` >= 3000
  ```bash
  curl -s -X POST "http://localhost:8570/admin/synonyms/auto-generate?dry_run=true" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); print('nb_categories:', d['nb_categories'], 'nb_generated:', d['nb_synonyms_generated'])"
  ```
- [ ] Push reel sans dry_run :
  ```bash
  curl -s -X POST "http://localhost:8570/admin/synonyms/auto-generate" | python3 -m json.tool
  ```
- [ ] Verifier le compte total des synonymes en Typesense :
  ```bash
  curl -s "http://localhost:8570/admin/synonyms" | python3 -c "import json,sys; d=json.load(sys.stdin); s=d if isinstance(d,list) else d.get('synonyms',[]); print('total:', len(s))"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
