### PR TITLE
feat(typesense): add url_images to schema + sync

### DIFF
--- a/apps-microservices/opti-moteur-front/app/core/typesense_client.py
+++ b/apps-microservices/opti-moteur-front/app/core/typesense_client.py
@@ -91,6 +91,12 @@ class TypesenseClient:
                 {"name": "date_maj",        "type": "string", "optional": True, "sort": True},
                 {"name": "chunk_number",    "type": "int32"},
                 {"name": "total_chunks",    "type": "int32"},
+                # 2026-05-07 : ajout url_images pour afficher les vignettes en P2-P4 Typesense.
+                # Avant : Typesense ne stockait pas, on enrichissait via SQL fallback (latence +20-50ms).
+                # Apres : url_images directement dans Typesense -> aucun roundtrip BDD.
+                # Pour les ~1.5M docs deja en Typesense (sans url_images), le SQL fallback PHP reste
+                # actif comme safety net jusqu'au prochain re-ingest complet.
+                {"name": "url_images",      "type": "string", "optional": True, "index": False},
                 {"name": "embedding",       "type": "float[]", "num_dim": settings.EMBEDDING_DIMENSION},
             ],
             "token_separators": ["-", "/"],

--- a/apps-microservices/opti-moteur-front/app/services/ingestion_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/ingestion_service.py
@@ -29,6 +29,7 @@ MILVUS_OUTPUT_FIELDS = [
     "ean", "sku", "reference",
     "date_ajout", "date_maj",
     "chunk_number", "total_chunks",
+    "url_images",  # 2026-05-07 : ajoute pour que les vignettes s'affichent en P2-P4 Typesense
     "embedding",
 ]
 
@@ -66,6 +67,7 @@ def _row_to_doc(row: Dict[str, Any]) -> Dict[str, Any]:
         "date_maj":        row.get("date_maj") or "",
         "chunk_number":    int(row.get("chunk_number", 0) or 0),
         "total_chunks":    int(row.get("total_chunks", 1) or 1),
+        "url_images":      row.get("url_images") or "",  # 2026-05-07
         "embedding":       list(row["embedding"]),
     }
     ph = _parse_price(row.get("prix_ht"))


### PR DESCRIPTION
## Summary

Ajout de `url_images` au sync Milvus → Typesense + au schema Typesense, pour resoudre le probleme des vignettes produit non affichees sur les pages 2-4 (mode hybride `&ajax=1`).

## Probleme

Sur les pages 2 a 4 du moteur (chargees via `search_ajax.php` qui interroge Typesense), les vignettes produit s'affichaient en **skeleton loader infini** :

- Cote backend : `MILVUS_OUTPUT_FIELDS` ne contenait pas `url_images`, donc jamais synchronise vers Typesense
- Cote PHP : `recup_info_prod_typesense` retournait `photo_produit=""` (commentaire explicite ligne 223)
- Cote JS : `<img src="">` -> skeleton loader visible mais image jamais chargee

Note : le mode RAG par defaut (sans `&ajax=1`) fonctionnait car il lit `url_images` directement depuis les metadata Milvus.

## Modifications

| Fichier | Modif |
|---|---|
| `apps-microservices/opti-moteur-front/app/services/ingestion_service.py` | Ajout `"url_images"` a `MILVUS_OUTPUT_FIELDS` + mapping dans `_row_to_doc` (default `""`) |
| `apps-microservices/opti-moteur-front/app/core/typesense_client.py` | Ajout du champ `url_images` au schema (string, optional, index=False) |

## Strategie de rollout

### Phase 1 — Deploy et migration schema

1. Merge cette PR
2. Sur la VM :
   ```bash
   cd /home/devhp/RAG-HP-PUB
   git pull origin features/poc
   cd apps-microservices/opti-moteur-front
   docker compose up -d --build opti-moteur-front
   ```
3. **Migration schema Typesense** (PATCH pour ajouter le champ a la collection existante) :
   ```bash
   API_KEY=$(grep TYPESENSE_API_KEY .env | cut -d= -f2)
   curl -X PATCH "http://localhost:8108/collections/produits_prod" \
     -H "X-TYPESENSE-API-KEY: $API_KEY" \
     -H "Content-Type: application/json" \
     -d '{"fields":[{"name":"url_images","type":"string","optional":true,"index":false}]}'
   ```

### Phase 2 — Enrichissement progressif

- Le sync incremental quotidien (`sync_typesense_daily.php` cron 03:30 sur Ecritel) va progressivement ajouter `url_images` aux docs modifies (~5-10k/jour, basee sur `date_maj`).
- Pour les ~1.5M docs deja en Typesense sans `url_images`, le **SQL fallback PHP** (deja en place dans `search_ajax.php` / `search_extension.php` cote SFTP) prend le relais : 1 query batch sur `produit_front` pour recuperer les vignettes par id, latence +20-50ms negligeable.

### Phase 3 — Optionnel : back-fill complet

Plus tard, possibilite de lancer une re-ingestion massive pour avoir url_images sur les 1.5M docs et retirer le SQL fallback. Pas urgent car le fallback est performant.

## Test plan

- [ ] PR mergee
- [ ] `git pull` + rebuild VM OK
- [ ] Migration schema Typesense via PATCH OK (verifier via `GET /collections/produits_prod`)
- [ ] Forcer un sync incremental sur fenetre courte :
  ```bash
  SINCE=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%S)
  curl -s -X POST "http://localhost:8570/sync/incremental" \
    -H "X-Sync-Token: hp_sync_2026_04_30_xZ7q" \
    -H "Content-Type: application/json" \
    -d "{\"since\":\"$SINCE\",\"delete_orphans\":false,\"batch_size\":500}" \
    | python3 -m json.tool
  ```
- [ ] Verifier qu'un produit recent a bien `url_images` :
  ```bash
  curl -s -H "X-TYPESENSE-API-KEY: $API_KEY" \
    "http://localhost:8108/collections/produits_prod/documents/search?q=ritmo&query_by=nom_produit&include_fields=id_produit,url_images&per_page=3" \
    | python3 -m json.tool
  ```

## Risques

- Aucun risque casse-prod : le SQL fallback PHP couvre tous les cas ou Typesense n'a pas encore url_images.
- La migration schema (PATCH) est non-destructive : les docs existants restent intacts, le champ est simplement ajoute comme optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
