### PR TITLE
chore(mcp-gateway-service): dump registry on zoho consent miss

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/gateway/gateway.go
+++ b/apps-microservices/mcp-gateway-service/internal/gateway/gateway.go
@@ -194,17 +194,28 @@ func (g *Gateway) DiscoverAndRegister(ctx context.Context, id string, url string
 // of truth).
 func (g *Gateway) FetchZohoStateForUser(ctx context.Context, email string) map[string]ZohoServerState {
 	if email == "" {
+		log.Printf("[zoho-diag] gateway.FetchZohoStateForUser: empty email — returning nil")
 		return nil
 	}
 
+	all := g.registry.All()
 	var zohoBackends []*BackendServer
-	for _, srv := range g.registry.All() {
+	for _, srv := range all {
 		if srv.HasTag("zoho") || srv.ToolPrefix == "zoho" {
 			zohoBackends = append(zohoBackends, srv)
 		}
 	}
 	if len(zohoBackends) == 0 {
+		log.Printf("[zoho-diag] gateway.FetchZohoStateForUser email=%s: NO zoho backend in in-memory registry (registry_total=%d). Dumping all registered backends:", email, len(all))
+		for _, srv := range all {
+			log.Printf("[zoho-diag]   registry id=%s name=%q tool_prefix=%q tags=%v", srv.ID, srv.Name, srv.ToolPrefix, srv.Tags)
+		}
+		log.Printf("[zoho-diag] gateway.FetchZohoStateForUser email=%s: registry/DB drift — DB rows that pass isZohoServer() exist but registry has none. Likely a health-check/re-discovery wiped tags, or the server was never registered with the 'zoho' tag.", email)
 		return nil
+	}
+	log.Printf("[zoho-diag] gateway.FetchZohoStateForUser email=%s: found %d zoho backend(s) in registry", email, len(zohoBackends))
+	for _, srv := range zohoBackends {
+		log.Printf("[zoho-diag]   zoho backend id=%s name=%q tool_prefix=%q tags=%v template_slug=%q created_by=%q", srv.ID, srv.Name, srv.ToolPrefix, srv.Tags, srv.TemplateSlug, srv.CreatedBy)
 	}
 
 	out := make(map[string]ZohoServerState, len(zohoBackends))


### PR DESCRIPTION
FetchZohoStateForUser now logs every registered backend (id, name, tool_prefix, tags) when no zoho-tagged backend matches in the in-memory registry. Exposes registry/DB drift cases where the consent path sees a zoho server via serverRepo.ListActive but the registry holds none (missing tag, casing mismatch on tool_prefix, or rediscovery dropping tags).

FetchZohoStateForUser journalise désormais chaque backend enregistré (id, name, tool_prefix, tags) lorsqu'aucun backend zoho n'est trouvé dans le registre en mémoire. Expose les cas de désynchronisation registre/BDD où le flux de consentement voit un serveur zoho via serverRepo.ListActive mais où le registre n'en contient aucun (tag manquant, casse incorrecte sur tool_prefix, ou redécouverte qui perd les tags).