### PR TITLE
feat(opti-moteur-front): A3 fallback adaptatif + A4 IDF tokens rares (audit v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,11 @@ secrets/
 # Docker compose override file
 docker-compose.override.yml
 
+# opti-moteur-front : fichiers de donnees generes offline (catalogue-dependants,
+# trop volumineux pour le repo, regenerables via scripts/compute_idf.py).
+apps-microservices/opti-moteur-front/app/data/*.json
+!apps-microservices/opti-moteur-front/app/data/.gitkeep
+
 # Logs folder
 ./logs/
 .claude/settings.local.json

--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -78,3 +78,41 @@ Respecter `app/{core,services,router,schemas,utils}/` :
 - `services/` : logique metier (detection, rerank, ingestion)
 - `schemas/` : contrats API pydantic
 - `router/` : routes FastAPI thin, deleguent aux services
+- `data/` : fichiers de donnees generes offline (gitignore, cf section IDF)
+
+## IDF tokens rares (A4, 2026-05-18)
+
+Le reranker pondere `name_match` et `cat_match` par l'IDF des tokens query
+(calcule sur l'ensemble des `nom_produit` Typesense). Cela resout les requetes
+combinatoires comme "melangeur conique" ou le token rare devrait peser plus
+que le token commun (audit v3, score 2.6/10 sur cette query).
+
+### Generer / regenerer le dict IDF
+
+Le fichier `app/data/idf_nom_produit.json` est gitignore (depend du catalogue
+live). A regenerer apres chaque ingestion majeure :
+
+```bash
+cd apps-microservices/opti-moteur-front
+python scripts/compute_idf.py
+# Recharge le dict IDF dans le service :
+docker compose restart opti-moteur-front
+```
+
+### Comportement si le fichier IDF est absent
+
+`idf_loader.idf_available()` retourne `False` -> le reranker bascule
+automatiquement sur le ratio simple (= comportement historique, backward-compat).
+Verifier le log au demarrage : `IDF file not found at ... - reranker will
+fallback to flat name_match`.
+
+## Filter_by_category : seuil de fallback adaptatif (A3, 2026-05-18)
+
+Le retry "sans filter_by" si pool < seuil utilise desormais un seuil adaptatif
+selon le nb de tokens query :
+- **1 token**  (compresseur, ERP) : seuil 150 -> evite que le filter etouffe
+  la P2 sur les requetes mono-token generiques (regression v3 audit).
+- **2 tokens** (armoire medicale) : seuil 20 -> conserve le gain v3 (+3.4).
+- **>=3 tokens** (Ritmo ELEKTRA M) : seuil 5 -> comportement strict actuel.
+
+Logique dans `app/services/search_service.py::_filter_fallback_threshold()`.

--- a/apps-microservices/opti-moteur-front/app/data/.gitkeep
+++ b/apps-microservices/opti-moteur-front/app/data/.gitkeep
@@ -1,0 +1,7 @@
+# Le dossier `app/data/` heberge des fichiers de donnees generes offline,
+# trop volumineux ou trop dependants du catalogue live pour etre commit.
+#
+# Fichiers attendus a runtime (genres a part puis copies/montes ici) :
+#   - idf_nom_produit.json  (genere par `python scripts/compute_idf.py`)
+#
+# Ce fichier .gitkeep n'a d'autre role que de conserver le dossier en git.

--- a/apps-microservices/opti-moteur-front/app/services/idf_loader.py
+++ b/apps-microservices/opti-moteur-front/app/services/idf_loader.py
@@ -1,0 +1,124 @@
+"""
+Charge le dictionnaire IDF (inverse document frequency) calcule offline sur
+les nom_produit du catalogue Typesense.
+
+Source : `app/data/idf_nom_produit.json` (genere par `scripts/compute_idf.py`).
+
+Pourquoi : le reranker actuel compte les tokens query matches dans nom_produit
+avec un poids uniforme (ratio simple). Sur des queries combinatoires comme
+"melangeur conique", "conique" est rare dans le catalogue et plus discriminant
+que "melangeur" (commun). En ponderant chaque token par son IDF, on favorise
+les produits qui contiennent le token rare, ce qui resout les regressions de
+l'audit v3 sur "melangeurs coniques" (2.6/10).
+
+Comportement si le fichier JSON est absent : `idf_available()` retourne False
+et le reranker bascule sur le ratio simple (backward-compat, aucun risque de
+regression a la mise en prod avant generation du fichier).
+"""
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Chemin par defaut du fichier IDF pre-calcule. Genere via :
+#   python scripts/compute_idf.py
+# Le fichier est gitignore (~1-5 MB, depend du catalogue live).
+_IDF_PATH = Path(__file__).resolve().parent.parent / "data" / "idf_nom_produit.json"
+
+
+# Etat global du loader (singleton, charge a la 1ere lecture)
+_idf_cache: Optional[Dict[str, float]] = None
+_idf_median: float = 1.0
+_load_attempted: bool = False
+
+
+def _compute_median(values) -> float:
+    """Mediane sans depend de numpy/statistics (~10ms sur 100k tokens)."""
+    if not values:
+        return 1.0
+    vals = sorted(values)
+    n = len(vals)
+    if n % 2 == 1:
+        return vals[n // 2]
+    return (vals[n // 2 - 1] + vals[n // 2]) / 2
+
+
+def _load_idf() -> Dict[str, float]:
+    """
+    Charge le dict IDF depuis le JSON (cache en RAM).
+    Retourne dict vide si fichier absent ou parse error (fallback safe).
+    """
+    global _idf_cache, _idf_median, _load_attempted
+
+    if _idf_cache is not None:
+        return _idf_cache
+    if _load_attempted:
+        return _idf_cache or {}
+    _load_attempted = True
+
+    if not _IDF_PATH.exists():
+        logger.warning(
+            "IDF file not found at %s - reranker will fallback to flat name_match (ratio simple). "
+            "Run `python scripts/compute_idf.py` to generate.",
+            _IDF_PATH,
+        )
+        _idf_cache = {}
+        return _idf_cache
+
+    try:
+        with open(_IDF_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+
+        # Format attendu : {"idf": {"token": float, ...}, "median": float, "n_docs": int}
+        # Tolere aussi un format flat {"token": float, ...} pour compat eventuelle.
+        if isinstance(data, dict) and "idf" in data and isinstance(data["idf"], dict):
+            idf_dict = data["idf"]
+            _idf_median = float(data.get("median") or _compute_median(idf_dict.values()))
+            n_docs = data.get("n_docs", "?")
+            logger.info(
+                "IDF loaded from %s : %d tokens, median=%.3f, n_docs=%s",
+                _IDF_PATH.name, len(idf_dict), _idf_median, n_docs,
+            )
+        elif isinstance(data, dict):
+            idf_dict = data
+            _idf_median = _compute_median(idf_dict.values())
+            logger.info(
+                "IDF loaded (flat format) from %s : %d tokens, median=%.3f",
+                _IDF_PATH.name, len(idf_dict), _idf_median,
+            )
+        else:
+            logger.error("IDF file %s has unexpected format (not a dict) - falling back", _IDF_PATH)
+            idf_dict = {}
+
+        _idf_cache = idf_dict
+    except (OSError, json.JSONDecodeError) as e:
+        logger.exception("Failed to load IDF file %s: %s - fallback to flat name_match", _IDF_PATH, e)
+        _idf_cache = {}
+
+    return _idf_cache
+
+
+def get_idf(token: str) -> float:
+    """
+    Retourne l'IDF d'un token. Tokens inconnus -> mediane (= token plutot rare,
+    pas penalise comme token frequent).
+    """
+    idf = _load_idf()
+    return idf.get(token, _idf_median)
+
+
+def idf_available() -> bool:
+    """True si le dict IDF est charge et non vide (= le reranker peut ponderer)."""
+    return bool(_load_idf())
+
+
+def reset_cache_for_test():
+    """Helper pour les tests unitaires : force le rechargement au prochain get_idf."""
+    global _idf_cache, _idf_median, _load_attempted
+    _idf_cache = None
+    _idf_median = 1.0
+    _load_attempted = False

--- a/apps-microservices/opti-moteur-front/app/services/reranker.py
+++ b/apps-microservices/opti-moteur-front/app/services/reranker.py
@@ -16,10 +16,33 @@ Formule (BM25 only, use_vector=False) :
 Penalite si name_match < 0.20 AND cat_match < 0.50 -> x 0.3
 (sans vecteur, on s'appuie davantage sur le nom qui est le signal le plus
  robuste pour les queries de type "categorie + adjectif").
+
+A4 (2026-05-18) -- Ponderation IDF des tokens
+---------------------------------------------
+name_match et cat_match sont ponderes par l'IDF des tokens query (inverse
+document frequency calculee offline sur l'ensemble des nom_produit).
+
+Exemple "melangeur conique" :
+  - "conique" rare dans le catalogue -> idf eleve (~3.0)
+  - "melangeur" plus commun           -> idf moyen (~1.5)
+  Produit "Saleuse a cuve conique" (matche conique, pas melangeur) :
+    name_match_simple = 1/2 = 0.50
+    name_match_idf    = 3.0 / (3.0 + 1.5) = 0.67
+  Produit "Mixeur peinture" (matche aucun token, mais titre semantique proche) :
+    name_match_simple = 0/2 = 0.00
+    name_match_idf    = 0.00 (inchange)
+
+Effet : les produits qui contiennent les tokens rares de la query remontent
+au-dessus de ceux qui ne contiennent que les tokens communs.
+
+Si le fichier IDF n'est pas charge (idf_available()=False, ex. fresh deploy
+sans avoir lance compute_idf.py), on bascule automatiquement sur le ratio
+simple : aucune regression possible vs le comportement actuel.
 """
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Set
 
 from app.core.credentials import settings
+from app.services.idf_loader import get_idf, idf_available
 from app.utils.text import tokenize
 
 
@@ -28,6 +51,34 @@ _W_VECTOR_NOVEC = 0.00
 _W_BM25_NOVEC   = 0.20
 _W_NAME_NOVEC   = 0.60
 _W_CAT_NOVEC    = 0.20
+
+
+def _idf_weighted_match(q_tokens: Set[str], doc_tokens: Set[str]) -> float:
+    """
+    Ratio de match pondere par IDF entre q_tokens et doc_tokens.
+    Si l'IDF n'est pas disponible -> fallback ratio simple
+    (= comportement historique, aucune regression).
+
+    Resultat entre 0.0 (aucun match) et 1.0 (tous les tokens query matches).
+    """
+    if not q_tokens:
+        return 0.0
+
+    if not idf_available():
+        # Fallback : ratio simple historique
+        return len(q_tokens & doc_tokens) / len(q_tokens)
+
+    matched = q_tokens & doc_tokens
+    if not matched:
+        return 0.0
+
+    sum_matched = sum(get_idf(t) for t in matched)
+    sum_total = sum(get_idf(t) for t in q_tokens)
+    if sum_total <= 0:
+        # Garde-fou : tous les tokens query ont idf=0 (theoriquement impossible
+        # avec idf lisse log((N+1)/(df+1))+1 >= 1) -> ratio simple
+        return len(matched) / len(q_tokens)
+    return sum_matched / sum_total
 
 
 def rerank_candidates(
@@ -72,11 +123,12 @@ def rerank_candidates(
         vec_score = 1 - min(vec_dist or 1.0, 1.0) if use_vector else 0.0
         tm_raw = hit.get("text_match", 0) or 0
 
+        # A4 : name_match et cat_match desormais ponderes par IDF (si dispo).
         name_tokens = tokenize(doc.get("nom_produit", ""))
-        name_match = len(q_tokens & name_tokens) / max(len(q_tokens), 1)
+        name_match = _idf_weighted_match(q_tokens, name_tokens)
 
         cat_tokens = tokenize(doc.get("categorie", ""))
-        cat_match = len(q_tokens & cat_tokens) / max(len(q_tokens), 1)
+        cat_match = _idf_weighted_match(q_tokens, cat_tokens)
 
         raw.append({
             "doc": doc,

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -13,8 +13,32 @@ from app.core.credentials import settings
 from app.core.typesense_client import typesense_client
 from app.services.category_detector import detect_categories
 from app.services.reranker import rerank_candidates
+from app.utils.text import tokenize
 
 logger = logging.getLogger(__name__)
+
+
+# A3 (2026-05-18) -- Seuil de fallback adaptatif selon longueur de la query.
+# Probleme observe (audit v3) : 12 mots-cles sur 24 perdent leur P2 a cause du
+# filter_by_category trop restrictif quand la categorie detectee est correcte
+# mais le catalogue large (ex. "compresseur", "ERP", "distributeur automatique").
+# Le pool filter < seuil declenche un retry sans filter -> P2 reapparait.
+#
+# Seuils calibres :
+#   1 token  : 150 -> requete mono-token generique, on veut un large pool si la
+#              categorie filtre exagerement (cas "compresseur" -> pool < 150).
+#   2 tokens : 20  -> requete cible specifique (ex. "armoire medicale"), on conserve
+#              le filter quand il marche (gain +3.4 en v3). Retry seulement si pool
+#              vraiment trop petit.
+#   >=3      : 5   -> requete tres specifique, on garde le comportement strict
+#              actuel (eviter de polluer "Ritmo ELEKTRA M" avec du hors-marque).
+def _filter_fallback_threshold(query: str) -> int:
+    n = len(tokenize(query))
+    if n <= 1:
+        return 150
+    if n == 2:
+        return 20
+    return 5
 
 
 def search(
@@ -55,11 +79,13 @@ def search(
     )
     groups = ts_result.get("grouped_hits", [])
 
-    # Fallback : si filter_by trop restrictif (< 5 resultats), retry sans filtre
-    if filter_cats and len(groups) < 5:
+    # Fallback : si filter_by trop restrictif, retry sans filtre.
+    # A3 (2026-05-18) : seuil adaptatif selon nb de tokens query (cf doc plus haut).
+    fallback_threshold = _filter_fallback_threshold(query)
+    if filter_cats and len(groups) < fallback_threshold:
         logger.info(
-            "filter_by trop restrictif (%d res) pour query=%r, fallback sans filtre",
-            len(groups), query,
+            "filter_by trop restrictif (%d res < seuil %d) pour query=%r, fallback sans filtre",
+            len(groups), fallback_threshold, query,
         )
         ts_result = _hybrid_typesense_search(
             query, query_vector, collection, candidates, filter_cats=None,

--- a/apps-microservices/opti-moteur-front/scripts/compute_idf.py
+++ b/apps-microservices/opti-moteur-front/scripts/compute_idf.py
@@ -1,0 +1,214 @@
+"""
+compute_idf.py
+==============
+Calcule l'IDF (Inverse Document Frequency) des tokens dans `nom_produit` pour
+la collection Typesense, et serialise le dict en JSON pour usage par le
+reranker (`app/services/idf_loader.py`).
+
+Pourquoi :
+  Le reranker compte historiquement les tokens query matches dans nom_produit
+  avec un poids uniforme. Pour des queries combinatoires comme
+  "melangeur conique", le token rare ("conique") devrait peser plus que le
+  token commun ("melangeur") -- d'ou la ponderation IDF.
+
+Usage :
+  # 1. Etre sur la VM ou dans un environnement qui peut joindre Typesense
+  cd apps-microservices/opti-moteur-front
+  python scripts/compute_idf.py
+
+  # Options
+  python scripts/compute_idf.py --collection produits_scale --out app/data/idf_nom_produit.json
+  python scripts/compute_idf.py --limit 50000   # echantillon (test rapide)
+
+Le fichier de sortie est gitignore (depend du catalogue live). A relancer
+apres chaque ingestion majeure (sync_typesense_daily + delta consequent).
+
+Couts :
+  Export ~700k docs Typesense (champ nom_produit only) : ~10-30s + ~50-200 MB RAM.
+  Calcul IDF : ~5s. JSON final : ~1-5 MB (selon vocab).
+"""
+import argparse
+import json
+import logging
+import math
+import re
+import sys
+import time
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+# Permet de lancer le script depuis la racine du service
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_APP_DIR = _SCRIPT_DIR.parent
+sys.path.insert(0, str(_APP_DIR))
+
+from app.core.credentials import settings  # noqa: E402
+from app.core.typesense_client import typesense_client  # noqa: E402
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("compute_idf")
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer : strict reflexion de app/utils/text.py (a maintenir aligne).
+# On ne reutilise pas directement pour ne pas tirer l'app dans le script si
+# l'arborescence change a l'avenir.
+# ---------------------------------------------------------------------------
+def normalize(s: str) -> str:
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFD", s)
+    return "".join(c for c in s if unicodedata.category(c) != "Mn").lower()
+
+
+def tokenize(s: str):
+    return set(re.findall(r"[a-z0-9]{2,}", normalize(s)))
+
+
+# ---------------------------------------------------------------------------
+# Export des nom_produit depuis Typesense
+# ---------------------------------------------------------------------------
+def iter_nom_produits(collection: str, limit: int = 0):
+    """
+    Streame les nom_produit via /documents/export (JSONL).
+
+    `limit` = 0 -> export complet. Sinon : tronque (utile pour test).
+
+    Note : Typesense renvoie 1 ligne JSON par document. Pour 700k docs c'est
+    ~50-200 MB de string en RAM -- acceptable. Si on doit traiter 10M+ docs,
+    refactoriser en streaming HTTP (requests.get stream=True + iter_lines).
+    """
+    t0 = time.time()
+    logger.info("Exporting documents from Typesense collection=%s ...", collection)
+    coll = typesense_client.client.collections[collection]
+    raw = coll.documents.export({"include_fields": "nom_produit"})
+    dt = time.time() - t0
+    n_lines = raw.count("\n") + 1 if raw else 0
+    logger.info("Export terminated in %.1fs (~%d lines, %.1f MB)", dt, n_lines, len(raw) / (1024 * 1024))
+
+    n = 0
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        nom = doc.get("nom_produit") or ""
+        if not nom:
+            continue
+        yield nom
+        n += 1
+        if limit and n >= limit:
+            logger.info("Limit %d reached, stopping export", limit)
+            break
+
+
+# ---------------------------------------------------------------------------
+# Calcul IDF lisse
+# ---------------------------------------------------------------------------
+def compute_idf(collection: str, limit: int = 0) -> dict:
+    """
+    Retourne :
+      {
+        "n_docs": int,
+        "n_tokens": int,
+        "median": float,
+        "idf": {token: float, ...}
+      }
+
+    Formule : idf(t) = log((N + 1) / (df(t) + 1)) + 1
+      - lisse pour eviter idf=0 ou inf
+      - >= 1 pour tous les tokens (le +1 final garantit qu'un token tres
+        frequent ait quand meme un poids non-nul, sinon le ratio name_match
+        deviendrait degenere).
+    """
+    df = Counter()
+    n_docs = 0
+    t0 = time.time()
+    last_log = t0
+
+    for nom in iter_nom_produits(collection, limit=limit):
+        n_docs += 1
+        for tok in tokenize(nom):
+            df[tok] += 1
+
+        # Heartbeat toutes les 5s
+        if time.time() - last_log > 5:
+            logger.info("Processed %d docs, %d unique tokens so far", n_docs, len(df))
+            last_log = time.time()
+
+    if n_docs == 0:
+        raise RuntimeError(f"No documents extracted from collection '{collection}' "
+                           "- verifier la connectivite Typesense et le nom de la collection")
+
+    logger.info("Tokenization done in %.1fs : %d docs, %d unique tokens",
+                time.time() - t0, n_docs, len(df))
+
+    # IDF lisse
+    idf = {}
+    for tok, freq in df.items():
+        idf[tok] = math.log((n_docs + 1) / (freq + 1)) + 1.0
+
+    # Mediane (utilisee comme fallback pour tokens inconnus a runtime)
+    vals = sorted(idf.values())
+    median = vals[len(vals) // 2] if vals else 1.0
+
+    # Statistiques rapides (pour sanity check post-generation)
+    min_idf = min(vals) if vals else 0.0
+    max_idf = max(vals) if vals else 0.0
+    logger.info("IDF stats : min=%.3f  median=%.3f  max=%.3f", min_idf, median, max_idf)
+
+    return {
+        "n_docs": n_docs,
+        "n_tokens": len(idf),
+        "median": median,
+        "idf": idf,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="Calcule l'IDF des tokens nom_produit pour le reranker")
+    parser.add_argument(
+        "--collection", default=settings.TYPESENSE_COLLECTION,
+        help=f"Collection Typesense source (default: {settings.TYPESENSE_COLLECTION})",
+    )
+    parser.add_argument(
+        "--out", default=str(_APP_DIR / "app" / "data" / "idf_nom_produit.json"),
+        help="Chemin du fichier JSON de sortie",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Limite le nombre de docs traites (0 = aucun). Utile pour test rapide.",
+    )
+    args = parser.parse_args()
+
+    t0 = time.time()
+    result = compute_idf(args.collection, limit=args.limit)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False)
+
+    size_kb = out_path.stat().st_size / 1024
+    logger.info(
+        "Wrote %s (%d tokens, median=%.3f, n_docs=%d, %.1f KB) in %.1fs",
+        out_path, result["n_tokens"], result["median"], result["n_docs"],
+        size_kb, time.time() - t0,
+    )
+    logger.info("Restart opti-moteur-front pour que le reranker recharge le nouveau dict IDF.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps-microservices/opti-moteur-front/tests/test_idf_loader.py
+++ b/apps-microservices/opti-moteur-front/tests/test_idf_loader.py
@@ -1,0 +1,60 @@
+"""Tests unitaires du loader IDF (A4)."""
+import json
+
+from app.services import idf_loader
+
+
+def test_idf_unavailable_when_file_missing(tmp_path, monkeypatch):
+    """Aucun fichier -> idf_available()=False, get_idf retourne la mediane (1.0)."""
+    missing = tmp_path / "no_idf.json"
+    monkeypatch.setattr(idf_loader, "_IDF_PATH", missing)
+    idf_loader.reset_cache_for_test()
+
+    assert idf_loader.idf_available() is False
+    assert idf_loader.get_idf("anything") == 1.0  # mediane par defaut
+
+
+def test_idf_loaded_with_full_format(tmp_path, monkeypatch):
+    """Format standard {idf, median, n_docs} : ok."""
+    path = tmp_path / "idf.json"
+    payload = {
+        "n_docs": 100000,
+        "n_tokens": 3,
+        "median": 2.5,
+        "idf": {"melangeur": 1.2, "conique": 4.8, "armoire": 2.0},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(idf_loader, "_IDF_PATH", path)
+    idf_loader.reset_cache_for_test()
+
+    assert idf_loader.idf_available() is True
+    assert idf_loader.get_idf("conique") == 4.8
+    assert idf_loader.get_idf("melangeur") == 1.2
+    # Token inconnu -> mediane
+    assert idf_loader.get_idf("inconnu") == 2.5
+
+
+def test_idf_loaded_with_flat_format(tmp_path, monkeypatch):
+    """Tolere aussi un format flat (dict token->float direct)."""
+    path = tmp_path / "idf_flat.json"
+    payload = {"foo": 3.0, "bar": 1.0, "baz": 5.0}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(idf_loader, "_IDF_PATH", path)
+    idf_loader.reset_cache_for_test()
+
+    assert idf_loader.idf_available() is True
+    assert idf_loader.get_idf("foo") == 3.0
+    # Mediane calculee sur [1.0, 3.0, 5.0] = 3.0
+    assert idf_loader.get_idf("not_present") == 3.0
+
+
+def test_idf_corrupt_file_fallbacks(tmp_path, monkeypatch):
+    """JSON corrompu -> idf_available()=False, pas de crash."""
+    path = tmp_path / "broken.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr(idf_loader, "_IDF_PATH", path)
+    idf_loader.reset_cache_for_test()
+
+    assert idf_loader.idf_available() is False
+    # mediane = 1.0 (default) car aucun load
+    assert idf_loader.get_idf("foo") == 1.0

--- a/apps-microservices/opti-moteur-front/tests/test_reranker.py
+++ b/apps-microservices/opti-moteur-front/tests/test_reranker.py
@@ -1,4 +1,7 @@
 """Tests unitaires du reranker."""
+from unittest import mock
+
+from app.services import reranker
 from app.services.reranker import rerank_candidates
 
 
@@ -41,3 +44,77 @@ class TestRerank:
         assert noise_entry["penalty"] == "noise_bm25"
         # Good doit etre premier
         assert ranked[0]["doc"]["id_produit"] == "good"
+
+
+class TestIdfWeightedMatch:
+    """
+    A4 (2026-05-18) : verifie que name_match privilegie les tokens rares quand
+    l'IDF est disponible. Quand l'IDF n'est pas charge (test default), on tombe
+    sur le ratio simple historique - backward-compat preservee.
+    """
+
+    def test_falls_back_to_simple_ratio_without_idf(self):
+        # Pas de fichier IDF dans l'environnement de test -> ratio simple.
+        # On verifie indirectement via le winner : "conique" matche les 2 docs,
+        # mais le premier matche aussi "melangeur" -> ratio 2/2 vs 1/2.
+        groups = [
+            make_group("both",   "Melangeur conique 5L", "Melangeurs",  vec_dist=0.3, text_match=800000),
+            make_group("partial", "Saleuse conique",     "Saleuses",    vec_dist=0.3, text_match=400000),
+        ]
+        ranked = rerank_candidates(groups, "melangeur conique")
+        assert ranked[0]["doc"]["id_produit"] == "both"
+
+    def test_idf_weighting_lifts_rare_token_match(self):
+        """
+        Quand l'IDF est disponible et que `conique` est plus rare que
+        `melangeur`, un produit qui matche uniquement "conique" (mais pas
+        "melangeur") doit avoir un name_match > 0.5 (au lieu de 0.5 strict
+        avec le ratio simple).
+        """
+        # Mock le loader IDF pour ce test : "melangeur" tres frequent (idf bas),
+        # "conique" rare (idf eleve).
+        fake_idf = {"melangeur": 1.0, "conique": 4.0}
+
+        with mock.patch.object(reranker, "idf_available", return_value=True), \
+             mock.patch.object(reranker, "get_idf",
+                               side_effect=lambda t: fake_idf.get(t, 2.0)):
+            groups = [
+                make_group("rare_only", "Saleuse conique", "Saleuses",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "melangeur conique")
+            # name_match_idf = idf("conique") / (idf("conique") + idf("melangeur"))
+            #                = 4.0 / (4.0 + 1.0) = 0.80  (vs 0.5 en ratio simple)
+            assert ranked[0]["name_match"] == 0.8
+
+    def test_idf_weighting_drops_common_token_match(self):
+        """
+        Inverse : un produit qui matche seulement "melangeur" (token commun)
+        doit avoir un name_match < 0.5 (vs 0.5 strict avec le ratio simple).
+        """
+        fake_idf = {"melangeur": 1.0, "conique": 4.0}
+
+        with mock.patch.object(reranker, "idf_available", return_value=True), \
+             mock.patch.object(reranker, "get_idf",
+                               side_effect=lambda t: fake_idf.get(t, 2.0)):
+            groups = [
+                make_group("common_only", "Melangeur classique", "Melangeurs",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "melangeur conique")
+            # name_match_idf = 1.0 / 5.0 = 0.20
+            assert abs(ranked[0]["name_match"] - 0.20) < 1e-9
+
+    def test_idf_full_match_still_one(self):
+        """Si tous les tokens query matchent, name_match doit toujours valoir 1.0."""
+        fake_idf = {"melangeur": 1.0, "conique": 4.0}
+
+        with mock.patch.object(reranker, "idf_available", return_value=True), \
+             mock.patch.object(reranker, "get_idf",
+                               side_effect=lambda t: fake_idf.get(t, 2.0)):
+            groups = [
+                make_group("full", "Melangeur conique 5L", "Melangeurs",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "melangeur conique")
+            assert ranked[0]["name_match"] == 1.0


### PR DESCRIPTION
## Contexte

Suite à l'**audit qualité moteur v3** (rapport du 18/05/2026, note moyenne 6.66 → 7.10), 2 des recommandations résiduelles sont implémentées dans cette PR :

- **A3** — Restaurer la P2 sur les requêtes mono-token génériques (12/24 mots-clés ont perdu leur P2 en v3 : `compresseur`, `ERP`, `distributeur automatique`, etc.).
- **A4** — Corriger les requêtes combinatoires (`mélangeurs coniques` reste à 2.6/10 car tokens traités en OR plutôt qu'avec pondération par rareté).

## Changements

### A3 — Seuil de fallback adaptatif (`search_service.py`)

Le retry "sans `filter_by`" si `pool < seuil` utilise désormais un seuil dépendant du nombre de tokens query :

| Tokens query | Seuil | Effet |
|---|---|---|
| 1 token (`compresseur`) | **150** | Restaure la P2 quand le filter étouffe (catalogue large) |
| 2 tokens (`armoire medicale`) | 20 | Conserve le gain v3 (+3.4 pts) |
| ≥3 tokens (`Ritmo ELEKTRA M`) | 5 | Inchangé (comportement strict pour queries spécifiques) |

### A4 — Pondération IDF des tokens (`reranker.py` + `idf_loader.py` + `compute_idf.py`)

- `name_match` et `cat_match` désormais pondérés par l'IDF des tokens query, calculé offline sur les `nom_produit` Typesense.
- **Exemple** `mélangeur conique` :
  - `conique` rare → IDF ≈ 3.0
  - `mélangeur` commun → IDF ≈ 1.5
  - Un produit "Saleuse à cuve conique" (matche `conique` seul) aura `name_match ≈ 0.67` (vs 0.5 en ratio simple).
- **Backward-compat safe** : si `app/data/idf_nom_produit.json` est absent (fresh deploy), `idf_loader.idf_available()` retourne `False` et le reranker bascule automatiquement sur le ratio simple historique.

## Fichiers touchés

```
apps-microservices/opti-moteur-front/
├── app/services/search_service.py    (A3 — modifié)
├── app/services/reranker.py          (A4 — modifié)
├── app/services/idf_loader.py        (A4 — nouveau)
├── app/data/.gitkeep                 (A4 — nouveau, héberge le JSON IDF gitignored)
├── scripts/compute_idf.py            (A4 — nouveau)
├── tests/test_reranker.py            (mise à jour, 4 nouveaux tests IDF)
├── tests/test_idf_loader.py          (nouveau)
└── CLAUDE.md                         (documenté A3 + A4 + opérations)

.gitignore                            (ignore app/data/*.json, keep .gitkeep)
```

## Tests

```bash
$ pytest tests/ -v
============================== 21 passed in 0.33s ==============================
```

3 existants + 8 nouveaux. Aucune régression.

## Ops après merge

Sur la VM (`/home/devhp/RAG-HP-PUB`) :

```bash
git pull origin features/poc
cd apps-microservices/opti-moteur-front

# Générer le dict IDF (~10-30s sur ~700k docs)
python scripts/compute_idf.py

# Recharger le service pour qu'il prenne en compte le nouveau dict IDF
docker compose restart opti-moteur-front
```

Vérif via logs au démarrage : `IDF loaded from idf_nom_produit.json : N tokens, median=X.XXX, n_docs=Y`.

**Si on oublie `compute_idf.py`** : aucun crash, le reranker log un warning et tombe sur le ratio simple → A3 reste actif, A4 inactif jusqu'à la génération du JSON.

## Test plan

- [ ] Sur la VM : `python scripts/compute_idf.py` génère bien le JSON (~1-5 MB)
- [ ] `docker compose restart opti-moteur-front` → vérifier le log `IDF loaded...`
- [ ] Tester `compresseur` : P2 doit redevenir disponible (le seuil 150 force le retry sans filter)
- [ ] Tester `mélangeurs coniques` : le top P1 doit remonter les produits avec "conique" présent (vs ceux sans)
- [ ] Tester `armoire medicale` : pas de régression (la top P1 v3 reste cohérente)
- [ ] Tester `Ritmo ELEKTRA M` : pas de régression (toujours filtré strict)

## Ne touche pas

- Pipeline d'ingestion Typesense
- Schema Typesense
- Front PHP (`fonctions_typesense.php`, `search_ajax.php`, `moteur_recherche_ajax.js`)
- Détection catégorie (`category_detector.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)