### PR TITLE
fix(tests/search-harness): singularize French plurals in tokenize()

### DIFF
--- a/tests/search_quality_harness/run_audit.py
+++ b/tests/search_quality_harness/run_audit.py
@@ -78,10 +78,44 @@ def normalize_text(s):
     return " ".join(s.split())
 
 
+def singularize_french(token):
+    """
+    Replique la fonction PHP `conversion_en_singulier_mt` qui canonise les pluriels.
+    Sans cette etape, le harness donnait 2.3 pour "melangeurs coniques" (pluriel)
+    vs 3.9 pour "melangeur conique" (singulier) - meme intention, meme produits cibles.
+
+    Regles (alignees sur le PHP) :
+      1. Mots >= 5 chars finissant par 's' -> strip 's' (armoires -> armoire)
+      2. Mots finissant par 'eaux' -> strip 'x' (bateaux -> bateau)
+      3. Mots finissant par 'aux' -> remplacer par 'al' (medicaux -> medical)
+    """
+    if not token or len(token) < 5:
+        return token
+    # Regle 3 : 'aux' -> 'al' (verifie en premier car 'eaux' est sous-cas de 'aux')
+    if token.endswith("eaux"):
+        # Regle 2 : 'eaux' -> 'eau' (strip 'x')
+        return token[:-1]
+    if token.endswith("aux"):
+        # Regle 3 : 'aux' -> 'al'
+        return token[:-3] + "al"
+    if token.endswith("s"):
+        # Regle 1 : strip 's' (sauf si fait <4 chars apres)
+        if len(token) - 1 >= 4:
+            return token[:-1]
+    return token
+
+
 def tokenize(s):
-    """Renvoie set de tokens normalises (filtres : len >= 2, pas stopwords basiques)."""
+    """Renvoie set de tokens normalises + singularises (filtres : len >= 2, pas stopwords).
+
+    Etapes :
+      1. Lowercase + NFD + strip diacritiques + ponctuation -> espaces (normalize_text)
+      2. Split par espaces
+      3. Filter : len >= 2 ET pas dans STOP
+      4. Singulariser FR (fix 2026-05-15 : pour aligner avec PHP traitement_mot_mt)
+    """
     STOP = {"de", "du", "la", "le", "les", "un", "une", "et", "ou", "a", "au", "aux", "en", "pour", "sur", "avec", "par"}
-    return {t for t in normalize_text(s).split() if len(t) >= 2 and t not in STOP}
+    return {singularize_french(t) for t in normalize_text(s).split() if len(t) >= 2 and t not in STOP}
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes a false negative in the search quality harness for plural French queries.

## Problem

For query \`melangeurs coniques\` (plural), the harness computes \`auto_score = 2.3\`.
For query \`melangeur conique\` (singular, same intent), \`auto_score = 3.9\`.

Same products targeted, same human intent, but **+1.6 pts gap** because the Python \`tokenize()\` function does not apply French plural-to-singular normalization that the PHP backend already does via \`traitement_mot_mt(..., true, true)\` -> \`conversion_en_singulier_mt\` (see \`site/annuaire_hp/fonctions/fonctions_annuaire_hp.php\`).

This causes a false negative in the harness : the optimization audit on Cowork sees the same products for both queries (correctly), but the harness penalizes plural queries because it cannot match the singular product titles.

## Fix

Add a \`singularize_french()\` helper to \`run_audit.py\` mirroring the PHP rules :

1. Words >= 5 chars ending in \`s\` -> strip \`s\` (\`armoires\` -> \`armoire\`)
2. Words ending in \`eaux\` -> strip \`x\` (\`bateaux\` -> \`bateau\`)
3. Words ending in \`aux\` -> replace by \`al\` (\`medicaux\` -> \`medical\`)

Call it in \`tokenize()\` after lowercase + NFD + stopwords filter.

## Tests

\`\`\`
singularize_french('armoires')  == 'armoire'
singularize_french('bateaux')   == 'bateau'
singularize_french('medicaux')  == 'medical'
singularize_french('melangeurs') == 'melangeur'
singularize_french('coniques')  == 'conique'

tokenize('melangeurs coniques') == tokenize('melangeur conique')   # {'melangeur', 'conique'}
tokenize('armoire medicale')    == tokenize('armoires medicales')  # {'armoire', 'medicale'}
\`\`\`

All assertions pass.

## Expected effect on baseline T0

After merge + \`git pull\` on the VM + rerun :
- \`melangeurs coniques\` auto_score : 2.3 -> ~3.9 (converges with singular form)
- \`mélangeurs coniques\` auto_score : 2.3 -> ~3.9 (same after NFD + singularize)
- All other keywords : unchanged

This is a **harness measurement fix**, NOT a search engine behavior change.

## Test plan

- [x] Local Python tests pass (\`singularize_french\` + \`tokenize\` equivalence)
- [ ] After merge : rerun baseline T0 on VM, confirm melangeurs coniques score climbs ~+1.6 pts
- [ ] Verify other keywords unchanged (no regression)
- [ ] Resume optimization actions with more accurate auto_score

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>