### PR TITLE
fix(mcp-gateway-service): hydrate registry tags on boot discovery

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/app/app.go
+++ b/apps-microservices/mcp-gateway-service/internal/app/app.go
@@ -523,6 +523,13 @@ func loadServersFromDB(gw *gateway.Gateway, reg *gateway.Registry, repo *reposit
 				if s.ToolPrefix != "" {
 					reg.SetToolPrefix(s.ID, s.ToolPrefix)
 				}
+				if len(s.Tags) > 0 {
+					tags := make([]string, 0, len(s.Tags))
+					for _, t := range s.Tags {
+						tags = append(tags, t.Tag)
+					}
+					reg.SetTags(s.ID, tags)
+				}
 				toolStates := make(map[string]bool, len(s.Tools))
 				for _, t := range s.Tools {
 					toolStates[t.Name] = t.IsActive


### PR DESCRIPTION
DiscoverAndRegister never loaded tags from the DB, so reachable backends ended up with empty Tags in the in-memory registry. The Zoho consent path relied on HasTag("zoho") to identify the stub backend and silently failed (registry/DB drift), rendering every Zoho server as "Non configuré".

Boot loop now calls reg.SetTags after a successful discovery, in parallel with the existing SetToolPrefix / SyncToolActiveStates calls. Failure path (registerFromDBCache) was already correct.

DiscoverAndRegister ne chargeait pas les tags depuis la BDD, donc les backends joignables se retrouvaient avec un slice Tags vide dans le registre en mémoire. Le flux de consentement Zoho s'appuie sur HasTag("zoho") pour identifier le backend stub et échouait silencieusement (désynchronisation registre/BDD), affichant chaque serveur Zoho comme « Non configuré ».

La boucle de boot appelle désormais reg.SetTags après une découverte réussie, en parallèle des appels SetToolPrefix / SyncToolActiveStates existants. Le chemin d'échec (registerFromDBCache) était déjà correct.