### PR TITLE
chore(mcp-gateway-service): log every branch of zoho consent state

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/app/zoho_catalog_adapter.go
+++ b/apps-microservices/mcp-gateway-service/internal/app/zoho_catalog_adapter.go
@@ -36,18 +36,37 @@ type zohoCatalogAdapter struct {
 }
 
 func (a *zohoCatalogAdapter) StateForEmail(_ context.Context, email string) gateway.ZohoCatalogState {
-	if a == nil || a.imports == nil || email == "" {
+	if a == nil {
+		log.Printf("[zoho-diag] StateForEmail: adapter is nil — returning empty state")
 		return gateway.ZohoCatalogState{}
 	}
+	if a.imports == nil {
+		log.Printf("[zoho-diag] StateForEmail email=%q: imports repo is nil — returning empty state", email)
+		return gateway.ZohoCatalogState{}
+	}
+	if email == "" {
+		log.Printf("[zoho-diag] StateForEmail: email is empty — returning empty state (no Configured flag set)")
+		return gateway.ZohoCatalogState{}
+	}
+
+	log.Printf("[zoho-diag] StateForEmail entry email=%q users_finder_wired=%t", email, a.users != nil)
 
 	isAdmin := false
 	if a.users != nil {
 		user, err := a.users.GetByEmail(email)
-		if err != nil {
-			log.Printf("[zoho-catalog] user lookup email=%s err=%v — treating as non-admin", email, err)
-		} else if user != nil && user.Role == "admin" {
+		switch {
+		case err != nil:
+			log.Printf("[zoho-diag] gateway_users lookup email=%q err=%v — treating as non-admin (fail-safe)", email, err)
+		case user == nil:
+			log.Printf("[zoho-diag] gateway_users lookup email=%q result=NO_ROW — treating as non-admin (user not in gateway_users)", email)
+		case user.Role == "admin":
+			log.Printf("[zoho-diag] gateway_users lookup email=%q result=ADMIN (role=%q) — will consult admin zoho row", email, user.Role)
 			isAdmin = true
+		default:
+			log.Printf("[zoho-diag] gateway_users lookup email=%q result=NON_ADMIN role=%q (literal 'admin' required) — will consult per-user zoho row", email, user.Role)
 		}
+	} else {
+		log.Printf("[zoho-diag] users finder not wired email=%q — defaulting to non-admin path", email)
 	}
 
 	var row *db.ZohoImport
@@ -55,26 +74,38 @@ func (a *zohoCatalogAdapter) StateForEmail(_ context.Context, email string) gate
 	if isAdmin {
 		row, err = a.imports.GetAdmin()
 		if err != nil {
-			log.Printf("[zoho-catalog] admin lookup err=%v email=%s", err, email)
+			log.Printf("[zoho-diag] GetAdmin email=%q err=%v — returning Configured=false", email, err)
+			return gateway.ZohoCatalogState{Configured: false}
 		}
+		if row == nil {
+			log.Printf("[zoho-diag] GetAdmin email=%q result=NO_ROW (no active is_admin=1 row in zoho_imports) — returning Configured=false", email)
+			return gateway.ZohoCatalogState{Configured: false}
+		}
+		log.Printf("[zoho-diag] GetAdmin email=%q result=HIT row_id=%s url=%s is_active=%t", email, row.ID, row.URL, row.IsActive)
 	} else {
 		row, err = a.imports.FindUserImportByEmail(email)
 		if err != nil {
-			log.Printf("[zoho-catalog] user import lookup email=%s err=%v", email, err)
+			log.Printf("[zoho-diag] FindUserImportByEmail email=%q err=%v — returning Configured=false", email, err)
+			return gateway.ZohoCatalogState{Configured: false}
 		}
-	}
-	if row == nil {
-		return gateway.ZohoCatalogState{Configured: false}
+		if row == nil {
+			log.Printf("[zoho-diag] FindUserImportByEmail email=%q result=NO_ROW (no active is_admin=0 row with LOWER(created_by)=LOWER(email)) — returning Configured=false. Hint: check zoho_imports.created_by exact match (no login-portion fallback in consent path).", email)
+			return gateway.ZohoCatalogState{Configured: false}
+		}
+		log.Printf("[zoho-diag] FindUserImportByEmail email=%q result=HIT row_id=%s created_by=%q url=%s is_active=%t", email, row.ID, row.CreatedBy, row.URL, row.IsActive)
 	}
 
 	tools, err := a.imports.ListTools(row.ID)
 	if err != nil {
-		log.Printf("[zoho-catalog] list tools import=%s err=%v", row.ID, err)
+		log.Printf("[zoho-diag] ListTools import_id=%s email=%q err=%v — returning Configured=false", row.ID, email, err)
 		return gateway.ZohoCatalogState{Configured: false}
 	}
 	if len(tools) == 0 {
+		log.Printf("[zoho-diag] ListTools import_id=%s email=%q tool_count=0 — returning Configured=false. Hint: discovery never persisted any tool (upstream tools/list failed or returned empty). Trigger POST /api/v1/zoho-imports/%s/discover and watch [zoho-discover] logs.", row.ID, email, row.ID)
 		return gateway.ZohoCatalogState{Configured: false}
 	}
+
+	log.Printf("[zoho-diag] StateForEmail email=%q result=Configured=true import_id=%s tool_count=%d", email, row.ID, len(tools))
 
 	out := make([]mcp.Tool, 0, len(tools))
 	for _, t := range tools {

--- a/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
@@ -257,9 +257,18 @@ func (s *AuthServer) renderConsent(w http.ResponseWriter, r *http.Request, clien
 	// Per-viewer Zoho state — fetched once before iterating servers so we
 	// can route unconfigured Zoho backends into a dedicated section while
 	// keeping configured ones in the main list.
+	log.Printf("[zoho-diag] renderConsent (HTML) email=%q client_id=%s pre_configured_scope=%t active_servers=%d zoho_servers=%d zoho_fetcher_wired=%t", userEmail, client.ID, hasPreConfiguredScope, len(servers), len(zohoIDs), s.zohoFetcher != nil)
 	var zohoState map[string]gateway.ZohoServerState
-	if s.zohoFetcher != nil && userEmail != "" && len(zohoIDs) > 0 {
+	switch {
+	case s.zohoFetcher == nil:
+		log.Printf("[zoho-diag] renderConsent email=%q: zoho fetcher not wired — every Zoho server stays as cached admin tools", userEmail)
+	case userEmail == "":
+		log.Printf("[zoho-diag] renderConsent: userEmail is empty — every Zoho server stays as cached admin tools (anonymous browser?)")
+	case len(zohoIDs) == 0:
+		log.Printf("[zoho-diag] renderConsent email=%q: no Zoho-tagged servers registered — skipping fetch", userEmail)
+	default:
 		zohoState = s.zohoFetcher.FetchZohoStateForUser(r.Context(), userEmail)
+		log.Printf("[zoho-diag] renderConsent email=%q: fetched zoho state entries=%d", userEmail, len(zohoState))
 	}
 
 	type toolEntry struct {

--- a/apps-microservices/mcp-gateway-service/internal/authserver/authorize_api.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/authorize_api.go
@@ -432,6 +432,7 @@ func (s *AuthServer) buildServerList(ctx context.Context, client *db.OAuth2Clien
 			zohoIDs[srv.ID] = true
 		}
 	}
+	log.Printf("[zoho-diag] buildServerList (JSON API) email=%q client_id=%s pre_configured_scope=%t active_servers=%d zoho_servers=%d zoho_fetcher_wired=%t", userEmail, client.ID, hasPreConfiguredScope, len(servers), len(zohoIDs), s.zohoFetcher != nil)
 
 	var result []authorizeServerDTO
 
@@ -520,29 +521,43 @@ func applyZohoUserState(
 	userEmail string,
 	docsURL string,
 ) []authorizeServerDTO {
-	if fetcher == nil || userEmail == "" || len(zohoIDs) == 0 {
+	if fetcher == nil {
+		log.Printf("[zoho-diag] applyZohoUserState: fetcher is nil — every Zoho server stays as cached admin tools (no per-viewer override)")
 		return servers
 	}
+	if userEmail == "" {
+		log.Printf("[zoho-diag] applyZohoUserState: userEmail is empty — every Zoho server stays as cached admin tools (no per-viewer override)")
+		return servers
+	}
+	if len(zohoIDs) == 0 {
+		log.Printf("[zoho-diag] applyZohoUserState email=%q: no Zoho-tagged servers registered — passthrough", userEmail)
+		return servers
+	}
+	log.Printf("[zoho-diag] applyZohoUserState email=%q zoho_backend_count=%d — fetching per-viewer state", userEmail, len(zohoIDs))
 	state := fetcher.FetchZohoStateForUser(ctx, userEmail)
+	if state == nil {
+		log.Printf("[zoho-diag] applyZohoUserState email=%q: FetchZohoStateForUser returned nil — every Zoho server will fall into unconfigured branch below", userEmail)
+	}
 	for i, srv := range servers {
 		if !zohoIDs[srv.ID] {
 			continue
 		}
 		st, ok := state[srv.ID]
 		if !ok {
-			// No entry returned: treat as unconfigured (fail-safe — never
-			// leak the cached admin tools onto a non-admin consent screen).
+			log.Printf("[zoho-diag] applyZohoUserState email=%q server_id=%s: no state entry returned — marking Configured=false (fail-safe)", userEmail, srv.ID)
 			servers[i].Tools = nil
 			servers[i].Configured = false
 			servers[i].DocsURL = docsURL
 			continue
 		}
 		if !st.Configured {
+			log.Printf("[zoho-diag] applyZohoUserState email=%q server_id=%s: state.Configured=false — marking unconfigured (root cause is in [zoho-diag] StateForEmail logs above)", userEmail, srv.ID)
 			servers[i].Tools = nil
 			servers[i].Configured = false
 			servers[i].DocsURL = docsURL
 			continue
 		}
+		log.Printf("[zoho-diag] applyZohoUserState email=%q server_id=%s: Configured=true tool_count=%d — substituting per-viewer tools", userEmail, srv.ID, len(st.Tools))
 		converted := make([]authorizeToolDTO, 0, len(st.Tools))
 		for _, t := range st.Tools {
 			converted = append(converted, authorizeToolDTO{


### PR DESCRIPTION
Add [zoho-diag] logs in zohoCatalogAdapter.StateForEmail, AuthServer renderConsent and buildServerList, plus applyZohoUserState. Each branch leading to Configured=false now identifies the exact cause (missing gateway_users row, role mismatch, GetAdmin/FindUserImportByEmail miss, ListTools empty, fetcher unwired) so the "Non configuré" symptom can be diagnosed from a single /authorize round.

Ajout de logs [zoho-diag] dans zohoCatalogAdapter.StateForEmail, dans renderConsent et buildServerList de AuthServer, ainsi que dans applyZohoUserState. Chaque branche menant à Configured=false précise désormais la cause exacte (ligne gateway_users manquante, rôle incorrect, échec de GetAdmin/FindUserImportByEmail, ListTools vide, fetcher non branché) pour diagnostiquer le symptôme « Non configuré » en un seul appel /authorize.