### PR TITLE
refactor(mcp-gateway-frontend): use clientName in consent recap text

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
@@ -11,7 +11,7 @@
           Récapitulatif de l'autorisation
         </h3>
         <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">
-          Connecter {{ articleAndNames }} via MCP
+          Connecter avec le MCP {{ clientName }}
         </p>
       </div>
     </div>
@@ -45,20 +45,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { Shield, Server } from 'lucide-vue-next'
 
-const props = defineProps<{
+defineProps<{
   totalServers: number
   enabledServers: number
   requiredServers: number
-  serverNames: string[]
+  clientName: string
 }>()
-
-const articleAndNames = computed(() => {
-  const names = props.serverNames
-  if (names.length === 0) return 'les serveurs MCP'
-  if (names.length === 1) return `le ${names[0]}`
-  return names.join(', ')
-})
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
@@ -33,7 +33,7 @@
             :total-servers="configuredServers.length"
             :enabled-servers="enabledServersCount"
             :required-servers="requiredServersCount"
-            :server-names="configuredServers.map((s) => s.name)"
+            :client-name="clientName"
           />
 
           <Separator />


### PR DESCRIPTION
Replace the comma-joined server name list with the OAuth2 client name in ConsentSummary. Récap now reads "Connecter avec le MCP {clientName}" (e.g. "Connecter avec le MCP Claude Desktop"), describing the connector rather than the connected backends. Drop the serverNames prop + articleAndNames computed; pass `client-name` from AuthorizeView.

refactor(mcp-gateway-frontend) : utilise le nom du client OAuth2 dans le récapitulatif de consentement (« Connecter avec le MCP X »).