### PR TITLE
fix(mcp-gateway-frontend): UI/UX audit fixes on consent page

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentHeader.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentHeader.vue
@@ -3,8 +3,11 @@
     class="sticky top-0 z-10 bg-white border-b border-gray-200 dark:bg-gray-900 dark:border-gray-800"
   >
     <div class="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
-      <router-link to="/docs" class="flex items-center gap-3 no-underline">
-        <img src="/images/servers/hp-logo.svg" alt="Hellopro" class="w-9 h-9" />
+      <router-link
+        to="/docs"
+        class="flex items-center gap-3 no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 rounded"
+      >
+        <img src="/images/servers/hp-logo.svg" alt="Hellopro" width="36" height="36" class="w-9 h-9" />
         <div>
           <h1 class="text-lg font-semibold text-gray-900 dark:text-white leading-tight">
             MCP Gateway

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
@@ -4,13 +4,13 @@
       <div
         class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800"
       >
-        <Shield class="h-4 w-4 text-gray-600 dark:text-gray-400" />
+        <Shield class="h-4 w-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
       </div>
       <div>
         <h3 class="font-semibold text-gray-900 dark:text-white">
           Récapitulatif de l'autorisation
         </h3>
-        <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">
+        <p class="text-base text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">
           Connecter avec le MCP {{ clientName }}
         </p>
       </div>
@@ -19,14 +19,14 @@
     <div class="grid grid-cols-3 gap-3">
       <div class="rounded-md bg-gray-100 dark:bg-gray-800/50 p-3 text-center">
         <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" />
+          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
         </div>
         <div class="text-2xl font-bold text-gray-900 dark:text-white">{{ totalServers }}</div>
         <div class="text-xs text-gray-600 dark:text-gray-400">Total serveurs</div>
       </div>
       <div class="rounded-md bg-brand-50 dark:bg-brand-500/15 p-3 text-center">
         <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Shield class="h-4 w-4 text-brand-600 dark:text-brand-400" />
+          <Shield class="h-4 w-4 text-brand-600 dark:text-brand-400" aria-hidden="true" />
         </div>
         <div class="text-2xl font-bold text-brand-600 dark:text-brand-400">
           {{ enabledServers }}
@@ -35,7 +35,7 @@
       </div>
       <div class="rounded-md bg-gray-100 dark:bg-gray-800/50 p-3 text-center">
         <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" />
+          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
         </div>
         <div class="text-2xl font-bold text-gray-900 dark:text-white">{{ requiredServers }}</div>
         <div class="text-xs text-gray-600 dark:text-gray-400">Requis</div>

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="rounded-lg border bg-white dark:bg-gray-900 transition-all duration-200"
+    class="rounded-lg border bg-white dark:bg-gray-900 transition-all duration-200 motion-reduce:transition-none"
     :class="enabled ? 'border-brand-500/50 shadow-sm' : 'border-gray-200 dark:border-gray-800'"
   >
     <div class="p-5">
@@ -17,9 +17,11 @@
             v-if="server.icon"
             :src="server.icon"
             :alt="server.name"
+            width="28"
+            height="28"
             class="h-7 w-7 object-contain"
           />
-          <Server v-else class="h-5 w-5" />
+          <Server v-else class="h-5 w-5" aria-hidden="true" />
         </div>
         <div class="space-y-1.5 flex-1">
           <div class="flex flex-wrap items-center gap-2">
@@ -31,12 +33,13 @@
 
       <button
         type="button"
-        class="mt-4 flex w-full items-center justify-between rounded-md px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white transition-colors"
+        :aria-expanded="expanded"
+        class="mt-4 flex w-full min-h-[44px] items-center justify-between rounded-md px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 transition-colors motion-reduce:transition-none"
         @click="$emit('toggle-expand', server.id)"
       >
         <span>Voir les outils ({{ (server.tools || []).length }})</span>
-        <ChevronUp v-if="expanded" class="h-4 w-4" />
-        <ChevronDown v-else class="h-4 w-4" />
+        <ChevronUp v-if="expanded" class="h-4 w-4" aria-hidden="true" />
+        <ChevronDown v-else class="h-4 w-4" aria-hidden="true" />
       </button>
 
       <div
@@ -46,20 +49,22 @@
         <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">
           Outils demandés
         </h4>
-        <div
+        <label
           v-for="tool in server.tools || []"
           :key="`${server.id}:${tool.name}`"
