### PR TITLE
fix(mcp-gateway-service): show full per-user zoho catalog on consent …

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
+++ b/apps-microservices/mcp-gateway-service/internal/authserver/authorize.go
@@ -313,6 +313,7 @@ func (s *AuthServer) renderConsent(w http.ResponseWriter, r *http.Request, clien
 			// "Non configurés" section.
 			srvTools := allowedTools[srv.ID]
 			source := srv.Tools
+			zohoOverride := false
 			if zohoIDs[srv.ID] {
 				unconf, userTools := decideZohoServerEntry(srv.ID, zohoIDs, zohoState)
 				if unconf {
@@ -324,9 +325,15 @@ func (s *AuthServer) renderConsent(w http.ResponseWriter, r *http.Request, clien
 					continue
 				}
 				source = toServerTools(userTools)
+				zohoOverride = true
 			}
 			for _, t := range source {
-				if srvTools != nil && !srvTools[t.Name] {
+				// Zoho catalogs are per-viewer and dynamic — the OAuth2 client's
+				// tool allow-list (built against the admin catalog) cannot
+				// represent the user's actual catalog 1:1. Skip the name filter
+				// when the source is a per-user Zoho override so the consent
+				// screen mirrors what buildServerList (JSON API) returns.
+				if !zohoOverride && srvTools != nil && !srvTools[t.Name] {
 					continue
 				}
 				entry.Tools = append(entry.Tools, toolEntry{


### PR DESCRIPTION
…HTML

renderConsent filtered the per-user Zoho tool list with the OAuth2 client's tool allow-list (built against the admin catalog), so a user with a richer catalog than the admin saw only the intersection — effectively the admin's tool names. buildServerList (JSON API) already bypassed the filter because applyZohoUserState replaces the DTO Tools wholesale after the filter loop; the HTML template was the divergent path.

Skip the per-tool name filter when source has been overridden by the Zoho user catalog. Non-Zoho servers still honor the allow-list.

renderConsent filtrait la liste d'outils Zoho par utilisateur avec l'allow-list d'outils du client OAuth2 (construite sur le catalogue admin) ; un utilisateur avec un catalogue plus riche que l'admin ne voyait que l'intersection — en pratique les outils de l'admin. buildServerList (API JSON) contournait déjà le filtre parce que applyZohoUserState remplace les Tools du DTO en bloc après la boucle de filtrage ; le template HTML était le chemin divergent.

Saute le filtre par nom d'outil lorsque la source provient du catalogue utilisateur Zoho. Les serveurs non-Zoho honorent toujours l'allow-list.