### PR TITLE
fix(opti-moteur-front): bind-mount app/data + doc python3 (suivi #590)

### DIFF
--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -90,14 +90,35 @@ que le token commun (audit v3, score 2.6/10 sur cette query).
 ### Generer / regenerer le dict IDF
 
 Le fichier `app/data/idf_nom_produit.json` est gitignore (depend du catalogue
-live). A regenerer apres chaque ingestion majeure :
+live). A regenerer apres chaque ingestion majeure.
+
+**Methode recommandee : execution dans le container** (toutes les deps sont
+deja la, pas besoin d'installer Python + requirements.txt sur la VM). Le
+bind-mount `./app/data:/app/app/data` (cf docker-compose.yaml) garantit que
+le JSON ecrit dans le container apparait aussi cote hote.
 
 ```bash
 cd apps-microservices/opti-moteur-front
-python scripts/compute_idf.py
-# Recharge le dict IDF dans le service :
+
+# 1. (Une seule fois apres ajout du bind-mount) recreer le container pour
+#    que le volume soit pris en compte. `restart` seul ne suffit pas.
+docker compose up -d --force-recreate opti-moteur-front
+
+# 2. Generer le dict IDF (~10-30s sur ~700k docs)
+docker compose exec opti-moteur-front python scripts/compute_idf.py
+
+# 3. Recharger pour que le reranker charge le nouveau dict IDF en RAM
 docker compose restart opti-moteur-front
+
+# 4. Verifier les logs au demarrage
+docker compose logs --tail 30 opti-moteur-front | grep -i "IDF"
+# Attendu : "IDF loaded from idf_nom_produit.json : NNNN tokens, median=X.XXX, n_docs=YYYYY"
 ```
+
+**Methode alternative (hors container)** : si Python 3 + deps installes sur
+la VM, `python3 scripts/compute_idf.py` ecrit directement dans
+`apps-microservices/opti-moteur-front/app/data/` (cote hote), visible par
+le container via le bind-mount.
 
 ### Comportement si le fichier IDF est absent
 

--- a/apps-microservices/opti-moteur-front/docker-compose.yaml
+++ b/apps-microservices/opti-moteur-front/docker-compose.yaml
@@ -10,6 +10,13 @@ services:
       - "8570:8570"
     env_file:
       - .env
+    # Bind-mount du dossier `app/data/` pour partager les fichiers de donnees
+    # generes offline (idf_nom_produit.json en particulier) entre l'hote et le
+    # container. Sans ce mount, le fichier IDF cree par compute_idf.py serait
+    # perdu au prochain `docker compose down` ou rebuild d'image.
+    # Le fichier JSON est gitignore (cf root .gitignore).
+    volumes:
+      - ./app/data:/app/app/data
     depends_on:
       - typesense
     restart: unless-stopped

--- a/apps-microservices/opti-moteur-front/scripts/compute_idf.py
+++ b/apps-microservices/opti-moteur-front/scripts/compute_idf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 compute_idf.py
 ==============
@@ -11,17 +12,23 @@ Pourquoi :
   "melangeur conique", le token rare ("conique") devrait peser plus que le
   token commun ("melangeur") -- d'ou la ponderation IDF.
 
-Usage :
-  # 1. Etre sur la VM ou dans un environnement qui peut joindre Typesense
+Usage RECOMMANDE -- dans le container Docker (deps deja la) :
   cd apps-microservices/opti-moteur-front
-  python scripts/compute_idf.py
+  docker compose exec opti-moteur-front python scripts/compute_idf.py
+  docker compose restart opti-moteur-front
+
+Usage alternatif -- depuis l'hote (besoin python3 + requirements.txt) :
+  cd apps-microservices/opti-moteur-front
+  python3 scripts/compute_idf.py
 
   # Options
-  python scripts/compute_idf.py --collection produits_scale --out app/data/idf_nom_produit.json
-  python scripts/compute_idf.py --limit 50000   # echantillon (test rapide)
+  python3 scripts/compute_idf.py --collection produits_scale
+  python3 scripts/compute_idf.py --limit 50000  # echantillon (test rapide)
 
-Le fichier de sortie est gitignore (depend du catalogue live). A relancer
-apres chaque ingestion majeure (sync_typesense_daily + delta consequent).
+Le fichier de sortie (`app/data/idf_nom_produit.json`) est gitignore (depend
+du catalogue live). Le bind-mount docker-compose `./app/data:/app/app/data`
+garantit que le fichier ecrit dans le container apparait cote hote, et vice-
+versa.
 
 Couts :
   Export ~700k docs Typesense (champ nom_produit only) : ~10-30s + ~50-200 MB RAM.
@@ -207,7 +214,11 @@ def main():
         out_path, result["n_tokens"], result["median"], result["n_docs"],
         size_kb, time.time() - t0,
     )