-          class="flex items-start gap-3 rounded-md p-3 bg-gray-50 dark:bg-gray-800/50"
+          class="flex items-start gap-3 rounded-md p-3 min-h-[44px] bg-gray-50 dark:bg-gray-800/50 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 focus-within:ring-2 focus-within:ring-brand-500/40 transition-colors motion-reduce:transition-none"
+          :class="preConfigured ? 'cursor-default' : ''"
         >
           <Check
             v-if="preConfigured"
             class="h-4 w-4 shrink-0 text-success-500 mt-0.5"
+            aria-hidden="true"
           />
           <input
             v-else
             type="checkbox"
             :checked="isToolChecked(tool.name)"
-            class="mt-0.5 rounded border-gray-300 text-brand-500 dark:border-gray-700"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-brand-500 dark:border-gray-700 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0"
             @change="$emit('toggle-tool', server.id, tool.name)"
           />
           <div class="flex-1 min-w-0 text-sm">
@@ -72,7 +77,7 @@
               -- {{ truncate(tool.description) }}
             </span>
           </div>
-        </div>
+        </label>
       </div>
     </div>
   </div>

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/UnconfiguredServersBlock.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/UnconfiguredServersBlock.vue
@@ -14,9 +14,11 @@
             v-if="server.icon"
             :src="server.icon"
             :alt="server.name"
+            width="20"
+            height="20"
             class="h-5 w-5 object-contain"
           />
-          <Server v-else class="h-4 w-4 text-amber-700 dark:text-amber-300" />
+          <Server v-else class="h-4 w-4 text-amber-700 dark:text-amber-300" aria-hidden="true" />
           <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
             {{ server.name }}
           </span>
@@ -26,7 +28,7 @@
           :href="server.docs_url"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-xs font-medium text-brand-600 hover:underline"
+          class="text-xs font-medium text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 rounded px-1 py-0.5"
         >
           Voir documentation &rarr;
         </a>

--- a/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
@@ -1,127 +1,137 @@
 <template>
-  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col">
+    <ConsentHeader :client-name="clientName" />
+
     <!-- Loading -->
-    <div v-if="loading" class="flex items-center justify-center min-h-screen">
+    <div v-if="loading" class="flex-1 flex items-center justify-center px-4">
       <div
         class="bg-white dark:bg-gray-900 rounded-lg shadow-theme-md p-8 text-center w-full max-w-md"
       >
-        <i class="pi pi-spinner pi-spin text-2xl text-brand-500" />
-        <p class="mt-3 text-gray-600 dark:text-gray-400">Chargement...</p>
+        <Loader2 class="h-8 w-8 mx-auto text-brand-500 animate-spin motion-reduce:animate-none" />
+        <p class="mt-3 text-base text-gray-600 dark:text-gray-400">Chargement…</p>
       </div>
     </div>
 
     <!-- Fatal error -->
-    <div v-else-if="fatalError" class="flex items-center justify-center min-h-screen">
+    <div v-else-if="fatalError" class="flex-1 flex items-center justify-center px-4">
       <div
         class="bg-white dark:bg-gray-900 rounded-lg shadow-theme-md p-8 w-full max-w-md text-center"
       >
-        <i class="pi pi-exclamation-triangle text-3xl text-error-500 mb-3" />
+        <AlertTriangle class="h-10 w-10 mx-auto text-error-500 mb-3" />
         <h1 class="text-xl font-bold text-gray-900 dark:text-white mb-2">
           Erreur d'autorisation
         </h1>
-        <p class="text-sm text-error-600 dark:text-error-400">{{ fatalError }}</p>
+        <p class="text-base text-error-600 dark:text-error-400 mb-6">{{ fatalError }}</p>
+        <button
+          type="button"
+          class="inline-flex items-center justify-center py-2 px-4 bg-brand-500 text-white font-medium rounded-md hover:bg-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/60 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 transition-colors motion-reduce:transition-none"
+          @click="retry"
+        >
+          Réessayer
+        </button>
       </div>
     </div>
 
     <!-- Consent -->
-    <template v-else>
-      <ConsentHeader :client-name="clientName" />
+    <main v-else class="mx-auto max-w-3xl w-full px-4 py-8 flex-1">
+      <div class="space-y-6">
+        <ConsentSummary
+          :total-servers="configuredServers.length"
+          :enabled-servers="enabledServersCount"
+          :required-servers="requiredServersCount"
+          :client-name="clientName"
+        />
 
