### PR TITLE
fix(tests/search-harness): handle renamed regression_threshold fields in run_audit.py

### DIFF
--- a/tests/search_quality_harness/run_audit.py
+++ b/tests/search_quality_harness/run_audit.py
@@ -371,7 +371,16 @@ def main():
     print(f"=== Termine en {summary['duration_s']}s ===")
     print(f"  Global avg auto_score : {summary['global_avg_auto_score']} /10  (audit Cowork = 6.7)")
     print(f"  Critical (9 kw) avg   : {summary['critical_avg_auto_score']} /10  (audit < 5)")
-    print(f"  Canary (8 kw) avg     : {summary['canary_avg_auto_score']} /10  (audit ~10)  -> seuil regression : {summary['regression_threshold']['canary_min_score']}")
+    # FIX 2026-05-15 : seuil renomme par PR #581 (canary_min_score -> canary_max_drop)
+    # On gere les 2 noms pour retro-compat + on tolere l'absence du champ.
+    rt = summary.get('regression_threshold') or {}
+    if 'canary_max_drop' in rt:
+        seuil_str = f"delta >= -{rt['canary_max_drop']} vs T0"
+    elif 'canary_min_score' in rt:
+        seuil_str = f"score >= {rt['canary_min_score']} (deprecated absolu)"
+    else:
+        seuil_str = "n/a"
+    print(f"  Canary (8 kw) avg     : {summary['canary_avg_auto_score']} /10  (audit ~10)  -> seuil regression : {seuil_str}")
     print(f"  Output JSON : {out_path}")
 
 


### PR DESCRIPTION
## Summary

Fixes `KeyError: 'canary_min_score'` in `run_audit.py` introduced by PR #581 (which renamed the field to `canary_max_drop`).

## Observed error

```
=== Termine en 5.6s ===
  Global avg auto_score : 6.22 /10  (audit Cowork = 6.7)
  Critical (9 kw) avg   : 3.54 /10  (audit < 5)
Traceback (most recent call last):
  File "run_audit.py", line 374, in main
    print(f"... seuil regression : {summary['regression_threshold']['canary_min_score']}")
KeyError: 'canary_min_score'
```

The error occurred after the audit was complete (JSON output file was correctly written) — it only affected the end-of-run summary print. So no data was lost, but the run looked like a failure.

## Fix

Read either `canary_max_drop` (new, relative) or `canary_min_score` (deprecated, absolute) for retro-compat. Tolerate absence of `regression_threshold`. Adapt the printed legend accordingly:

```python
rt = summary.get('regression_threshold') or {}
if 'canary_max_drop' in rt:
    seuil_str = f"delta >= -{rt['canary_max_drop']} vs T0"
elif 'canary_min_score' in rt:
    seuil_str = f"score >= {rt['canary_min_score']} (deprecated absolu)"
else:
    seuil_str = "n/a"
```

## Test plan

- [ ] After merge, rerun `python3 run_audit.py` on the VM — should print the new legend without traceback
- [ ] Verify the JSON output is identical to before (no behavior change, only print fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)