### PR TITLE
feat(mcp-gateway-service): self-heal zoho consent when catalog empty

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/api/zoho_discover.go
+++ b/apps-microservices/mcp-gateway-service/internal/api/zoho_discover.go
@@ -1,23 +1,14 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"time"
 
 	"mcp-gateway/internal/crypto"
 	"mcp-gateway/internal/db"
 	"mcp-gateway/internal/repository"
+	"mcp-gateway/internal/zohodiscover"
 )
-
-// zohoDiscoverTimeout caps each upstream tools/list probe. Mirrors the
-// timeout used by the manual /test endpoint so behaviour stays consistent.
-const zohoDiscoverTimeout = 10 * time.Second
 
 // discoverZohoToolsForImport fetches the current tool catalog from the
 // upstream MCP server pointed at by row.URL using the row's decrypted
@@ -35,7 +26,7 @@ func discoverZohoToolsForImport(
 		return
 	}
 
-	tools, err := fetchZohoTools(ctx, encryptor, row)
+	tools, err := zohodiscover.FetchTools(ctx, encryptor, row)
 	if err != nil {
 		log.Printf("[zoho-discover] import=%s url=%s err=%v — keeping previous catalog", row.ID, row.URL, err)
 		return
@@ -48,92 +39,19 @@ func discoverZohoToolsForImport(
 	log.Printf("[zoho-discover] import=%s url=%s tools=%d persisted", row.ID, row.URL, len(tools))
 }
 
-// fetchZohoTools POSTs a JSON-RPC tools/list to the upstream URL with the
-// decrypted auth headers and returns the parsed catalog. Errors here are
-// terminal for this call but never reach the user — the caller logs and
-// keeps the previously persisted catalog.
+// fetchZohoTools is a thin wrapper retained so zoho_admin_handlers.go and
+// existing tests keep their call sites. New code should call
+// zohodiscover.FetchTools directly.
 func fetchZohoTools(ctx context.Context, encryptor *crypto.Encryptor, row *db.ZohoImport) ([]db.ZohoImportTool, error) {
-	headers := decryptZohoAuthHeaders(encryptor, row.AuthHeaders)
-
-	const probeBody = `{"jsonrpc":"2.0","method":"tools/list","id":1}`
-	reqCtx, cancel := context.WithTimeout(ctx, zohoDiscoverTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, row.URL, bytes.NewBufferString(probeBody))
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-
-	return parseToolsListResponse(body)
+	return zohodiscover.FetchTools(ctx, encryptor, row)
 }
 
-// decryptZohoAuthHeaders returns the {k:v} header map persisted for a Zoho
-// row. Always returns a non-nil map so callers can range over it without a
-// nil check. Errors are silently mapped to an empty map — same as the
-// existing test endpoint behaviour.
+// decryptZohoAuthHeaders wrapper kept for test compatibility.
 func decryptZohoAuthHeaders(encryptor *crypto.Encryptor, raw []byte) map[string]string {
-	headers := map[string]string{}
-	if len(raw) == 0 {
-		return headers
-	}
-	if encryptor != nil {
-		pt, err := encryptor.Decrypt(raw)
-		if err != nil {
-			return headers
-		}
-		_ = json.Unmarshal(pt, &headers)
-		return headers
-	}
-	_ = json.Unmarshal(raw, &headers)
-	return headers
+	return zohodiscover.DecryptAuthHeaders(encryptor, raw)
 }
 
-// parseToolsListResponse decodes a JSON-RPC tools/list envelope. Missing
-// or error responses yield an empty slice (no error) — the caller logs
-// the upstream status separately.
+// parseToolsListResponse wrapper kept for test compatibility.
 func parseToolsListResponse(body []byte) ([]db.ZohoImportTool, error) {
-	var envelope struct {
-		Result struct {
-			Tools []struct {
-				Name        string          `json:"name"`
-				Description string          `json:"description"`
-				InputSchema json.RawMessage `json:"inputSchema"`
-			} `json:"tools"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-	out := make([]db.ZohoImportTool, 0, len(envelope.Result.Tools))
-	for _, t := range envelope.Result.Tools {
-		schema := t.InputSchema
-		if len(schema) == 0 {
-			schema = json.RawMessage(`{}`)
-		}
-		out = append(out, db.ZohoImportTool{
-			Name:        t.Name,
-			Description: t.Description,
-			InputSchema: schema,
-		})
-	}
-	return out, nil
+	return zohodiscover.ParseToolsListResponse(body)
 }

--- a/apps-microservices/mcp-gateway-service/internal/app/app.go
+++ b/apps-microservices/mcp-gateway-service/internal/app/app.go
@@ -387,7 +387,7 @@ func registerRESTAndOAuthServer(
 	apiHandler.SetEncryptor(dbs.encryptor)
 	zohoImportRepo := repository.NewZohoImportRepo(dbs.database)
 	apiHandler.SetZohoImportRepo(zohoImportRepo)
-	gw.SetZohoUserCatalog(&zohoCatalogAdapter{imports: zohoImportRepo, users: dbs.userRepo})
+	gw.SetZohoUserCatalog(&zohoCatalogAdapter{imports: zohoImportRepo, users: dbs.userRepo, encryptor: dbs.encryptor})
 	log.Println("[main] zoho-imports admin REST wired + persisted catalog source attached to gateway")
 
 	if cfg.GoogleClientID != "" && cfg.GoogleClientSecret != "" {

--- a/apps-microservices/mcp-gateway-service/internal/app/zoho_catalog_adapter.go
+++ b/apps-microservices/mcp-gateway-service/internal/app/zoho_catalog_adapter.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"log"
 
+	"mcp-gateway/internal/crypto"
 	"mcp-gateway/internal/db"
 	"mcp-gateway/internal/gateway"
 	"mcp-gateway/internal/mcp"
 	"mcp-gateway/internal/repository"
+	"mcp-gateway/internal/zohodiscover"
 )
 
 // userFinder is the slice of *repository.UserRepo the adapter needs to
@@ -30,12 +32,20 @@ type userFinder interface {
 //
 // On any UserRepo error, the viewer is treated as non-admin (fail-safe:
 // never auto-promote on transient DB errors).
+//
+// When the persisted catalog (zoho_import_tools) is empty for a resolved
+// row, the adapter performs a one-shot live tools/list probe against the
+// row's upstream URL (using the row's decrypted auth headers) and
+// persists the result. Subsequent consent renders are served from the
+// persisted catalog. The probe is bounded by zohodiscover.DefaultTimeout
+// (10s) and is best-effort: any failure logs and returns Configured=false.
 type zohoCatalogAdapter struct {
-	imports *repository.ZohoImportRepo
-	users   userFinder
+	imports   *repository.ZohoImportRepo
+	users     userFinder
+	encryptor *crypto.Encryptor
 }
 
-func (a *zohoCatalogAdapter) StateForEmail(_ context.Context, email string) gateway.ZohoCatalogState {
+func (a *zohoCatalogAdapter) StateForEmail(ctx context.Context, email string) gateway.ZohoCatalogState {
 	if a == nil {
 		log.Printf("[zoho-diag] StateForEmail: adapter is nil — returning empty state")
 		return gateway.ZohoCatalogState{}
@@ -101,8 +111,13 @@ func (a *zohoCatalogAdapter) StateForEmail(_ context.Context, email string) gate
 		return gateway.ZohoCatalogState{Configured: false}
 	}
 	if len(tools) == 0 {
-		log.Printf("[zoho-diag] ListTools import_id=%s email=%q tool_count=0 — returning Configured=false. Hint: discovery never persisted any tool (upstream tools/list failed or returned empty). Trigger POST /api/v1/zoho-imports/%s/discover and watch [zoho-discover] logs.", row.ID, email, row.ID)
-		return gateway.ZohoCatalogState{Configured: false}
+		log.Printf("[zoho-diag] ListTools import_id=%s email=%q tool_count=0 — running one-shot live tools/list probe + persist", row.ID, email)
+		tools = a.liveDiscoverAndPersist(ctx, row, email)
+		if len(tools) == 0 {
+			log.Printf("[zoho-diag] live probe import_id=%s email=%q persisted_count=0 — returning Configured=false (upstream tools/list failed or returned empty; check [zoho-discover] logs)", row.ID, email)
+			return gateway.ZohoCatalogState{Configured: false}
+		}
+		log.Printf("[zoho-diag] live probe import_id=%s email=%q persisted_count=%d — Configured=true", row.ID, email, len(tools))
 	}
 
 	log.Printf("[zoho-diag] StateForEmail email=%q result=Configured=true import_id=%s tool_count=%d", email, row.ID, len(tools))
@@ -119,3 +134,26 @@ func (a *zohoCatalogAdapter) StateForEmail(_ context.Context, email string) gate
 	return gateway.ZohoCatalogState{Tools: out, Configured: true}
 }
 
+// liveDiscoverAndPersist runs a one-shot upstream tools/list probe against
+// row.URL with the row's decrypted auth headers and persists the result
+// into zoho_import_tools. Returns the freshly persisted slice (possibly
+// empty when the upstream is unreachable / mis-auth'd). Best-effort: all
+// errors are logged and mapped to an empty slice so the consent path
+// stays responsive.
+func (a *zohoCatalogAdapter) liveDiscoverAndPersist(ctx context.Context, row *db.ZohoImport, email string) []db.ZohoImportTool {
+	if row == nil || row.URL == "" {
+		log.Printf("[zoho-diag] liveDiscoverAndPersist skipped: row nil or row.URL empty (email=%q)", email)
+		return nil
+	}
+	tools, err := zohodiscover.FetchTools(ctx, a.encryptor, row)
+	if err != nil {
+		log.Printf("[zoho-discover] import=%s url=%s email=%q err=%v (consent-path probe)", row.ID, row.URL, email, err)
+		return nil
+	}
+	if _, perr := a.imports.ReplaceTools(row.ID, tools); perr != nil {
+		log.Printf("[zoho-discover] import=%s persist err=%v (consent-path probe) — returning fetched tools without persistence", row.ID, perr)
+		return tools
+	}
+	log.Printf("[zoho-discover] import=%s url=%s tools=%d persisted (consent-path probe email=%q)", row.ID, row.URL, len(tools), email)
+	return tools
+}

--- a/apps-microservices/mcp-gateway-service/internal/zohodiscover/discover.go
+++ b/apps-microservices/mcp-gateway-service/internal/zohodiscover/discover.go
@@ -1,0 +1,113 @@
+// Package zohodiscover probes an upstream Zoho MCP server for its current
+// tools/list catalog and shapes the result into db.ZohoImportTool rows ready
+// for persistence in zoho_import_tools.
+//
+// Two callers share the helper:
+//   - api.discoverZohoToolsForImport — runs at row create / admin upsert /
+//     manual /discover / successful /test.
+//   - app.zohoCatalogAdapter — runs at consent-screen render when the
+//     persisted catalog is empty, so the first viewer triggers a probe and
+//     the result is persisted for every subsequent render.
+package zohodiscover
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"mcp-gateway/internal/crypto"
+	"mcp-gateway/internal/db"
+)
+
+// DefaultTimeout caps each upstream tools/list probe.
+const DefaultTimeout = 10 * time.Second
+
+// FetchTools POSTs a JSON-RPC tools/list to row.URL with the decrypted
+// auth headers and returns the parsed catalog. Errors are terminal for
+// this call; callers log and decide how to handle (keep previous, return
+// Configured=false, etc.).
+func FetchTools(ctx context.Context, encryptor *crypto.Encryptor, row *db.ZohoImport) ([]db.ZohoImportTool, error) {
+	headers := DecryptAuthHeaders(encryptor, row.AuthHeaders)
+
+	const probeBody = `{"jsonrpc":"2.0","method":"tools/list","id":1}`
+	reqCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, row.URL, bytes.NewBufferString(probeBody))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	return ParseToolsListResponse(body)
+}
+
+// DecryptAuthHeaders returns the {k:v} header map persisted for a Zoho row.
+// Always returns a non-nil map. Errors are silently mapped to an empty map.
+func DecryptAuthHeaders(encryptor *crypto.Encryptor, raw []byte) map[string]string {
+	headers := map[string]string{}
+	if len(raw) == 0 {
+		return headers
+	}
+	if encryptor != nil {
+		pt, err := encryptor.Decrypt(raw)
+		if err != nil {
+			return headers
+		}
+		_ = json.Unmarshal(pt, &headers)
+		return headers
+	}
+	_ = json.Unmarshal(raw, &headers)
+	return headers
+}
+
+// ParseToolsListResponse decodes a JSON-RPC tools/list envelope.
+func ParseToolsListResponse(body []byte) ([]db.ZohoImportTool, error) {
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string          `json:"name"`
+				Description string          `json:"description"`
+				InputSchema json.RawMessage `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	out := make([]db.ZohoImportTool, 0, len(envelope.Result.Tools))
+	for _, t := range envelope.Result.Tools {
+		schema := t.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{}`)
+		}
+		out = append(out, db.ZohoImportTool{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: schema,
+		})
+	}
+	return out, nil
+}

--- a/apps-microservices/mcp-gateway-service/internal/zohodiscover/discover_test.go
+++ b/apps-microservices/mcp-gateway-service/internal/zohodiscover/discover_test.go
@@ -1,0 +1,92 @@
+package zohodiscover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"mcp-gateway/internal/db"
+)
+
+func TestParseToolsListResponse_HappyPath(t *testing.T) {
+	body := []byte(`{"result":{"tools":[{"name":"a","description":"d","inputSchema":{"type":"object"}}]}}`)
+	tools, err := ParseToolsListResponse(body)
+	if err != nil {
+		t.Fatalf("ParseToolsListResponse: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "a" || tools[0].Description != "d" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+	if string(tools[0].InputSchema) == "" || string(tools[0].InputSchema) == "null" {
+		t.Fatalf("inputSchema empty/null: %s", string(tools[0].InputSchema))
+	}
+}
+
+func TestParseToolsListResponse_EmptySchemaDefault(t *testing.T) {
+	body := []byte(`{"result":{"tools":[{"name":"a"}]}}`)
+	tools, err := ParseToolsListResponse(body)
+	if err != nil {
+		t.Fatalf("ParseToolsListResponse: %v", err)
+	}
+	if string(tools[0].InputSchema) != "{}" {
+		t.Fatalf("want default '{}', got %q", string(tools[0].InputSchema))
+	}
+}
+
+func TestParseToolsListResponse_InvalidJSON(t *testing.T) {
+	_, err := ParseToolsListResponse([]byte(`not-json`))
+	if err == nil {
+		t.Fatal("want error on invalid JSON")
+	}
+}
+
+func TestDecryptAuthHeaders_NoEncryptor_PlaintextJSON(t *testing.T) {
+	raw, _ := json.Marshal(map[string]string{"Authorization": "Bearer x"})
+	got := DecryptAuthHeaders(nil, raw)
+	if got["Authorization"] != "Bearer x" {
+		t.Fatalf("want Bearer x, got %+v", got)
+	}
+}
+
+func TestDecryptAuthHeaders_Empty(t *testing.T) {
+	got := DecryptAuthHeaders(nil, nil)
+	if len(got) != 0 {
+		t.Fatalf("want empty map, got %+v", got)
+	}
+}
+
+func TestFetchTools_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "yes" {
+			t.Errorf("missing forwarded header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"tools":[{"name":"tool-1","description":"d","inputSchema":{"type":"object"}}]}}`))
+	}))
+	defer srv.Close()
+
+	hdrs, _ := json.Marshal(map[string]string{"X-Custom": "yes"})
+	row := &db.ZohoImport{URL: srv.URL, AuthHeaders: hdrs}
+
+	tools, err := FetchTools(context.Background(), nil, row)
+	if err != nil {
+		t.Fatalf("FetchTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "tool-1" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}
+
+func TestFetchTools_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	row := &db.ZohoImport{URL: srv.URL}
+	if _, err := FetchTools(context.Background(), nil, row); err == nil {
+		t.Fatal("want error on 500")
+	}
+}


### PR DESCRIPTION
Extracted the upstream tools/list probe into a shared internal/zohodiscover package consumed by both the existing api.discoverZohoToolsForImport path (sheet import, admin upsert, manual /test and /discover) and the new consent-screen self-heal path.

When zohoCatalogAdapter.StateForEmail resolves a row but finds zoho_import_tools empty, it now performs a one-shot live probe against the row's upstream URL with the decrypted auth headers, persists the result via ReplaceTools and returns Configured=true on success. Probe bounded by zohodiscover.DefaultTimeout (10s). Best-effort: any failure logs and yields Configured=false so the consent screen still renders (with the existing docs CTA).

Extraction de la sonde upstream tools/list dans un package partagé internal/zohodiscover utilisé à la fois par le chemin existant api.discoverZohoToolsForImport (import de feuille, upsert admin, /test et /discover manuels) et par le nouveau chemin d'auto-soin de l'écran de consentement.

Quand zohoCatalogAdapter.StateForEmail résout une ligne mais trouve zoho_import_tools vide, il effectue désormais une sonde unique en direct contre l'URL upstream avec les en-têtes d'auth déchiffrés, persiste le résultat via ReplaceTools et renvoie Configured=true en cas de succès. Sonde bornée par zohodiscover.DefaultTimeout (10s). Meilleur effort : tout échec journalise et renvoie Configured=false pour que l'écran de consentement s'affiche quand même (avec le CTA docs existant).