-      <main class="mx-auto max-w-3xl px-4 py-8">
-        <div class="space-y-6">
-          <ConsentSummary
-            :total-servers="configuredServers.length"
-            :enabled-servers="enabledServersCount"
-            :required-servers="requiredServersCount"
-            :client-name="clientName"
-          />
+        <Separator />
 
-          <Separator />
-
-          <section>
-            <div class="mb-4">
-              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                Accès aux serveurs MCP
-              </h2>
-              <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                Sélectionnez les serveurs et examinez leurs permissions
-              </p>
-            </div>
-
-            <div
-              v-if="errorMessage"
-              class="mb-4 p-3 bg-error-50 dark:bg-error-500/15 border border-error-200 dark:border-error-500/30 rounded-md text-sm text-error-600 dark:text-error-400"
-            >
-              {{ errorMessage }}
-            </div>
-
-            <div class="space-y-4">
-              <MCPServerCard
-                v-for="server in configuredServers"
-                :key="server.id"
-                :server="server"
-                :pre-configured="preConfigured"
-                :expanded="expandedServers.has(server.id)"
-                :selected-tools="selectedTools.get(server.id)"
-                @toggle-tool="toggleToolSelection"
-                @toggle-expand="toggleServer"
-              />
-            </div>
-          </section>
-
-          <UnconfiguredServersBlock
-            v-if="unconfiguredServers.length > 0"
-            :servers="unconfiguredServers"
-          />
-
-          <Separator />
-
-          <div class="rounded-lg bg-gray-100 dark:bg-gray-800/50 p-4">
-            <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">
-              Informations de sécurité
-            </h3>
-            <ul class="space-y-1.5 text-sm text-gray-600 dark:text-gray-400">
-              <li>Vous pouvez révoquer cet accès à tout moment depuis vos paramètres.</li>
-              <li>Tous les appels d'API sont journalisés et auditables.</li>
-            </ul>
+        <section>
+          <div class="mb-4">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+              Accès aux serveurs MCP
+            </h2>
+            <p class="text-base text-gray-600 dark:text-gray-400 mt-1">
+              Sélectionnez les serveurs et examinez leurs permissions
+            </p>
           </div>
 
-          <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              class="sm:order-1 py-2 px-4 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-              :disabled="submitting"
-              @click="handleDeny"
-            >
-              Refuser
-            </button>
-            <button
-              type="button"
-              class="sm:order-2 py-2 px-4 bg-success-600 text-white font-medium rounded-md hover:bg-success-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-              :disabled="submitting || (!preConfigured && selectedServerIds.length === 0)"
-              @click="handleConsent"
-            >
-              <i v-if="submitting" class="pi pi-spinner pi-spin" />
-              Autoriser {{ enabledServersCount }} serveur{{ enabledServersCount !== 1 ? 's' : '' }}
-            </button>
+          <div
+            v-if="errorMessage"
+            class="mb-4 p-3 bg-error-50 dark:bg-error-500/15 border border-error-200 dark:border-error-500/30 rounded-md text-sm text-error-600 dark:text-error-400"
+            role="alert"
+          >
+            {{ errorMessage }}
           </div>
 
-          <p class="text-center text-xs text-gray-500 dark:text-gray-500">
-            En autorisant, vous acceptez la
-            <RouterLink to="/privacy" class="underline underline-offset-2 hover:text-gray-900 dark:hover:text-white">
-              politique de confidentialité
-            </RouterLink>
-            .
-          </p>
+          <div class="space-y-4">
+            <MCPServerCard
+              v-for="server in configuredServers"
+              :key="server.id"
+              :server="server"
+              :pre-configured="preConfigured"
+              :expanded="expandedServers.has(server.id)"
+              :selected-tools="selectedTools.get(server.id)"
+              @toggle-tool="toggleToolSelection"
+              @toggle-expand="toggleServer"
+            />
+          </div>
+        </section>
+
+        <UnconfiguredServersBlock
+          v-if="unconfiguredServers.length > 0"
+          :servers="unconfiguredServers"
+        />
+
+        <Separator />
+
+        <div class="rounded-lg bg-gray-100 dark:bg-gray-800/50 p-4">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">
+            Informations de sécurité
+          </h3>
+          <ul class="space-y-1.5 text-sm text-gray-600 dark:text-gray-400">
+            <li>Vous pouvez révoquer cet accès à tout moment depuis vos paramètres.</li>
+            <li>Tous les appels d'API sont journalisés et auditables.</li>
+          </ul>
         </div>
