### PR TITLE
refactor(mcp-gateway-frontend): trim consent summary and server row

### DIFF
--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/ConsentSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5">
-    <div class="flex items-start gap-3 mb-4">
+    <div class="flex items-start gap-3">
       <div
         class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800"
       >
@@ -15,42 +15,13 @@
         </p>
       </div>
     </div>
-
-    <div class="grid grid-cols-3 gap-3">
-      <div class="rounded-md bg-gray-100 dark:bg-gray-800/50 p-3 text-center">
-        <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
-        </div>
-        <div class="text-2xl font-bold text-gray-900 dark:text-white">{{ totalServers }}</div>
-        <div class="text-xs text-gray-600 dark:text-gray-400">Total serveurs</div>
-      </div>
-      <div class="rounded-md bg-brand-50 dark:bg-brand-500/15 p-3 text-center">
-        <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Shield class="h-4 w-4 text-brand-600 dark:text-brand-400" aria-hidden="true" />
-        </div>
-        <div class="text-2xl font-bold text-brand-600 dark:text-brand-400">
-          {{ enabledServers }}
-        </div>
-        <div class="text-xs text-gray-600 dark:text-gray-400">Activés</div>
-      </div>
-      <div class="rounded-md bg-gray-100 dark:bg-gray-800/50 p-3 text-center">
-        <div class="flex items-center justify-center gap-1.5 mb-1">
-          <Server class="h-4 w-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
-        </div>
-        <div class="text-2xl font-bold text-gray-900 dark:text-white">{{ requiredServers }}</div>
-        <div class="text-xs text-gray-600 dark:text-gray-400">Requis</div>
-      </div>
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Shield, Server } from 'lucide-vue-next'
+import { Shield } from 'lucide-vue-next'
 
 defineProps<{
-  totalServers: number
-  enabledServers: number
-  requiredServers: number
   clientName: string
 }>()
 </script>

--- a/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/components/consent/MCPServerCard.vue
@@ -22,7 +22,6 @@
 
       <div class="flex-1 min-w-0 flex items-center gap-2">
         <span class="font-medium text-gray-900 dark:text-white truncate">{{ server.name }}</span>
-        <Badge v-if="preConfigured" color="primary" size="sm">Requis</Badge>
         <span class="text-xs text-gray-500 dark:text-gray-400">
           ({{ (server.tools || []).length }} outil{{ (server.tools || []).length !== 1 ? 's' : '' }})
         </span>
@@ -71,7 +70,6 @@
 
 <script setup lang="ts">
 import { Server, ChevronDown, ChevronUp, Check } from 'lucide-vue-next'
-import Badge from '@/components/ui/Badge.vue'
 import type { AuthorizeServer } from '@/types/oauth2'
 
 const props = defineProps<{

--- a/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
+++ b/apps-microservices/mcp-gateway-frontend/src/views/AuthorizeView.vue
@@ -35,12 +35,7 @@
     <!-- Consent -->
     <main v-else class="mx-auto max-w-3xl w-full px-4 py-8 flex-1">
       <div class="space-y-6">
-        <ConsentSummary
-          :total-servers="configuredServers.length"
-          :enabled-servers="enabledServersCount"
-          :required-servers="requiredServersCount"
-          :client-name="clientName"
-        />
+        <ConsentSummary :client-name="clientName" />
 
         <Separator />
 
@@ -189,9 +184,6 @@ const selectedToolIds = computed(() => {
 })
 
 const enabledServersCount = computed(() => selectedServerIds.value.length)
-const requiredServersCount = computed(() =>
-  preConfigured.value ? configuredServers.value.length : 0,
-)
 
 function toggleServer(serverId: string): void {
   if (expandedServers.has(serverId)) expandedServers.delete(serverId)


### PR DESCRIPTION
- ConsentSummary: drop the 3-tile numeric grid (Total / Activés / Requis). The block now contains only the Shield icon header and the "Connecter avec le MCP {clientName}" description. Server / Shield numeric tiles removed along with their props (totalServers, enabledServers, requiredServers).
- MCPServerCard: drop the "Requis" badge from each row. Server rows show only icon + name + tool count + chevron.
- AuthorizeView: drop the unused requiredServersCount computed; only pass clientName to ConsentSummary.

refactor(mcp-gateway-frontend) : retire la grille numérique du récapitulatif (Total/Activés/Requis) et le tag « Requis » sur les lignes de serveur.