### PR TITLE
feat(tests): add search quality E2E harness for regression-safe optimization

### DIFF
--- a/tests/search_quality_harness/README.md
+++ b/tests/search_quality_harness/README.md
@@ -1,0 +1,112 @@
+# Harness E2E qualite moteur de recherche HelloPro
+
+## But
+
+Reproduire l'audit Cowork de maniere automatisee, sans dependance externe,
+pour pouvoir mesurer **avant/apres** chaque modif (LOW cert, dedup, etc.)
+et **detecter les regressions** sur les keywords canari.
+
+## Fichiers
+
+| Fichier | Role |
+|---|---|
+| `keywords.json` | 17 keywords baseline (9 critiques + 8 canari) issus de l'audit du 13/05 |
+| `run_audit.py` | Script principal : fetch URL front + parse HTML + scoring auto + KPIs |
+| `compare.py` | Diff entre 2 runs : detecte gains, regressions, calcule verdict |
+| `results/` | Output JSON de chaque run + .md du compare |
+
+## Prerequis (sur la VM)
+
+```bash
+# Installer les deps Python (1 fois)
+pip3 install --user requests beautifulsoup4
+```
+
+## Workflow type pour un test avant/apres
+
+```bash
+# 1. Aller dans le dossier
+cd /home/devhp/RAG-HP-PUB/tests/search_quality_harness
+
+# 2. Capturer baseline avant modif
+python3 run_audit.py --output results/T0_baseline_2026-05-15.json --verbose
+
+# 3. Appliquer la modif PHP (ex: deployer fonctions_annuaire_hp.php avec flag penalize_low_cert)
+#    + activer le flag : URL ?ajax=1&core_v2=1&penalize_low_cert=1 dans run_audit.py
+
+# 4. Capturer apres modif
+python3 run_audit.py --output results/T1_after_low_cert.json --verbose
+
+# 5. Comparer
+python3 compare.py results/T0_baseline_2026-05-15.json results/T1_after_low_cert.json --md results/diff_T0_T1.md
+
+# 6. Lire le verdict
+cat results/diff_T0_T1.md
+```
+
+Le verdict du compare.py est :
+- **VALIDE** : critical avg progresse de +0.3 ET aucun canary < 9.5 -> on garde la modif
+- **SANS EFFET** : critical avg pas de progression -> on revert la modif
+- **ROLLBACK OBLIGATOIRE** : un canary chute -> rollback immediat
+
+## Options run_audit.py
+
+```
+--keywords PATH      Path vers keywords.json (default: keywords.json)
+--output PATH        Path output JSON (default: results/run_<timestamp>.json)
+--workers N          Nb threads paralleles (default: 4)
+--pages N            Nb pages a analyser (default: 4, soit P1+P2+P3+P4)
+--verbose            Print chaque requete + latence
+--only-critical      Tester uniquement les 9 critiques (rapide ~30s)
+--only-canary        Tester uniquement les 8 canari (rapide ~30s)
+```
+
+## Calibration
+
+Apres le tout premier run (T0 baseline), comparer le `global_avg_auto_score`
+avec la note Cowork de l'audit du 13/05 (= 6.7/10).
+
+- Si la note auto est entre **5.5 et 7.5** -> calibration OK, on peut commencer les actions.
+- Si la note auto est < 5 ou > 8 -> l'heuristique de scoring est trop laxiste ou trop stricte.
+  Ajuster les paliers dans `score_match()` ou la tokenisation dans `tokenize()`.
+
+## Heuristique de scoring (note 1-5 par produit)
+
+```
+nb_hits = |tokens_query intersection tokens_titre|  (apres normalisation NFD + lowercase + sans accent)
+ratio = nb_hits / |tokens_query|
+
+  ratio >= 1.0  -> 5  (parfait)
+  ratio >= 0.75 -> 4  (bon)
+  ratio >= 0.5  -> 3  (moyen)
+  ratio >= 0.25 -> 2  (faible)
+  ratio <  0.25 -> 1  (hors-sujet)
+```
+
+C'est une heuristique simple : la note Cowork humaine est plus nuancee
+(elle tient compte du contexte, des marques, etc.). Mais cette heuristique
+est **reproductible** et **rapide**, donc parfaite pour mesurer un delta
+entre 2 runs.
+
+## Note globale ponderee
+
+```
+note_finale_10 = (0.6 * mean_score_p1 + 0.4 * mean_score_p2) * 2
+```
+
+Meme ponderation que l'audit Cowork (60% P1, 40% P2).
+Si P2 est vide (single page), on prend juste mean_score_p1 * 2.
+
+## Limites connues
+
+1. Le parser HTML s'appuie sur la classe `.card-product.list_produit`.
+   Si HelloPro change le markup, le parser cassera silencieusement.
+2. La detection de l'ID produit cherche `data-id-produit`, `data-produit-id`,
+   puis fallback regex `/produit-(\d+)-` dans le href. A adapter si le
+   markup change.
+3. La detection societe cherche plusieurs selecteurs (`.product-vendor`,
+   `.vendeur`, etc.). Si aucun ne matche, la dedup par societe ne marchera pas
+   correctement. A verifier sur le HTML reel.
+4. En mode hybride server-side, TOUTES les cartes sont dans le HTML
+   (jusqu'a ~200). On slice par lots de 40 pour reconstruire P1/P2/P3/P4.
+   Si le slice server-side change (cf fix P0 du 30/04), il faudra adapter.

--- a/tests/search_quality_harness/compare.py
+++ b/tests/search_quality_harness/compare.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+=============================================================================
+compare.py - Diff entre 2 runs du harness
+=============================================================================
+Usage :
+  python3 compare.py results/run_T0_baseline.json results/run_T1_after_low_cert_fix.json
+
+Sorties :
+  - Tableau Markdown : keyword | audit | T0 | T1 | delta
+  - Detection des regressions canari (canary_min_score depasse a la baisse)
+  - Liste des gros gagnants / gros perdants
+
+Verdicts :
+  - VALIDE     : critical avg progresse ET canary tous >= canary_min_score
+  - REGRESSE   : un canary tombe en dessous de canary_min_score -> ROLLBACK !
+  - SANS-EFFET : critical avg ne progresse pas (<+0.3)
+=============================================================================
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_run(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("baseline", help="Run de reference (T0)")
+    ap.add_argument("target", help="Run a comparer (T1, T2, etc.)")
+    ap.add_argument("--md", default=None, help="Path output Markdown (default: stdout)")
+    args = ap.parse_args()
+
+    t0 = load_run(args.baseline)
+    t1 = load_run(args.target)
+
+    # Index par query
+    t0_by_q = {k["query"]: k for k in t0["keywords"]}
+    t1_by_q = {k["query"]: k for k in t1["keywords"]}
+
+    canary_min = t0.get("regression_threshold", {}).get("canary_min_score", 9.5)
+
+    rows = []
+    regressions_canary = []
+    gains = []
+    losses = []
+
+    for query, k0 in t0_by_q.items():
+        k1 = t1_by_q.get(query)
+        if not k1:
+            continue
+        if "auto_score" not in k0 or "auto_score" not in k1:
+            continue
+
+        score_0 = k0["auto_score"]
+        score_1 = k1["auto_score"]
+        delta = round(score_1 - score_0, 2)
+        group = k1.get("group") or k0.get("group", "?")
+
+        rows.append({
+            "query": query[:60],
+            "group": group,
+            "audit": k0.get("audit_score"),
+            "T0": score_0,
+            "T1": score_1,
+            "delta": delta,
+        })
+
+        if group == "canary" and score_1 < canary_min:
+            regressions_canary.append((query, score_0, score_1))
+
+        if delta >= 1.0:
+            gains.append((query, score_0, score_1, delta))
+        elif delta <= -1.0:
+            losses.append((query, score_0, score_1, delta))
+
+    rows.sort(key=lambda r: (0 if r["group"] == "critical" else 1, r["audit"] or 0))
+
+    # Markdown
+    md = []
+    md.append(f"# Comparaison harness : {Path(args.baseline).name} vs {Path(args.target).name}")
+    md.append("")
+    md.append(f"- Baseline run : `{Path(args.baseline).name}` ({t0.get('run_id','?')})")
+    md.append(f"- Target run   : `{Path(args.target).name}` ({t1.get('run_id','?')})")
+    md.append("")
+    md.append(f"## Synthese globale")
+    md.append("")
+    md.append(f"| Indicateur | T0 (baseline) | T1 (target) | Delta |")
+    md.append(f"|---|---|---|---|")
+    md.append(f"| Global avg | {t0['global_avg_auto_score']} | {t1['global_avg_auto_score']} | {round(t1['global_avg_auto_score']-t0['global_avg_auto_score'], 2):+} |")
+    md.append(f"| Critical avg | {t0['critical_avg_auto_score']} | {t1['critical_avg_auto_score']} | {round(t1['critical_avg_auto_score']-t0['critical_avg_auto_score'], 2):+} |")
+    md.append(f"| Canary avg | {t0['canary_avg_auto_score']} | {t1['canary_avg_auto_score']} | {round(t1['canary_avg_auto_score']-t0['canary_avg_auto_score'], 2):+} |")
+    md.append("")
+
+    md.append(f"## Verdict")
+    md.append("")
+    if regressions_canary:
+        md.append(f"### ROLLBACK OBLIGATOIRE - Regression canari")
+        md.append(f"Les keywords canari suivants ont chute sous le seuil {canary_min} :")
+        for q, s0, s1 in regressions_canary:
+            md.append(f"- **{q}** : {s0} -> {s1}")
+    else:
+        delta_critical = t1['critical_avg_auto_score'] - t0['critical_avg_auto_score']
+        if delta_critical >= 0.3:
+            md.append(f"### VALIDE - Critical avg progresse de +{round(delta_critical, 2)} sans regression canari")
+        else:
+            md.append(f"### SANS EFFET - Critical avg progresse de seulement +{round(delta_critical, 2)} (seuil +0.3 non atteint)")
+    md.append("")
+
+    md.append(f"## Detail par keyword")
+    md.append("")
+    md.append("| Group | Query | Audit | T0 | T1 | Delta |")
+    md.append("|---|---|---|---|---|---|")
+    for r in rows:
+        emoji = ""
+        if r["group"] == "canary" and r["T1"] < canary_min:
+            emoji = " (REGR)"
+        elif r["delta"] >= 1.0:
+            emoji = " (+)"
+        elif r["delta"] <= -1.0:
+            emoji = " (-)"
+        md.append(f"| {r['group']} | {r['query']} | {r['audit']} | {r['T0']} | {r['T1']} | {r['delta']:+}{emoji} |")
+    md.append("")
+
+    if gains:
+        md.append(f"## Gros gagnants (delta >= +1.0)")
+        for q, s0, s1, d in sorted(gains, key=lambda x: -x[3]):
+            md.append(f"- **{q}** : {s0} -> {s1} ({d:+})")
+        md.append("")
+    if losses:
+        md.append(f"## Gros perdants (delta <= -1.0)")
+        for q, s0, s1, d in sorted(losses, key=lambda x: x[3]):
+            md.append(f"- **{q}** : {s0} -> {s1} ({d:+})")
+        md.append("")
+
+    output = "\n".join(md)
+    if args.md:
+        Path(args.md).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.md, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Markdown ecrit : {args.md}")
+    else:
+        print(output)
+
+    # Exit code : 1 si regression canari (pour CI)
+    sys.exit(1 if regressions_canary else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/search_quality_harness/keywords.json
+++ b/tests/search_quality_harness/keywords.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "created_at": "2026-05-15",
+  "source": "audit_moteur_recherche_hellopro_2026-05-13.docx",
+  "url_template": "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles={query}&ajax=1&core_v2=1",
+  "regression_threshold": {
+    "canary_min_score": 9.5,
+    "comment": "Si un keyword canary passe sous 9.5 apres une modif -> rollback obligatoire"
+  },
+  "groups": {
+    "critical": [
+      {"query": "mélangeurs coniques",                                                                                       "audit_score": 2.6, "category": "accent_plural"},
+      {"query": "Machine universelle pour manchon electrosoudable Ritmo ELEKTRA XL avec SAV",                                "audit_score": 3.4, "category": "exact_title"},
+      {"query": "Machine pour soudure bout à bout - large gamme et fiches techniques détaillées",                            "audit_score": 3.6, "category": "exact_title"},
+      {"query": "armoire medicale",                                                                                          "audit_score": 3.9, "category": "duplicates_vendor"},
+      {"query": "Machine pour soudure bout a bout Ritmo BASIC 250 315 355",                                                  "audit_score": 4.0, "category": "exact_title"},
+      {"query": "melangeur conique",                                                                                         "audit_score": 4.2, "category": "combinatorial"},
+      {"query": "Machine universelle Ritmo ELEKTRA S - Soudeuse pour manchon électrosoudable avec SAV et maintenance",       "audit_score": 4.4, "category": "exact_title"},
+      {"query": "soudure ritmo",                                                                                             "audit_score": 4.7, "category": "rare_token_brand"},
+      {"query": "Machine universelle pour manchon electrosoudable Ritmo ELEKTRA M avec SAV",                                 "audit_score": 4.8, "category": "exact_title"}
+    ],
+    "canary": [
+      {"query": "fraiseuse",                "audit_score": 10.0, "category": "mono_token"},
+      {"query": "perceuse colonne",         "audit_score": 10.0, "category": "bi_token"},
+      {"query": "machine de decoupe",       "audit_score": 10.0, "category": "tri_token"},
+      {"query": "nettoyage",                "audit_score": 10.0, "category": "mono_token"},
+      {"query": "distributeur automatique", "audit_score": 10.0, "category": "bi_token"},
+      {"query": "compresseur",              "audit_score": 10.0, "category": "mono_token"},
+      {"query": "aspirateur",               "audit_score":  9.9, "category": "mono_token"},
+      {"query": "erp",                      "audit_score":  9.8, "category": "acronym"}
+    ]
+  }
+}

--- a/tests/search_quality_harness/run_audit.py
+++ b/tests/search_quality_harness/run_audit.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+=============================================================================
+run_audit.py - Harness E2E qualite moteur de recherche HelloPro
+=============================================================================
+But : reproduire l'audit Cowork de maniere automatisee et reproductible.
+
+Pour chaque keyword (17 au total), le script :
+  1. GET l'URL front (mode hybride : ?ajax=1&core_v2=1)
+  2. Parse le HTML pour extraire les cartes produits (.card-product.list_produit)
+  3. Calcule une note auto par heuristique simple :
+       - tokens query normalises (NFD + lowercase + stripped accents)
+       - tokens titre normalises
+       - match_ratio = |intersection| / |query_tokens|
+       - note 1-5 selon paliers (5=parfait, 1=hors-sujet)
+  4. Calcule KPIs page par page (P1, P2, P3, P4) :
+       - moyenne note /10
+       - % pertinents (note >=4)
+       - doublons stricts (meme id_produit + meme societe+titre>80%)
+       - latence ms
+  5. Sortie JSON datee dans results/
+
+Usage :
+  python3 run_audit.py [--output results/T0_baseline_2026-05-15.json]
+                       [--keywords keywords.json]
+                       [--workers 4]
+                       [--pages 4]
+                       [--verbose]
+
+Resultats : note globale ponderee 60% P1 + 40% P2 (comme l'audit Cowork)
+=============================================================================
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import quote_plus
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError as e:
+    print(f"ERREUR : modules manquants ({e}). Installer : pip install requests beautifulsoup4")
+    sys.exit(1)
+
+
+# =============================================================================
+# CONFIG
+# =============================================================================
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Linux x86_64) HP-SearchQualityHarness/1.0 (+rravelonarisoa@hellopro.fr)",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+}
+PAGE_SIZE = 40   # 40 produits par page (server-side)
+TIMEOUT_SEC = 30
+
+
+# =============================================================================
+# NORMALISATION (alignee avec traitement_mot_mt cote PHP)
+# =============================================================================
+def normalize_text(s):
+    """Lowercase + NFD + strip diacritiques + ponctuation -> espaces."""
+    if not s:
+        return ""
+    s = s.lower()
+    # NFD + filter diacritiques
+    s = "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
+    # ponctuation -> espace
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    return " ".join(s.split())
+
+
+def tokenize(s):
+    """Renvoie set de tokens normalises (filtres : len >= 2, pas stopwords basiques)."""
+    STOP = {"de", "du", "la", "le", "les", "un", "une", "et", "ou", "a", "au", "aux", "en", "pour", "sur", "avec", "par"}
+    return {t for t in normalize_text(s).split() if len(t) >= 2 and t not in STOP}
+
+
+# =============================================================================
+# SCORING heuristique
+# =============================================================================
+def score_match(query_tokens, title_tokens):
+    """
+    Renvoie note 1-5 selon ratio tokens query trouves dans titre.
+      5 = tous les tokens query presents (match parfait)
+      4 = >=75%
+      3 = >=50%
+      2 = >=25%
+      1 = aucun match
+    """
+    if not query_tokens:
+        return 1
+    nb_hits = len(query_tokens & title_tokens)
+    ratio = nb_hits / len(query_tokens)
+    if ratio >= 1.0:
+        return 5
+    if ratio >= 0.75:
+        return 4
+    if ratio >= 0.5:
+        return 3
+    if ratio >= 0.25:
+        return 2
+    return 1
+
+
+def page_kpis(cards, query_tokens):
+    """Calcule KPIs (note moyenne, % pertinents, doublons) pour une liste de cartes."""
+    if not cards:
+        return {"n": 0, "mean_score": 0.0, "pertinent_pct": 0.0, "top5_mean": 0.0, "duplicates": 0}
+
+    scores = []
+    seen_ids = set()
+    seen_norm_titles = {}  # norm_title -> count
+    duplicates = 0
+
+    for card in cards:
+        title_tokens = tokenize(card["title"])
+        s = score_match(query_tokens, title_tokens)
+        scores.append(s)
+
+        # doublon strict : meme id_produit OU meme titre normalise + meme societe
+        if card["id"] and card["id"] in seen_ids:
+            duplicates += 1
+        else:
+            if card["id"]:
+                seen_ids.add(card["id"])
+
+        norm_t = normalize_text(card["title"])[:80]  # 80 premiers chars
+        norm_key = (norm_t, card.get("societe", "").lower())
+        seen_norm_titles[norm_key] = seen_norm_titles.get(norm_key, 0) + 1
+
+    # compter les vrais doublons par titre normalise + societe
+    dup_by_title = sum(v - 1 for v in seen_norm_titles.values() if v > 1)
+
+    return {
+        "n": len(cards),
+        "mean_score": round(sum(scores) / len(scores), 2),
+        "pertinent_pct": round(100.0 * sum(1 for s in scores if s >= 4) / len(scores), 1),
+        "top5_mean": round(sum(scores[:5]) / min(5, len(scores)), 2),
+        "duplicates_by_id": duplicates,
+        "duplicates_by_normalized_title": dup_by_title,
+    }
+
+
+# =============================================================================
+# PARSER HTML
+# =============================================================================
+def parse_cards(html):
+    """
+    Extrait les cartes produits du HTML.
+    Cherche les elements ayant classe 'card-product list_produit'.
+    Renvoie liste de dict : {id, title, societe, position}
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    cards = []
+
+    # Selecteur principal d'apres REGLES_MOTEUR_RECHERCHE_V2.md (l.443-450)
+    for idx, card in enumerate(soup.select(".card-product.list_produit"), start=1):
+        # ID produit : data-id-produit ou data-produit-id ou href contenant /produit-XXX-
+        pid = card.get("data-id-produit") or card.get("data-produit-id") or ""
+        if not pid:
+            link = card.find("a", href=True)
+            if link:
+                m = re.search(r"/produit-(\d+)-", link["href"])
+                if m:
+                    pid = m.group(1)
+
+        # Titre : chercher dans h3 / h2 / a[title]
+        title = ""
+        for sel in ["h3", "h2", ".product-title", ".titre-produit", "a[title]"]:
+            el = card.select_one(sel)
+            if el:
+                title = el.get("title", "") or el.get_text(strip=True)
+                if title:
+                    break
+
+        # Fallback : tout le texte de la premiere ligne
+        if not title:
+            title = card.get_text(strip=True)[:120]
+
+        # Societe : data-societe ou cherche dans un span class containing societe
+        societe = card.get("data-societe", "")
+        if not societe:
+            for sel in [".product-vendor", ".vendeur", ".nom-societe", "[class*=societe]"]:
+                el = card.select_one(sel)
+                if el:
+                    societe = el.get_text(strip=True)
+                    if societe:
+                        break
+
+        cards.append({
+            "position": idx,
+            "id": pid,
+            "title": title.strip(),
+            "societe": societe.strip(),
+        })
+
+    return cards
+
+
+def slice_pages(all_cards, pages_wanted=4):
+    """Split la liste de cartes en pages de PAGE_SIZE (40).
+    En mode hybride server-side, toutes les cartes sont dans le HTML."""
+    pages = {}
+    for p in range(1, pages_wanted + 1):
+        start = (p - 1) * PAGE_SIZE
+        end = start + PAGE_SIZE
+        pages[f"p{p}"] = all_cards[start:end]
+    return pages
+
+
+# =============================================================================
+# FETCH
+# =============================================================================
+def fetch_query(query, url_template, verbose=False):
+    """Fetch une URL, retourne (status, latency_ms, html, error)."""
+    url = url_template.format(query=quote_plus(query))
+    t0 = time.time()
+    try:
+        r = requests.get(url, headers=HEADERS, timeout=TIMEOUT_SEC, allow_redirects=True)
+        elapsed_ms = int((time.time() - t0) * 1000)
+        if verbose:
+            print(f"  [HTTP {r.status_code}] {elapsed_ms}ms  {query[:60]}", flush=True)
+        return (r.status_code, elapsed_ms, r.text, None)
+    except Exception as e:
+        elapsed_ms = int((time.time() - t0) * 1000)
+        if verbose:
+            print(f"  [ERROR] {elapsed_ms}ms  {query[:60]}  : {e}", flush=True)
+        return (None, elapsed_ms, "", str(e))
+
+
+def audit_one_keyword(kw_obj, url_template, pages_wanted=4, verbose=False):
+    """Audit complet d'un keyword."""
+    query = kw_obj["query"]
+    query_tokens = tokenize(query)
+
+    status, latency_ms, html, error = fetch_query(query, url_template, verbose=verbose)
+    if error or status != 200:
+        return {
+            "query": query,
+            "audit_score": kw_obj.get("audit_score"),
+            "category": kw_obj.get("category"),
+            "error": error or f"HTTP {status}",
+            "latency_ms": latency_ms,
+        }
+
+    all_cards = parse_cards(html)
+    pages = slice_pages(all_cards, pages_wanted=pages_wanted)
+
+    page_results = {}
+    for pname, cards in pages.items():
+        page_results[pname] = page_kpis(cards, query_tokens)
+        # Pour debug : top5 titles
+        page_results[pname]["top5_titles"] = [
+            {"pos": c["position"], "title": c["title"][:80], "score": score_match(query_tokens, tokenize(c["title"]))}
+            for c in cards[:5]
+        ]
+
+    # Note globale : moyenne ponderee 60% P1 + 40% P2 (comme audit)
+    p1_mean = page_results["p1"]["mean_score"]
+    p2_mean = page_results["p2"]["mean_score"]
+    if page_results["p2"]["n"] > 0:
+        global_score_5 = 0.6 * p1_mean + 0.4 * p2_mean
+    else:
+        global_score_5 = p1_mean
+    auto_score_10 = round(global_score_5 * 2.0, 2)
+
+    return {
+        "query": query,
+        "audit_score": kw_obj.get("audit_score"),
+        "category": kw_obj.get("category"),
+        "auto_score": auto_score_10,
+        "delta_vs_audit": round(auto_score_10 - kw_obj.get("audit_score", 0), 2),
+        "latency_ms": latency_ms,
+        "total_cards_parsed": len(all_cards),
+        "pages": page_results,
+    }
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+def main():
+    ap = argparse.ArgumentParser(description="Harness E2E qualite recherche HelloPro")
+    ap.add_argument("--keywords", default="keywords.json", help="Path vers keywords.json")
+    ap.add_argument("--output", default=None, help="Path output JSON (default: results/T<run_id>.json)")
+    ap.add_argument("--workers", type=int, default=4, help="Nb threads paralleles")
+    ap.add_argument("--pages", type=int, default=4, help="Nb pages a analyser")
+    ap.add_argument("--verbose", action="store_true", help="Print chaque requete")
+    ap.add_argument("--only-critical", action="store_true", help="Tester uniquement les 9 critiques")
+    ap.add_argument("--only-canary", action="store_true", help="Tester uniquement les 8 canari")
+    args = ap.parse_args()
+
+    # Load keywords
+    with open(args.keywords, encoding="utf-8") as f:
+        kw_data = json.load(f)
+
+    url_template = kw_data["url_template"]
+    all_keywords = []
+    if not args.only_canary:
+        all_keywords.extend(("critical", k) for k in kw_data["groups"]["critical"])
+    if not args.only_critical:
+        all_keywords.extend(("canary", k) for k in kw_data["groups"]["canary"])
+
+    print(f"=== Audit qualite recherche - {len(all_keywords)} keywords ===")
+    print(f"URL template : {url_template}")
+    print(f"Workers : {args.workers}, pages : {args.pages}")
+    print()
+
+    t_start = time.time()
+    results = []
+
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(audit_one_keyword, kw, url_template, args.pages, args.verbose): (grp, kw) for grp, kw in all_keywords}
+        for fut in as_completed(futs):
+            grp, kw = futs[fut]
+            try:
+                res = fut.result()
+                res["group"] = grp
+                results.append(res)
+                marker = "OK" if "error" not in res else "KO"
+                score_str = f"audit={res.get('audit_score')} auto={res.get('auto_score','?')}" if "auto_score" in res else f"ERREUR {res.get('error')}"
+                print(f"  [{marker}] [{grp:8s}] {res['query'][:60]:60s} | {score_str}", flush=True)
+            except Exception as e:
+                print(f"  [EXC] {kw['query']}: {e}", flush=True)
+
+    # Tri stable : critical d'abord (ordre audit_score asc), puis canary
+    results.sort(key=lambda r: (0 if r["group"] == "critical" else 1, r.get("audit_score", 0)))
+
+    # Globaux
+    by_group = {"critical": [], "canary": []}
+    for r in results:
+        if "auto_score" in r:
+            by_group[r["group"]].append(r["auto_score"])
+    avg_all = sum([r.get("auto_score", 0) for r in results if "auto_score" in r]) / max(1, sum(1 for r in results if "auto_score" in r))
+
+    summary = {
+        "run_id": datetime.now().strftime("%Y-%m-%d_%H-%M-%S"),
+        "ts_start": datetime.now().isoformat(),
+        "duration_s": round(time.time() - t_start, 1),
+        "url_template": url_template,
+        "nb_keywords": len(results),
+        "global_avg_auto_score": round(avg_all, 2),
+        "critical_avg_auto_score": round(sum(by_group["critical"]) / max(1, len(by_group["critical"])), 2),
+        "canary_avg_auto_score": round(sum(by_group["canary"]) / max(1, len(by_group["canary"])), 2),
+        "regression_threshold": kw_data.get("regression_threshold"),
+        "keywords": results,
+    }
+
+    # Output
+    if args.output:
+        out_path = args.output
+    else:
+        run_id = summary["run_id"]
+        os.makedirs("results", exist_ok=True)
+        out_path = f"results/run_{run_id}.json"
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+    print()
+    print(f"=== Termine en {summary['duration_s']}s ===")
+    print(f"  Global avg auto_score : {summary['global_avg_auto_score']} /10  (audit Cowork = 6.7)")
+    print(f"  Critical (9 kw) avg   : {summary['critical_avg_auto_score']} /10  (audit < 5)")
+    print(f"  Canary (8 kw) avg     : {summary['canary_avg_auto_score']} /10  (audit ~10)  -> seuil regression : {summary['regression_threshold']['canary_min_score']}")
+    print(f"  Output JSON : {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an automated E2E harness to measure the quality of the HelloPro search engine **before/after** each optimization, without relying on Claude Cowork (slow, non-reproducible).

This unlocks the next wave of pertinence optimizations identified in the Cowork audit of 2026-05-13 (global score 6.7/10, target > 8).

> **Note**: this PR targets `features/poc` (project convention, not `main`).

## Context

The audit identified 9 critical keywords (< 5/10):
- `mélangeurs coniques` (2.6) — accent + plural handling
- 5 exact-title Ritmo queries (3.4 - 4.8) — cap 5/société penalizes APREAU
- `armoire medicale` (3.9) — 14 doublons "banque accueil" Bureau-Store
- `melangeur conique` (4.2) — combinatorial query
- `soudure ritmo` (4.7) — rare-token brand dilution

Each upcoming PHP modification (`fonctions_annuaire_hp.php`, etc.) must be **measurable** and **reversible** via URL flags. Without an automatable harness, every iteration would require launching a 1h Cowork session — not viable.

## What this PR adds

| File | Role |
|---|---|
| `tests/search_quality_harness/keywords.json` | 17 keywords (9 critical + 8 canary) from the 2026-05-13 audit |
| `tests/search_quality_harness/run_audit.py` | Fetches the front URL (`?ajax=1&core_v2=1`), parses HTML, computes per-page KPIs (mean score, % pertinents, duplicates, latency, top-5 mean) |
| `tests/search_quality_harness/compare.py` | Diff between 2 runs, detects canary regressions, renders verdict |
| `tests/search_quality_harness/README.md` | Usage doc + before/after workflow |

## Scoring heuristic

For each card returned, score 1-5 based on query-token overlap with the title (normalized: lowercase + NFD + stripped accents):

```
ratio = |query_tokens ∩ title_tokens| / |query_tokens|

ratio >= 1.00 -> 5  (perfect match)
ratio >= 0.75 -> 4  (good)
ratio >= 0.50 -> 3  (medium)
ratio >= 0.25 -> 2  (weak)
ratio <  0.25 -> 1  (off-topic)
```

Global score is weighted **60% P1 + 40% P2** (same as the Cowork audit).

This is a simpler heuristic than human Cowork scoring, but it is **reproducible** and **fast** (~2 min for 17 keywords with 4 workers), which is exactly what's needed for delta measurement between runs.

## Workflow type

```bash
# 1. Baseline
python3 run_audit.py --output results/T0_baseline.json

# 2. Apply PHP modification with URL flag (e.g. ?penalize_low_cert=1)
#    Modify keywords.json url_template to include the flag

# 3. Re-run
python3 run_audit.py --output results/T1_after.json

# 4. Diff
python3 compare.py results/T0_baseline.json results/T1_after.json --md results/diff_T0_T1.md
```

Verdict from `compare.py`:
- **VALIDE** : critical avg progresses by +0.3 AND no canary drops below 9.5 -> keep the modification
- **SANS EFFET** : critical avg unchanged -> revert
- **ROLLBACK OBLIGATOIRE** : a canary drops below 9.5 -> rollback immediately

## Test plan

- [ ] Install deps on the VM: `pip3 install --user requests beautifulsoup4`
- [ ] First run on the production URL: `python3 run_audit.py --output results/T0_baseline_2026-05-15.json --verbose`
- [ ] Check that `global_avg_auto_score` is in the 5.5 - 7.5 range (calibration validation vs Cowork 6.7)
- [ ] If calibration off, tune scoring thresholds in `score_match()`
- [ ] Once calibrated, capture baseline T0 for next optimization wave (Action 1: penalize LOW cert)

## Out of scope (next PRs)

- Action 1: penalize LOW cert (`fonctions_annuaire_hp.php` line 15502-15536)
- Action 2: bypass cap 5/société for exact-title queries
- Action 3: dedup by normalized title in the reliquat
- Action 4: French stemming for Typesense
- Action 5: typo tolerance (Solr `~2` or Typesense `num_typos`)

These will follow the same protocol: implement behind a URL flag → harness run before/after → keep if `VALIDE`, revert if `ROLLBACK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)