### PR TITLE
fix(mcp-gateway-service): surface full live zoho catalog to mcp client

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/gateway/scoped_gateway.go
+++ b/apps-microservices/mcp-gateway-service/internal/gateway/scoped_gateway.go
@@ -237,15 +237,15 @@ func (sg *ScopedGateway) fetchZohoTools(ctx context.Context, b *BackendServer) [
 		return sg.registry.MergedToolsFilteredWithTools(map[string]bool{b.ID: true}, sg.allowedTools)
 	}
 	log.Printf("[scoped] zoho tools/list live-fetch backend=%s live_count=%d", b.ID, len(liveTools))
-	var toolSet map[string]bool
-	if sg.allowedTools != nil {
-		toolSet = sg.allowedTools[b.ID]
-	}
+	// Zoho catalogs are per-viewer and dynamic. The OAuth2 client / scope
+	// token's tool allow-list (sg.allowedTools[b.ID]) was selected against
+	// the admin catalog at issuance time and cannot represent the live
+	// per-user catalog 1:1. Surface every live tool to the MCP client so
+	// they actually see their own catalog — buildServerList (JSON API)
+	// and the consent HTML already do the same. Non-Zoho backends keep
+	// their per-tool filter via MergedToolsFilteredWithTools.
 	out := make([]mcp.Tool, 0, len(liveTools))
 	for _, t := range liveTools {
-		if toolSet != nil && !toolSet[t.Name] {
-			continue
-		}
 		out = append(out, mcp.Tool{
 			Name:        PrefixedToolName(b.ToolPrefix, t.Name),
 			Description: t.Description,


### PR DESCRIPTION
handleToolsList live-fetches Zoho tools per-user via mcp-zoho-service but then re-applied the OAuth2 client's tool allow-list, dropping every tool the per-user upstream exposes that the admin catalog didn't list. The MCP client therefore saw only the intersection of admin and user catalogs (looking like the admin's default tools).

Drop the per-tool filter on the live-fetched Zoho path; non-Zoho backends keep their existing per-tool allow-list via MergedToolsFilteredWithTools. Matches buildServerList (JSON API) and renderConsent (HTML) which already surface the full per-user catalog at consent time.

handleToolsList récupère en direct les outils Zoho par utilisateur via mcp-zoho-service, mais réappliquait ensuite l'allow-list d'outils du client OAuth2, supprimant tous les outils exposés par l'upstream utilisateur que le catalogue admin ne listait pas. Le client MCP ne voyait donc que l'intersection des catalogues admin et utilisateur (ressemblant aux outils par défaut de l'admin).

Supprime le filtre par outil sur le chemin de récupération live Zoho ; les backends non-Zoho conservent leur allow-list existante via MergedToolsFilteredWithTools. Aligné avec buildServerList (API JSON) et renderConsent (HTML) qui exposaient déjà le catalogue utilisateur complet à l'écran de consentement.