### PR TITLE
fix(mcp-gateway-frontend): route /authorize to Vue SPA instead of Go …

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/nginx.conf
+++ b/apps-microservices/mcp-gateway-frontend/nginx.conf
@@ -119,33 +119,13 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # OAuth2 authorization endpoint (login form + consent) — throttle form brute-force (5 r/s, burst 10).
-    # proxy_hide_header drops the Go backend's legacy CSP/X-Frame headers so the nginx-level
-    # security headers win without duplication.
+    # OAuth2 authorization endpoint (consent UI) — served by the Vue SPA.
+    # The Vue AuthorizeView calls /api/v1/oauth2/authorize/info and /consent for data
+    # and POST submissions, and redirects to /sso/login?purpose=oauth2 when no session.
+    # The Go backend's HTML /authorize handler is unreachable from outside but kept
+    # for non-browser flows.
     location = /authorize {
-        limit_req zone=auth_authorize burst=10 nodelay;
-        proxy_hide_header Content-Security-Policy;
-        proxy_hide_header X-Frame-Options;
-
-        # nginx replaces (does not merge) parent add_header when a location block
-        # declares its own — restate the baseline security headers here.
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-        add_header X-Robots-Tag "noindex, nofollow" always;
-        # Loosened CSP for the OAuth2 login/consent templates: allow the Tailwind
-        # CDN runtime (needs 'unsafe-eval') and the small inline <script> blocks
-        # in login.html / consent.html ('unsafe-inline'). Long-term: self-host
-        # Tailwind + extract inline scripts so this can drop back to strict CSP.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
-
-        proxy_pass $backend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        try_files /index.html =404;
     }
 
     # Well-known OAuth2 metadata → Go backend


### PR DESCRIPTION
…backend

The Vue AuthorizeView consent UI was unreachable from outside: nginx was proxying GET /authorize to the Go backend, which served the server-rendered consent.html template. Replace the proxy block with a try_files /index.html so the SPA boots on /authorize and Vue Router takes over.

The Vue AuthorizeView already handles every case the old HTML flow covered:
- Calls GET /api/v1/oauth2/authorize/info for client + server list.
- Redirects to /sso/login?purpose=oauth2&return_to=... when has_session is false.
- Submits consent via POST /api/v1/oauth2/authorize/consent.
- Builds the deny redirect from redirect_uri + state.

Security headers are inherited from the server block (nginx merges only when the location does not declare its own add_header — the previous block restated them defensively). Rate limit for the brute-force auth form is dropped because there is no form here anymore; brute force is covered upstream at /sso/login.

The Go backend's HTML /authorize handler is unreachable from external nginx but kept for non-browser callers.

fix(mcp-gateway-frontend) : route /authorize vers la SPA Vue au lieu du backend Go pour exposer la nouvelle page de consentement.