-    logger.info("Restart opti-moteur-front pour que le reranker recharge le nouveau dict IDF.")
+    logger.info(
+        "Done. Pour que le reranker recharge le dict IDF en RAM, executer :\n"
+        "    docker compose restart opti-moteur-front\n"
+        "Puis verifier : docker compose logs --tail 30 opti-moteur-front | grep -i IDF"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Contexte

Suite au déploiement de [#590](https://github.com/Hellopro-fr/RAG-HP-PUB/pull/590) sur la VM, deux problèmes opérationnels :

1. **`python` introuvable sur la VM** (Ubuntu utilise `python3`) → le script `compute_idf.py` n'a pas été exécuté → A4 reste inactif (le reranker tombe en fallback ratio simple, A3 actif comme prévu).
2. **Pas de bind-mount** entre `app/data/` et le container → même avec le bon binaire Python, le fichier IDF aurait été perdu au prochain `docker compose down` / rebuild.

A3 fonctionne déjà en prod (code-only). C'est juste A4 qui ne peut pas démarrer tant que ce fix n'est pas mergé.

## Changements

### `docker-compose.yaml` — bind-mount

```yaml
services:
  opti-moteur-front:
    ...
    volumes:
      - ./app/data:/app/app/data
```

Le dossier `app/data/` côté hôte est partagé avec `/app/app/data/` côté container. Le fichier `idf_nom_produit.json` survit aux `down` / rebuild.

### `CLAUDE.md` — méthode ops recommandée

Documentation révisée : méthode principale = **exécution dans le container** via `docker compose exec`. Pas besoin d'installer Python + `requirements.txt` sur la VM puisque le container a déjà toutes les deps.

### `scripts/compute_idf.py` — `python3` partout + shebang

- Shebang `#!/usr/bin/env python3` (au cas où quelqu'un fait `./compute_idf.py`)
- Doc d'usage : `python3` (pas `python`), `docker compose exec` mis en avant.
- Message final logue les commandes exactes à lancer derrière.

## 🚑 Procédure d'ops post-merge (sur la VM)

```bash
cd ~/RAG-HP-PUB
git pull origin features/poc

cd apps-microservices/opti-moteur-front

# 1. Recreer le container pour que le bind-mount soit pris en compte.
#    Important : `restart` seul ne suffit pas pour ajouter un volume.
docker compose up -d --force-recreate opti-moteur-front

# 2. Generer l'IDF (~10-30s sur ~700k docs)
docker compose exec opti-moteur-front python scripts/compute_idf.py

# 3. Recharger pour que le reranker charge le dict en RAM
docker compose restart opti-moteur-front

# 4. Verifier
docker compose logs --tail 30 opti-moteur-front | grep -i IDF
# Attendu : "IDF loaded from idf_nom_produit.json : NNNN tokens, median=X.XXX, n_docs=YYYYY"

# Sanity check : le fichier est bien cote hote (persiste aux rebuild)
ls -lh app/data/idf_nom_produit.json
```

## Test plan

- [ ] `git pull` propre sur la VM
- [ ] `docker compose up -d --force-recreate` recree le container avec le mount
- [ ] `docker compose exec opti-moteur-front python scripts/compute_idf.py` produit le JSON sans crash, log "Wrote ... in Xs"
- [ ] `ls app/data/idf_nom_produit.json` montre un fichier ~1-5 MB côté hôte
- [ ] `docker compose restart` puis logs : "IDF loaded from idf_nom_produit.json : NNNN tokens"
- [ ] Tester sur cowork une query type `mélangeurs coniques` : produits avec "conique" doivent remonter (A4 actif)

## Ne touche pas

- Logique A3 / A4 (code Python inchangé)
- Ingestion Typesense
- Front PHP

🤖 Generated with [Claude Code](https://claude.com/claude-code)