### PR TITLE
fix(mcp-gateway-service): route unknown zoho tools to stub via fallback

### DIFF
--- a/apps-microservices/mcp-gateway-service/internal/gateway/scoped_gateway.go
+++ b/apps-microservices/mcp-gateway-service/internal/gateway/scoped_gateway.go
@@ -207,6 +207,31 @@ func (sg *ScopedGateway) handleToolsList(ctx context.Context, req *mcp.Request) 
 	return okResp(req.ID, mcp.ListToolsResult{Tools: tools})
 }
 
+// findZohoFallback returns the in-scope Zoho stub backend that owns the
+// given tool name, along with the unprefixed name to forward upstream.
+// Used by handleToolsCall when the registry lookup misses (the user's
+// per-instance Zoho catalog exposes tools the admin instance doesn't,
+// so they aren't cached in the registry). Matches happen on the
+// (optional) Zoho tool_prefix or, when the stub has no prefix, on every
+// Zoho-tagged backend in scope. Returns (nil, "") when no Zoho backend
+// is in scope.
+func (sg *ScopedGateway) findZohoFallback(name string) (*BackendServer, string) {
+	zohoBackends := sg.zohoBackendsInScope()
+	if len(zohoBackends) == 0 {
+		return nil, ""
+	}
+	for _, b := range zohoBackends {
+		if b.ToolPrefix == "" {
+			return b, name
+		}
+		prefix := b.ToolPrefix + "_"
+		if len(name) > len(prefix) && name[:len(prefix)] == prefix {
+			return b, name[len(prefix):]
+		}
+	}
+	return nil, ""
+}
+
 // zohoBackendsInScope returns the allowed backends carrying the Zoho tag
 // (or the legacy "zoho" tool_prefix). Order is undefined — caller must not
 // rely on it. Empty when no Zoho backend is in scope.
@@ -264,7 +289,23 @@ func (sg *ScopedGateway) handleToolsCall(ctx context.Context, req *mcp.Request) 
 
 	backend, originalName := sg.registry.FindByToolFilteredWithTools(params.Name, sg.allowedIDs, sg.allowedTools)
 	if backend == nil {
-		return errorResp(req.ID, mcp.ErrInvalidParams, fmt.Sprintf("unknown tool: %s", params.Name))
+		// Zoho fallback: the registry only caches the admin tool catalog;
+		// per-user upstreams expose tools the admin instance doesn't have
+		// (see tools/list live-fetch path). When the unknown tool name
+		// targets the Zoho stub (matching prefix, or no prefix and a Zoho
+		// backend is in scope) and the caller carries an end-user identity,
+		// route to that stub so mcp-zoho-service can forward to the user's
+		// upstream where the tool actually lives.
+		if _, hasEmail := scopetoken.EndUserEmailFromContext(ctx); hasEmail {
+			if b, orig := sg.findZohoFallback(params.Name); b != nil {
+				log.Printf("[scoped] tools/call zoho fallback name=%s backend=%s original=%s — registry miss but routing to zoho stub", params.Name, b.ID, orig)
+				backend = b
+				originalName = orig
+			}
+		}
+		if backend == nil {
+			return errorResp(req.ID, mcp.ErrInvalidParams, fmt.Sprintf("unknown tool: %s", params.Name))
+		}
 	}
 
 	// Compute per-request backend headers, starting from the static auth


### PR DESCRIPTION
handleToolsCall resolved backends via Registry.FindByToolFilteredWithTools which only scans the cached admin tool catalog. Tools that exist on a non-admin user's Zoho upstream but not on the admin instance (e.g. ZohoCRM_updateRecords) returned "unknown tool" to the MCP client even after tools/list correctly surfaced them.

When the registry lookup misses AND the caller carries an end-user identity AND a Zoho-tagged backend is in scope, fall back to that stub (matching the tool's prefix when set, otherwise routing every name). mcp-zoho-service then forwards to the user's upstream where the tool actually lives. Non-Zoho registry misses still return the original "unknown tool" error.

handleToolsCall résolvait les backends via
Registry.FindByToolFilteredWithTools qui ne parcourt que le catalogue admin en cache. Les outils présents sur l'upstream Zoho d'un utilisateur non-admin mais absents de l'instance admin (ex. ZohoCRM_updateRecords) renvoyaient « unknown tool » au client MCP même après que tools/list les ait correctement exposés.

Quand la résolution registre échoue ET que l'appelant porte une identité utilisateur ET qu'un backend taggé zoho est dans le scope, repli vers ce stub (en respectant le tool_prefix si présent, sinon tous les noms). mcp-zoho-service forward ensuite vers l'upstream utilisateur où l'outil existe vraiment. Les misses non-zoho renvoient toujours « unknown tool ».