-      </main>
-    </template>
+
+        <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            class="sm:order-1 py-2 px-4 min-h-[44px] bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950 disabled:opacity-50 disabled:cursor-not-allowed transition-colors motion-reduce:transition-none"
+            :disabled="submitting"
+            @click="handleDeny"
+          >
+            Refuser
+          </button>
+          <button
+            type="button"
+            class="sm:order-2 py-2 px-4 min-h-[44px] bg-success-600 text-white font-medium rounded-md hover:bg-success-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-success-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors motion-reduce:transition-none"
+            :disabled="submitting || (!preConfigured && selectedServerIds.length === 0)"
+            @click="handleConsent"
+          >
+            <Loader2 v-if="submitting" class="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+            Autoriser {{ enabledServersCount }} serveur{{ enabledServersCount !== 1 ? 's' : '' }}
+          </button>
+        </div>
+
+        <p class="text-center text-xs text-gray-600 dark:text-gray-400">
+          En autorisant, vous acceptez la
+          <RouterLink
+            to="/privacy"
+            class="underline underline-offset-2 hover:text-gray-900 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 rounded"
+          >
+            politique de confidentialité
+          </RouterLink>
+          .
+        </p>
+      </div>
+    </main>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from 'vue'
 import { useRoute, RouterLink } from 'vue-router'
+import { Loader2, AlertTriangle } from 'lucide-vue-next'
 import { authorizeApi } from '@/api/authorize'
 import type { AuthorizeServer } from '@/types/oauth2'
 import ConsentHeader from '@/components/consent/ConsentHeader.vue'
@@ -206,6 +216,7 @@ function initializeSelections(): void {
 
 async function fetchInfo(): Promise<void> {
   loading.value = true
+  fatalError.value = ''
   try {
     if (!clientId.value || !redirectUri.value) {
       fatalError.value = 'Paramètres manquants : client_id et redirect_uri sont requis.'
@@ -233,6 +244,10 @@ async function fetchInfo(): Promise<void> {
   } finally {
     loading.value = false
   }
+}
+
+function retry(): void {
+  fetchInfo()
 }
 
 async function handleConsent(): Promise<void> {


### PR DESCRIPTION
Apply UI/UX rules pass over the AuthorizeView consent flow.

Accessibility (critical):
- Add focus-visible:ring-2 + ring-offset to Refuser/Autoriser buttons, the privacy link, the per-server expand toggle, and the docs link in UnconfiguredServersBlock. Keyboard users now see focus state.
- Wrap each tool row in a <label> with min-h-[44px] so the entire row is the tap target (was a ~16px native checkbox). preConfigured rows use cursor-default to communicate non-interactivity.
- Add focus:ring to the native checkbox itself.
- Add aria-hidden to decorative lucide icons; aria-expanded on the "Voir les outils" toggle; role="alert" on the inline error banner.
- Fatal-error state gains a "Réessayer" button instead of being a dead end.
- Loading + fatal states now share the same ConsentHeader so the page identity is preserved across all states.

Touch & interaction:
- min-h-[44px] enforced on Refuser/Autoriser buttons and the expand toggle so they meet the 44pt mobile target.

Icon consistency:
- Replace `pi pi-spinner` + `pi pi-exclamation-triangle` with the lucide equivalents (Loader2, AlertTriangle) so the consent page uses a single icon family.

Typography & contrast:
- Bump body description text from text-sm (14px) to text-base (16px) on ConsentSummary and the section subtitle to avoid iOS auto-zoom on inputs and improve mobile readability.
- Footer link text bumped from gray-500/500 to gray-600/400 so dark mode meets 4.5:1 contrast.

Motion:
- Add motion-reduce:transition-none on card + button transitions and motion-reduce:animate-none on the Loader2 spinners to honour the user's reduced-motion preference.

Performance:
- Add explicit width/height attributes to the hp-logo and per-server <img> tags to reduce CLS.

fix(mcp-gateway-frontend) : audit UI/UX du consent page — focus visible, taille de cibles tactiles, icônes unifiées (lucide), texte 16px, contraste footer, reduced-motion, bouton Réessayer sur erreur, dimensions explicites sur les images.