### PR TITLE
fix(mcp-gateway-service): match per-user zoho row by login portion too

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/repository/zoho_import_repo.go
+++ b/apps-microservices/mcp-gateway-service/internal/repository/zoho_import_repo.go
@@ -99,11 +99,22 @@ func (r *ZohoImportRepo) DeleteAdmin() error {
 }
 
 // FindUserImportByEmail returns the oldest active per-user import whose
-// created_by matches email (case-insensitive). Returns (nil, nil) when not found.
+// created_by matches email (case-insensitive). Mirrors the runtime resolver
+// in mcp-zoho-service: tries exact-email first, then falls back to the
+// login portion (local-part before @) so sheet-imports that stored
+// created_by="alice" still resolve when the caller is alice@hp.fr.
+// Returns (nil, nil) when nothing matches.
 func (r *ZohoImportRepo) FindUserImportByEmail(email string) (*db.ZohoImport, error) {
+	login := email
+	if at := strings.IndexByte(email, '@'); at > 0 {
+		login = email[:at]
+	}
 	var out db.ZohoImport
 	err := r.db.
-		Where("is_admin = ? AND is_active = ? AND LOWER(created_by) = LOWER(?)", false, true, email).
+		Where(
+			"is_admin = ? AND is_active = ? AND (LOWER(created_by) = LOWER(?) OR (? <> '' AND LOWER(created_by) = LOWER(?)))",
+			false, true, email, login, login,
+		).
 		Order("created_at ASC").
 		First(&out).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
FindUserImportByEmail did exact-email match only, while the runtime resolver in mcp-zoho-service (db/queries.go FindUserZohoImport) already falls back to the login portion (local-part before '@'). Drift: sheet-imports that stored created_by="alice" route fine at runtime but the consent screen rendered "Non configuré".

The repo now mirrors the runtime: exact email first, then login fallback. Both branches still scoped to is_admin=0 AND is_active=1.

FindUserImportByEmail effectuait une correspondance exacte sur l'email alors que le résolveur runtime dans mcp-zoho-service (db/queries.go FindUserZohoImport) accepte déjà le repli sur la partie login (local-part avant '@'). Désynchronisation : les imports de feuille stockés avec created_by="alice" routaient correctement au runtime mais l'écran de consentement affichait « Non configuré ».

Le repo reflète désormais le runtime : email exact d'abord, puis repli sur le login. Les deux branches restent filtrées par is_admin=0 ET is_active=1.