### PR TITLE
fix(tests/search-harness): use relative delta vs T0 for canary regression detection

### DIFF
--- a/tests/search_quality_harness/README.md
+++ b/tests/search_quality_harness/README.md
@@ -44,10 +44,15 @@ python3 compare.py results/T0_baseline_2026-05-15.json results/T1_after_low_cert
 cat results/diff_T0_T1.md
 ```
 
-Le verdict du compare.py est :
-- **VALIDE** : critical avg progresse de +0.3 ET aucun canary < 9.5 -> on garde la modif
-- **SANS EFFET** : critical avg pas de progression -> on revert la modif
-- **ROLLBACK OBLIGATOIRE** : un canary chute -> rollback immediat
+Le verdict du compare.py est (seuils RELATIFS au baseline T0, override via CLI) :
+- **VALIDE** : critical avg progresse d'au moins `critical_min_gain` (default 0.3) ET aucun canary n'a chute de plus de `canary_max_drop` (default 0.5) vs T0 -> on garde la modif
+- **SANS EFFET** : critical avg pas de progression suffisante -> on revert la modif
+- **ROLLBACK OBLIGATOIRE** : au moins un canary a chute de plus de `canary_max_drop` vs T0 -> rollback immediat
+
+> **Note 2026-05-15** : seuil canari devenu RELATIF (delta vs T0) au lieu d'absolu.
+> L'ancien seuil `canary_min_score=9.5` etait trop strict : en baseline T0 du 15/05,
+> 5/8 canaris etaient deja sous 9.5 (calibration auto-score plus strict que humain Cowork).
+> Le seuil relatif detecte une vraie regression introduite par la modif, pas la valeur absolue.
 
 ## Options run_audit.py
 

--- a/tests/search_quality_harness/compare.py
+++ b/tests/search_quality_harness/compare.py
@@ -5,16 +5,30 @@ compare.py - Diff entre 2 runs du harness
 =============================================================================
 Usage :
   python3 compare.py results/run_T0_baseline.json results/run_T1_after_low_cert_fix.json
+                     [--md results/diff.md]
+                     [--canary-max-drop 0.5]
+                     [--critical-min-gain 0.3]
 
 Sorties :
   - Tableau Markdown : keyword | audit | T0 | T1 | delta
-  - Detection des regressions canari (canary_min_score depasse a la baisse)
+  - Detection des regressions canari par DELTA RELATIF (au lieu d'un seuil absolu)
   - Liste des gros gagnants / gros perdants
 
 Verdicts :
-  - VALIDE     : critical avg progresse ET canary tous >= canary_min_score
-  - REGRESSE   : un canary tombe en dessous de canary_min_score -> ROLLBACK !
-  - SANS-EFFET : critical avg ne progresse pas (<+0.3)
+  - ROLLBACK    : un canari chute de plus de canary_max_drop vs T0 -> ROLLBACK !
+  - VALIDE      : critical avg progresse d'au moins critical_min_gain ET aucun
+                  canari ne chute de plus de canary_max_drop
+  - SANS-EFFET  : critical avg ne progresse pas suffisamment
+
+Seuils par defaut (overridables via CLI ou via keywords.json regression_threshold) :
+  - canary_max_drop = 0.5  (un canari T1 < T0 - 0.5 -> ROLLBACK)
+  - critical_min_gain = 0.3 (critical avg T1 < T0 + 0.3 -> SANS EFFET)
+
+Changement 2026-05-15 :
+  Anciennement seuil absolu canary_min_score=9.5. Abandonne car en baseline T0
+  5/8 canaris sont sous 9.5 (calibration auto-score plus strict que humain).
+  Le seuil relatif (delta vs T0) est plus juste : detecte une vraie regression
+  introduite par la modif, pas la valeur absolue.
 =============================================================================
 """
 
@@ -29,24 +43,46 @@ def load_run(path):
         return json.load(f)
 
 
+def get_thresholds(t0_data, cli_canary_drop, cli_critical_gain):
+    """Resolution des seuils : CLI override > keywords.json > defaults."""
+    rt = t0_data.get("regression_threshold", {}) or {}
+    canary_max_drop = (
+        cli_canary_drop
+        if cli_canary_drop is not None
+        else rt.get("canary_max_drop", 0.5)
+    )
+    critical_min_gain = (
+        cli_critical_gain
+        if cli_critical_gain is not None
+        else rt.get("critical_min_gain", 0.3)
+    )
+    return float(canary_max_drop), float(critical_min_gain)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("baseline", help="Run de reference (T0)")
     ap.add_argument("target", help="Run a comparer (T1, T2, etc.)")
     ap.add_argument("--md", default=None, help="Path output Markdown (default: stdout)")
+    ap.add_argument("--canary-max-drop", type=float, default=None,
+                    help="Override : un canari T1 < T0 - max_drop = ROLLBACK. Default = 0.5 ou valeur du keywords.json")
+    ap.add_argument("--critical-min-gain", type=float, default=None,
+                    help="Override : critical avg T1 < T0 + min_gain = SANS EFFET. Default = 0.3 ou valeur du keywords.json")
     args = ap.parse_args()
 
     t0 = load_run(args.baseline)
     t1 = load_run(args.target)
 
+    canary_max_drop, critical_min_gain = get_thresholds(
+        t0, args.canary_max_drop, args.critical_min_gain
+    )
+
     # Index par query
     t0_by_q = {k["query"]: k for k in t0["keywords"]}
     t1_by_q = {k["query"]: k for k in t1["keywords"]}
 
-    canary_min = t0.get("regression_threshold", {}).get("canary_min_score", 9.5)
-
     rows = []
-    regressions_canary = []
+    regressions_canary = []  # tuples (query, T0, T1, delta)
     gains = []
     losses = []
 
@@ -71,8 +107,10 @@ def main():
             "delta": delta,
         })
 
-        if group == "canary" and score_1 < canary_min:
-            regressions_canary.append((query, score_0, score_1))
+        # NOUVEAU 2026-05-15 : regression canari = delta < -canary_max_drop
+        # (au lieu de score absolu < canary_min_score)
+        if group == "canary" and delta < -canary_max_drop:
+            regressions_canary.append((query, score_0, score_1, delta))
 
         if delta >= 1.0:
             gains.append((query, score_0, score_1, delta))
@@ -87,29 +125,31 @@ def main():
     md.append("")
     md.append(f"- Baseline run : `{Path(args.baseline).name}` ({t0.get('run_id','?')})")
     md.append(f"- Target run   : `{Path(args.target).name}` ({t1.get('run_id','?')})")
+    md.append(f"- Seuils utilises : canary_max_drop = {canary_max_drop}, critical_min_gain = {critical_min_gain}")
     md.append("")
     md.append(f"## Synthese globale")
     md.append("")
+    delta_global = round(t1['global_avg_auto_score'] - t0['global_avg_auto_score'], 2)
+    delta_critical = round(t1['critical_avg_auto_score'] - t0['critical_avg_auto_score'], 2)
+    delta_canary = round(t1['canary_avg_auto_score'] - t0['canary_avg_auto_score'], 2)
     md.append(f"| Indicateur | T0 (baseline) | T1 (target) | Delta |")
     md.append(f"|---|---|---|---|")
-    md.append(f"| Global avg | {t0['global_avg_auto_score']} | {t1['global_avg_auto_score']} | {round(t1['global_avg_auto_score']-t0['global_avg_auto_score'], 2):+} |")
-    md.append(f"| Critical avg | {t0['critical_avg_auto_score']} | {t1['critical_avg_auto_score']} | {round(t1['critical_avg_auto_score']-t0['critical_avg_auto_score'], 2):+} |")
-    md.append(f"| Canary avg | {t0['canary_avg_auto_score']} | {t1['canary_avg_auto_score']} | {round(t1['canary_avg_auto_score']-t0['canary_avg_auto_score'], 2):+} |")
+    md.append(f"| Global avg | {t0['global_avg_auto_score']} | {t1['global_avg_auto_score']} | {delta_global:+} |")
+    md.append(f"| Critical avg | {t0['critical_avg_auto_score']} | {t1['critical_avg_auto_score']} | {delta_critical:+} |")
+    md.append(f"| Canary avg | {t0['canary_avg_auto_score']} | {t1['canary_avg_auto_score']} | {delta_canary:+} |")
     md.append("")
 
     md.append(f"## Verdict")
     md.append("")
     if regressions_canary:
         md.append(f"### ROLLBACK OBLIGATOIRE - Regression canari")
-        md.append(f"Les keywords canari suivants ont chute sous le seuil {canary_min} :")
-        for q, s0, s1 in regressions_canary:
-            md.append(f"- **{q}** : {s0} -> {s1}")
+        md.append(f"Les keywords canari suivants ont chute de plus de {canary_max_drop} pts vs baseline T0 :")
+        for q, s0, s1, d in regressions_canary:
+            md.append(f"- **{q}** : {s0} -> {s1} ({d:+})")
+    elif delta_critical >= critical_min_gain:
+        md.append(f"### VALIDE - Critical avg progresse de +{delta_critical} (seuil +{critical_min_gain}) sans regression canari")
     else:
-        delta_critical = t1['critical_avg_auto_score'] - t0['critical_avg_auto_score']
-        if delta_critical >= 0.3:
-            md.append(f"### VALIDE - Critical avg progresse de +{round(delta_critical, 2)} sans regression canari")
-        else:
-            md.append(f"### SANS EFFET - Critical avg progresse de seulement +{round(delta_critical, 2)} (seuil +0.3 non atteint)")
+        md.append(f"### SANS EFFET - Critical avg progresse de seulement +{delta_critical} (seuil +{critical_min_gain} non atteint)")
     md.append("")
 
     md.append(f"## Detail par keyword")
@@ -118,7 +158,7 @@ def main():
     md.append("|---|---|---|---|---|---|")
     for r in rows:
         emoji = ""
-        if r["group"] == "canary" and r["T1"] < canary_min:
+        if r["group"] == "canary" and r["delta"] < -canary_max_drop:
             emoji = " (REGR)"
         elif r["delta"] >= 1.0:
             emoji = " (+)"

--- a/tests/search_quality_harness/keywords.json
+++ b/tests/search_quality_harness/keywords.json
@@ -4,8 +4,10 @@
   "source": "audit_moteur_recherche_hellopro_2026-05-13.docx",
   "url_template": "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles={query}&ajax=1&core_v2=1",
   "regression_threshold": {
-    "canary_min_score": 9.5,
-    "comment": "Si un keyword canary passe sous 9.5 apres une modif -> rollback obligatoire"
+    "canary_max_drop": 0.5,
+    "critical_min_gain": 0.3,
+    "_deprecated_canary_min_score": 9.5,
+    "comment": "Verdict du compare.py : ROLLBACK si un canari chute de plus de canary_max_drop (delta vs baseline T0). VALIDE si critical avg progresse d'au moins critical_min_gain. Note : ancien seuil absolu canary_min_score=9.5 abandonne car 5/8 canaris sont sous 9.5 des le baseline T0 du 2026-05-15 (calibration auto-score plus strict que la notation humaine Cowork)."
   },
   "groups": {
     "critical": [


### PR DESCRIPTION
## Summary

Fixes the search-harness canary regression detection to use a **relative delta vs baseline T0** instead of an absolute threshold.

## Problem

The previous logic used `canary_min_score=9.5` as an absolute threshold: any canary below 9.5 was flagged as a regression and triggered ROLLBACK.

The actual T0 baseline captured on 2026-05-15 revealed that **5/8 canaris are already below 9.5**:
```
fraiseuse                 9.2
machine de decoupe        9.2
distributeur automatique  9.4
compresseur               8.8
erp                       8.0
```

This is because the harness's auto-scoring heuristic (token-overlap based) is more strict than human Cowork notation. The audit scored them 9.8-10, but the auto-score is around 8.0-9.5.

Without this fix, **any future modification would falsely be flagged as ROLLBACK** because the same canaris would still be below 9.5 — even if they hadn't actually regressed.

## Fix

Switch to a **relative delta** check:
- A canary is flagged as regression if its T1 score drops more than `canary_max_drop` (default 0.5) below its T0 score
- This catches real regressions introduced by a change, not the absolute notation gap

## Changes

| File | Change |
|---|---|
| `keywords.json` | `regression_threshold` exposes new fields `canary_max_drop` (0.5) and `critical_min_gain` (0.3). Old `canary_min_score` kept as `_deprecated_canary_min_score` for trace. |
| `compare.py` | Refactored verdict logic. Added `--canary-max-drop` and `--critical-min-gain` CLI overrides. |
| `README.md` | Workflow doc updated to reflect the new relative threshold logic. |

## Verdict logic (unchanged 3 outcomes)

| Verdict | Condition |
|---|---|
| **ROLLBACK** | any canary T1 < T0 - canary_max_drop |
| **VALIDE** | critical avg T1 >= T0 + critical_min_gain AND no canary regression |
| **SANS-EFFET** | critical avg T1 < T0 + critical_min_gain |

## Test plan

- [x] Edits compile (no syntax error)
- [ ] After merge: rerun T0 baseline on the VM (just to refresh JSON with new threshold fields)
- [ ] Then proceed with Action 1.a (cap reliquat LOW cert) test cycle:
      `python3 run_audit.py --output results/T1_action_1a.json` then
      `python3 compare.py results/T0_baseline.json results/T1_action_1a.json --md results/diff.md`

## Out of scope

- Action 1.a itself (cap reliquat LOW cert) is a PHP change in `fonctions_annuaire_hp.php` outside this repo, deployed manually via SFTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)