### PR TITLE
feat(mcp-gateway-frontend): align consent UI with /docs layout + cond…

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentHeader.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentHeader.vue
@@ -1,40 +1,23 @@
 <template>
-  <header class="border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-    <div class="mx-auto max-w-3xl px-4 py-6">
-      <div class="flex flex-col items-center gap-4 text-center">
-        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-brand-500">
-          <KeyRound class="h-6 w-6 text-white" />
-        </div>
-        <div class="space-y-3">
-          <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
-            Demande d'autorisation
+  <header
+    class="sticky top-0 z-10 bg-white border-b border-gray-200 dark:bg-gray-900 dark:border-gray-800"
+  >
+    <div class="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
+      <router-link to="/docs" class="flex items-center gap-3 no-underline">
+        <img src="/images/servers/hp-logo.svg" alt="Hellopro" class="w-9 h-9" />
+        <div>
+          <h1 class="text-lg font-semibold text-gray-900 dark:text-white leading-tight">
+            MCP Gateway
           </h1>
-          <div class="flex items-center justify-center gap-3">
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-xs font-medium text-gray-700 dark:text-gray-300"
-            >
-              {{ initials }}
-            </div>
-            <span class="font-medium text-gray-900 dark:text-white">{{ clientName }}</span>
-          </div>
-          <p class="text-sm text-gray-600 dark:text-gray-400 max-w-md">
-            demande l'autorisation d'accéder à vos serveurs MCP en votre nom
-          </p>
+          <p class="text-xs text-gray-500 dark:text-gray-400">Autorisation</p>
         </div>
-      </div>
+      </router-link>
     </div>
   </header>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { KeyRound } from 'lucide-vue-next'
-
-const props = defineProps<{
+defineProps<{
   clientName: string
 }>()
-
-const initials = computed(() =>
-  (props.clientName || '??').slice(0, 2).toUpperCase(),
-)
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
@@ -11,10 +11,7 @@
           Récapitulatif de l'autorisation
         </h3>
         <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">
-          Vous autorisez l'accès à {{ enabledServers }} serveur(s) sur {{ totalServers }}.
-          <span v-if="requiredServers > 0" class="block mt-1">
-            {{ requiredServers }} requis pour cette application.
-          </span>
+          Connecter {{ articleAndNames }} via MCP
         </p>
       </div>
     </div>
@@ -48,11 +45,20 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Shield, Server } from 'lucide-vue-next'
 
-defineProps<{
+const props = defineProps<{
   totalServers: number
   enabledServers: number
   requiredServers: number
+  serverNames: string[]
 }>()
+
+const articleAndNames = computed(() => {
+  const names = props.serverNames
+  if (names.length === 0) return 'les serveurs MCP'
+  if (names.length === 1) return `le ${names[0]}`
+  return names.join(', ')
+})
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
@@ -62,18 +62,15 @@
             class="mt-0.5 rounded border-gray-300 text-brand-500 dark:border-gray-700"
             @change="$emit('toggle-tool', server.id, tool.name)"
           />
-          <div class="flex-1 min-w-0">
+          <div class="flex-1 min-w-0 text-sm">
             <code
               class="text-xs font-mono bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-gray-900 dark:text-white"
             >
               {{ tool.name }}
             </code>
-            <p
-              v-if="tool.description"
-              class="text-sm text-gray-600 dark:text-gray-400 mt-1"
-            >
-              {{ tool.description }}
-            </p>
+            <span v-if="tool.description" class="text-gray-600 dark:text-gray-400">
+              -- {{ truncate(tool.description) }}
+            </span>
           </div>
         </div>
       </div>
@@ -108,5 +105,9 @@ const enabled = computed(() => {
 
 function isToolChecked(toolName: string): boolean {
   return !!props.selectedTools && props.selectedTools.has(toolName)
+}
+
+function truncate(text: string): string {
+  return text.length > 150 ? text.slice(0, 150) + '…' : text
 }
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
@@ -33,6 +33,7 @@
             :total-servers="configuredServers.length"
             :enabled-servers="enabledServersCount"
             :required-servers="requiredServersCount"
+            :server-names="configuredServers.map((s) => s.name)"
           />
 
           <Separator />


### PR DESCRIPTION
…ense tools

- ConsentHeader: replace KeyRound + client-name avatar with the same sticky header used by DocsLayout (hp-logo + 'MCP Gateway' title and 'Autorisation' subtitle, max-w-5xl shell). Visual consistency with the public docs surface.
- ConsentSummary: replace the descriptive sentence with 'Connecter le {server_name} via MCP' (or comma-joined names when more than one configured server). Tile grid (Total / Activés / Requis) is preserved.
- MCPServerCard: condense each tool row into a single line — '<code>name</code> -- description...' with the description truncated at 150 characters + ellipsis. Drops the multi-line code+paragraph layout.

AuthorizeView passes configuredServers.map(name) into ConsentSummary as the new serverNames prop.

feat(mcp-gateway-frontend) : alignement de la page de consentement sur le header /docs, récap reformulé en « Connecter le X via MCP » et liste d'outils condensée sur une ligne (description tronquée à 150 caractères).