### PR TITLE
fix(nextjs-formulaire-hp): increase mobile bottom padding so explanat…

### DIFF
--- a/apps-microservices/nextjs-formulaire-hp/components/flow/QuestionScreen.tsx
+++ b/apps-microservices/nextjs-formulaire-hp/components/flow/QuestionScreen.tsx
@@ -90,8 +90,11 @@ const QuestionScreen = ({
 
   return (
     <div className="flex flex-col min-h-full">
-      {/* Scrollable content */}
-      <div className="flex-1 pb-32 sm:pb-6">
+      {/* Scrollable content.
+          pb-48 sur mobile : le sticky footer (réassurance + boutons + safe-area)
+          fait ~150px, on ajoute 40px de marge pour que la card explication mobile
+          ne se retrouve pas collée/cachée sous le footer en bas de scroll. */}
+      <div className="flex-1 pb-48 sm:pb-6">
         <div className="px-4 sm:px-6 lg:px-10 pt-5 sm:pt-8">
         <div className={cn(
           "mx-auto grid gap-6 lg:gap-10",


### PR DESCRIPTION
…ion card clears sticky footer

fix(nextjs-formulaire-hp): augmente le padding-bottom mobile pour que la card explication ne soit plus masquée par le sticky footer

Bumped the scrollable content padding-bottom on mobile from pb-32 (128px) to pb-48 (192px). The mobile sticky footer (reassurance row + nav buttons) totals roughly 150px, so the previous 128px reserve was insufficient and the bottom of the QuestionExplanationPanel was sliding under the footer on scroll. Verified visually at viewport 390x844 with Chrome DevTools MCP.

Augmentation du padding-bottom du contenu scrollable sur mobile de pb-32 (128px) à pb-48 (192px). Le sticky footer mobile (réassurance + boutons de navigation) fait environ 150px, donc les 128px réservés étaient insuffisants et le bas du QuestionExplanationPanel passait sous le footer au scroll. Vérifié visuellement en viewport 390x844 via Chrome DevTools MCP.