### PR TITLE
feat(opti-moteur-front): A6 — synonymes Typesense dans le reranker (fix crane→grue)

### DIFF
--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -137,3 +137,43 @@ selon le nb de tokens query :
 - **>=3 tokens** (Ritmo ELEKTRA M) : seuil 5 -> comportement strict actuel.
 
 Logique dans `app/services/search_service.py::_filter_fallback_threshold()`.
+
+## Synonymes dans le reranker (A6, 2026-05-20)
+
+Le reranker considere desormais les synonymes Typesense pour le matching
+name/cat. Resout le cas multilingue ("crane" anglais -> "Grue" francais) et
+toutes les variantes (medical/medicale, electrique/electric, etc.).
+
+### Probleme avant
+Typesense applique deja les synonymes au niveau de la recherche (le multi_search
+retourne les Grues XCMG quand la query est "crane"). Mais le reranker Python
+recalculait `name_match` en mode texte strict :
+  query="crane", doc="Grue XCMG QY50KA"
+  tokens_query = {"crane"}, doc_tokens = {"grue","xcmg",...}
+  intersection vide -> name_match = 0 -> reranker remontait d'autres produits.
+
+### Fix
+`app/services/synonyms_loader.py` charge le mapping Typesense au runtime
+(GET /collections/<col>/synonyms) et expose `get_synonyms_map() -> {token: Set}`.
+Le reranker (`_idf_weighted_match`) considere un token query "couvert" si
+lui-meme OU un de ses synonymes apparait dans le doc.
+
+### Comportement si Typesense KO
+`get_synonyms_map()` retourne {} -> matching strict (= comportement A4 sans A6).
+Aucune regression possible.
+
+### Pour ajouter de nouveaux synonymes en prod
+1. Editer `site/fichiers_communs_bo_front/hellopro_fr/typesense_synonyms_manual.json`
+2. Push direct via curl PUT sur Typesense (ou via le script sync_synonyms_daily.php)
+3. Restart opti-moteur-front -> reload du cache
+
+Exemple :
+```bash
+TS_KEY=$(grep '^TYPESENSE_API_KEY=' .env | cut -d= -f2-)
+curl -X PUT "http://10.0.130.66:8108/collections/produits_prod/synonyms/manual-grue" \
+  -H "X-TYPESENSE-API-KEY: $TS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"synonyms":["grue","grues","grutier","crane","cranes","e-crane"]}'
+
+docker compose restart opti-moteur-front
+```

--- a/apps-microservices/opti-moteur-front/app/services/reranker.py
+++ b/apps-microservices/opti-moteur-front/app/services/reranker.py
@@ -28,21 +28,22 @@ Exemple "melangeur conique" :
   Produit "Saleuse a cuve conique" (matche conique, pas melangeur) :
     name_match_simple = 1/2 = 0.50
     name_match_idf    = 3.0 / (3.0 + 1.5) = 0.67
-  Produit "Mixeur peinture" (matche aucun token, mais titre semantique proche) :
-    name_match_simple = 0/2 = 0.00
-    name_match_idf    = 0.00 (inchange)
 
-Effet : les produits qui contiennent les tokens rares de la query remontent
-au-dessus de ceux qui ne contiennent que les tokens communs.
+A6 (2026-05-20) -- Support synonymes dans le matching
+------------------------------------------------------
+Un token query est considere "couvert" par le doc si lui-meme OU un de ses
+synonymes Typesense apparait dans nom_produit / categorie. Resout les cas
+multilingues comme "crane" -> "Grue XCMG" (le synonyme manual-grue contient
+"crane" + "grue" + "grues" + ...).
 
-Si le fichier IDF n'est pas charge (idf_available()=False, ex. fresh deploy
-sans avoir lance compute_idf.py), on bascule automatiquement sur le ratio
-simple : aucune regression possible vs le comportement actuel.
+Sans synonymes (Typesense indisponible ou pas configure) : fallback sur le
+matching strict (= comportement A4). Aucune regression possible.
 """
-from typing import Dict, List, Any, Set
+from typing import Dict, List, Any, Set, Optional
 
 from app.core.credentials import settings
 from app.services.idf_loader import get_idf, idf_available
+from app.services.synonyms_loader import get_synonyms_map
 from app.utils.text import tokenize
 
 
@@ -53,31 +54,54 @@ _W_NAME_NOVEC   = 0.60
 _W_CAT_NOVEC    = 0.20
 
 
-def _idf_weighted_match(q_tokens: Set[str], doc_tokens: Set[str]) -> float:
+def _idf_weighted_match(
+    q_tokens: Set[str],
+    doc_tokens: Set[str],
+    syn_map: Optional[Dict[str, Set[str]]] = None,
+) -> float:
     """
-    Ratio de match pondere par IDF entre q_tokens et doc_tokens.
-    Si l'IDF n'est pas disponible -> fallback ratio simple
-    (= comportement historique, aucune regression).
+    Ratio de match pondere par IDF, avec support synonymes optionnel.
 
-    Resultat entre 0.0 (aucun match) et 1.0 (tous les tokens query matches).
+    Logique :
+      - Pour chaque token query, on verifie s'il est "couvert" par le doc.
+        Un token est couvert si lui-meme OU un de ses synonymes est dans doc_tokens.
+      - Score = somme des IDF des tokens couverts / somme des IDF de TOUS les tokens query.
+
+    Si IDF non disponible -> fallback ratio simple (= comportement historique).
+    Si syn_map non fourni -> matching strict (comportement A4 sans A6).
+
+    Resultat entre 0.0 (aucun token couvert) et 1.0 (tous couverts).
     """
     if not q_tokens:
         return 0.0
 
-    if not idf_available():
-        # Fallback : ratio simple historique
-        return len(q_tokens & doc_tokens) / len(q_tokens)
+    use_idf = idf_available()
+    sum_total = 0.0
+    sum_matched = 0.0
+    n_matched = 0
 
-    matched = q_tokens & doc_tokens
-    if not matched:
-        return 0.0
+    for t in q_tokens:
+        weight = get_idf(t) if use_idf else 1.0
+        sum_total += weight
 
-    sum_matched = sum(get_idf(t) for t in matched)
-    sum_total = sum(get_idf(t) for t in q_tokens)
+        # Direct match (token litteral dans le doc)
+        if t in doc_tokens:
+            sum_matched += weight
+            n_matched += 1
+            continue
+
+        # Synonym match (un equivalent du token est dans le doc)
+        if syn_map is not None:
+            equivs = syn_map.get(t)
+            if equivs and not equivs.isdisjoint(doc_tokens):
+                sum_matched += weight
+                n_matched += 1
+                continue
+
     if sum_total <= 0:
-        # Garde-fou : tous les tokens query ont idf=0 (theoriquement impossible
-        # avec idf lisse log((N+1)/(df+1))+1 >= 1) -> ratio simple
-        return len(matched) / len(q_tokens)
+        # Garde-fou (theoriquement impossible avec idf lisse >= 1)
+        return n_matched / len(q_tokens)
+
     return sum_matched / sum_total
 
 
@@ -97,6 +121,9 @@ def rerank_candidates(
     q_tokens = tokenize(query)
     if not q_tokens or not groups:
         return []
+
+    # A6 : charge le mapping synonymes (lazy + cache). {} si non disponible.
+    syn_map = get_synonyms_map() or None
 
     # Choix des poids
     if use_vector:
@@ -123,12 +150,12 @@ def rerank_candidates(
         vec_score = 1 - min(vec_dist or 1.0, 1.0) if use_vector else 0.0
         tm_raw = hit.get("text_match", 0) or 0
 
-        # A4 : name_match et cat_match desormais ponderes par IDF (si dispo).
+        # A4+A6 : name_match et cat_match ponderes par IDF + expansion synonymes.
         name_tokens = tokenize(doc.get("nom_produit", ""))
-        name_match = _idf_weighted_match(q_tokens, name_tokens)
+        name_match = _idf_weighted_match(q_tokens, name_tokens, syn_map=syn_map)
 
         cat_tokens = tokenize(doc.get("categorie", ""))
-        cat_match = _idf_weighted_match(q_tokens, cat_tokens)
+        cat_match = _idf_weighted_match(q_tokens, cat_tokens, syn_map=syn_map)
 
         raw.append({
             "doc": doc,

--- a/apps-microservices/opti-moteur-front/app/services/synonyms_loader.py
+++ b/apps-microservices/opti-moteur-front/app/services/synonyms_loader.py
@@ -1,0 +1,173 @@
+"""
+synonyms_loader.py
+==================
+Charge les synonymes Typesense au runtime pour expand les query tokens
+dans le reranker. Permet le matching multilingue (crane=grue, screen=ecran)
+et les variantes (medical/medicale/medicaux) sans avoir a hardcoder.
+
+Pourquoi :
+  Typesense applique deja les synonymes au niveau de la recherche (le
+  multi_search retourne les Grues XCMG quand on cherche "crane"). MAIS le
+  reranker Python recalcule `name_match` en mode texte strict :
+  tokens query = {"crane"}, doc "Grue XCMG" = {"grue","xcmg"} -> intersection
+  vide -> name_match = 0 -> reranker remonte d'autres produits hors-sujet.
+
+  Avec ce loader, le reranker connait aussi les equivalences. Pour la query
+  "crane", il calcule name_match comme si l'utilisateur avait tape "crane OU
+  grue OU grues OU grutier" -> le doc "Grue XCMG" matche "grue" -> covered.
+
+Comportement si Typesense indisponible : `get_synonyms_map()` retourne
+{} et le reranker bascule sur le matching strict (= comportement A4 actuel,
+sans regression).
+"""
+import logging
+from typing import Dict, Set, Optional
+
+from app.core.credentials import settings
+from app.core.typesense_client import typesense_client
+from app.utils.text import tokenize
+
+logger = logging.getLogger(__name__)
+
+
+# Etat global (singleton charge a la 1ere demande, cache en RAM jusqu'au restart)
+_syn_map: Optional[Dict[str, Set[str]]] = None
+_load_attempted: bool = False
+
+
+def _build_mapping_from_clusters(clusters) -> Dict[str, Set[str]]:
+    """
+    A partir des clusters synonymes Typesense, construit un dict :
+      token -> set de tokens equivalents (incluant le token lui-meme).
+
+    Tokenise/normalise les synonymes via `tokenize()` (meme regex que le
+    reranker), pour garantir un alignement parfait (accents, casse,
+    multi-mots, longueur min 2 chars).
+
+    Exemple cluster :
+      {"synonyms": ["grue", "grues", "grutier", "crane", "cranes", "e-crane"]}
+    -> apres tokenize : {"grue", "grues", "grutier", "crane", "cranes"}
+       (le "e" de "e-crane" est filtre car < 2 chars)
+    -> mapping construit :
+       {
+         "grue":    {"grue","grues","grutier","crane","cranes"},
+         "grues":   {idem},
+         "grutier": {idem},
+         "crane":   {idem},
+         "cranes":  {idem},
+       }
+    """
+    mapping: Dict[str, Set[str]] = {}
+    if not clusters:
+        return mapping
+
+    for cluster in clusters:
+        if not isinstance(cluster, dict):
+            continue
+        syns = cluster.get("synonyms") or []
+        if not syns:
+            continue
+
+        # Tokenise et fusionne en un seul set de tokens pour ce cluster
+        cluster_tokens: Set[str] = set()
+        for syn in syns:
+            cluster_tokens |= tokenize(syn)
+        # Inclut aussi le "root" si fourni (one-way synonym)
+        root = cluster.get("root")
+        if root:
+            cluster_tokens |= tokenize(root)
+
+        if not cluster_tokens:
+            continue
+
+        # Pour chaque token du cluster, l'associer au set complet d'equivalents
+        for t in cluster_tokens:
+            if t not in mapping:
+                mapping[t] = set()
+            mapping[t] |= cluster_tokens  # union (inclut soi-meme, no-op)
+
+    return mapping
+
+
+def _load_synonyms() -> Dict[str, Set[str]]:
+    """
+    Charge le mapping synonymes une seule fois (cache singleton).
+    Fallback safe si Typesense indisponible ou collection sans synonymes.
+    """
+    global _syn_map, _load_attempted
+
+    if _syn_map is not None:
+        return _syn_map
+    if _load_attempted:
+        return _syn_map or {}
+    _load_attempted = True
+
+    try:
+        res = typesense_client.list_synonyms()
+        clusters = res.get("synonyms", []) if isinstance(res, dict) else []
+        mapping = _build_mapping_from_clusters(clusters)
+        _syn_map = mapping
+
+        # Stats utiles dans les logs (visibles au demarrage du service apres la 1ere recherche)
+        n_clusters = len(clusters)
+        n_tokens = len(mapping)
+        if n_tokens > 0:
+            n_avg = sum(len(v) for v in mapping.values()) / n_tokens
+            logger.info(
+                "Synonyms loaded from Typesense: %d clusters, %d unique tokens, avg %.1f equivalents/token",
+                n_clusters, n_tokens, n_avg,
+            )
+        else:
+            logger.warning(
+                "Synonyms loaded from Typesense but mapping is empty (%d clusters returned, 0 tokens after tokenize)",
+                n_clusters,
+            )
+    except Exception as e:
+        logger.warning(
+            "Failed to load synonyms from Typesense (%s) - reranker will skip token expansion",
+            e,
+        )
+        _syn_map = {}
+
+    return _syn_map
+
+
+def get_synonyms_map() -> Dict[str, Set[str]]:
+    """
+    Retourne le mapping token -> set d'equivalents.
+    {} si Typesense indisponible ou pas de synonymes (fallback safe).
+    """
+    return _load_synonyms()
+
+
+def synonyms_available() -> bool:
+    """True si des synonymes sont charges (i.e. mapping non vide)."""
+    return bool(_load_synonyms())
+
+
+def expand_tokens(q_tokens: Set[str]) -> Set[str]:
+    """
+    Helper : expand un set de tokens query avec leurs synonymes.
+    Ex : expand_tokens({"crane"}) -> {"crane", "grue", "grues", "grutier", "cranes"}
+
+    Note : le reranker n'utilise PAS cette fonction directement (il prefere
+    appeler _idf_weighted_match avec syn_map pour preserver le denominateur IDF
+    base sur les tokens ORIGINAUX). Elle est exposee pour usage externe / tests.
+    """
+    syn_map = _load_synonyms()
+    if not syn_map:
+        return set(q_tokens)
+
+    expanded = set(q_tokens)
+    for t in q_tokens:
+        equivs = syn_map.get(t)
+        if equivs:
+            expanded |= equivs
+    return expanded
+
+
+def reset_cache_for_test():
+    """Helper tests unitaires : force le rechargement au prochain appel."""
+    global _syn_map, _load_attempted
+    _syn_map = None
+    _load_attempted = False

--- a/apps-microservices/opti-moteur-front/tests/test_reranker.py
+++ b/apps-microservices/opti-moteur-front/tests/test_reranker.py
@@ -118,3 +118,105 @@ class TestIdfWeightedMatch:
             ]
             ranked = rerank_candidates(groups, "melangeur conique")
             assert ranked[0]["name_match"] == 1.0
+
+
+class TestSynonymsInReranker:
+    """
+    A6 (2026-05-20) : verifie que le reranker considere les synonymes Typesense
+    pour le matching name/cat. Resout le cas multilingue "crane" -> "Grue XCMG".
+    """
+
+    def test_synonyms_match_lifts_grue_for_crane_query(self):
+        """
+        Query "crane" + doc "Grue XCMG" : sans synonymes, name_match=0.
+        Avec synonymes {crane,grue,grues}, name_match=1.0 (le token query
+        "crane" est couvert par "grue" present dans le nom).
+        """
+        syn_map = {
+            "crane":   {"crane", "grue", "grues", "grutier"},
+            "grue":    {"crane", "grue", "grues", "grutier"},
+            "grues":   {"crane", "grue", "grues", "grutier"},
+            "grutier": {"crane", "grue", "grues", "grutier"},
+        }
+        with mock.patch.object(reranker, "get_synonyms_map", return_value=syn_map):
+            groups = [
+                make_group("grue_xcmg", "Grue automotrice XCMG QY50KA - 50 tonnes", "Grues automotrices",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "crane")
+            # "crane" est couvert via le synonyme "grue" -> name_match doit valoir 1.0
+            assert ranked[0]["name_match"] == 1.0
+
+    def test_no_synonyms_keeps_strict_matching(self):
+        """
+        Si syn_map vide (Typesense KO), le matching reste strict.
+        Doc "Grue XCMG" ne matche PAS la query "crane" -> name_match=0.
+        """
+        with mock.patch.object(reranker, "get_synonyms_map", return_value={}):
+            groups = [
+                make_group("grue_xcmg", "Grue automotrice XCMG QY50KA", "Grues",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "crane")
+            # Pas de synonyme -> matching strict -> name_match = 0
+            assert ranked[0]["name_match"] == 0.0
+
+    def test_synonyms_with_idf_keeps_idf_weighting(self):
+        """
+        Avec synonymes + IDF : le denominateur reste base sur les tokens query
+        originaux (pas etendus), donc le score IDF n'est pas dilue.
+
+        Query "soudure ritmo" :
+          - syn cluster soudure : ["soudure","welding"]
+          - syn cluster ritmo : (pas de synonyme, marque exacte)
+        Doc "Soudeuse Ritmo" : matche les 2 tokens (soudure via stem, ritmo direct).
+        """
+        syn_map = {
+            "soudure":  {"soudure", "soudures", "welding"},
+            "soudures": {"soudure", "soudures", "welding"},
+            "welding":  {"soudure", "soudures", "welding"},
+        }
+        # IDF fictif : ritmo est rare, soudure commune
+        fake_idf = {"soudure": 1.5, "ritmo": 6.0, "welding": 6.0}
+
+        with mock.patch.object(reranker, "get_synonyms_map", return_value=syn_map), \
+             mock.patch.object(reranker, "idf_available", return_value=True), \
+             mock.patch.object(reranker, "get_idf",
+                               side_effect=lambda t: fake_idf.get(t, 2.0)):
+            groups = [
+                # Doc qui matche les 2 tokens directement (ritmo + soudure)
+                make_group("apreau", "Machine pour soudure bout a bout Ritmo BASIC 250",
+                           "Machines de soudure", vec_dist=0.3, text_match=900000),
+                # Doc qui matche seulement "soudure" (un mot, pas ritmo)
+                make_group("romus", "Chalumeau electronique Leister - soudure du cordon",
+                           "Soudure", vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "soudure ritmo")
+            # Apreau (les 2 tokens) doit etre premier
+            assert ranked[0]["doc"]["id_produit"] == "apreau"
+            assert ranked[0]["name_match"] == 1.0
+            # Romus (1 token seulement) : name_match = idf(soudure) / (idf(soudure)+idf(ritmo))
+            #                            = 1.5 / 7.5 = 0.20
+            romus_entry = next(r for r in ranked if r["doc"]["id_produit"] == "romus")
+            assert abs(romus_entry["name_match"] - 0.20) < 1e-9
+
+    def test_synonyms_match_via_categorie(self):
+        """
+        Un token query est aussi couvert si son synonyme apparait dans
+        `categorie` (pas seulement `nom_produit`).
+        """
+        syn_map = {
+            "crane": {"crane", "grue", "grues"},
+            "grue":  {"crane", "grue", "grues"},
+            "grues": {"crane", "grue", "grues"},
+        }
+        with mock.patch.object(reranker, "get_synonyms_map", return_value=syn_map):
+            groups = [
+                # Le nom n'a pas "crane" ni "grue", mais la categorie oui
+                make_group("xcmg", "XCMG QY50KA 50 tonnes", "Grues automotrices",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "crane")
+            # name_match = 0 (nom_produit ne contient ni crane ni grue ni grues)
+            # cat_match = 1.0 (categorie contient "grues" qui est synonyme de "crane")
+            assert ranked[0]["cat_match"] == 1.0

--- a/apps-microservices/opti-moteur-front/tests/test_synonyms_loader.py
+++ b/apps-microservices/opti-moteur-front/tests/test_synonyms_loader.py
@@ -1,0 +1,112 @@
+"""Tests unitaires du loader synonymes (A6)."""
+from unittest import mock
+
+from app.services import synonyms_loader
+
+
+def _typesense_response(clusters):
+    """Helper : construit la reponse Typesense {synonyms: [...]}."""
+    return {"synonyms": clusters}
+
+
+def test_no_synonyms_when_typesense_returns_empty(monkeypatch):
+    """Typesense retourne 0 cluster -> mapping vide, synonyms_available()=False."""
+    synonyms_loader.reset_cache_for_test()
+    monkeypatch.setattr(
+        synonyms_loader.typesense_client,
+        "list_synonyms",
+        lambda **kw: _typesense_response([]),
+    )
+    assert synonyms_loader.synonyms_available() is False
+    assert synonyms_loader.get_synonyms_map() == {}
+    # expand_tokens doit retourner les tokens inchanges
+    assert synonyms_loader.expand_tokens({"crane"}) == {"crane"}
+
+
+def test_no_synonyms_when_typesense_fails(monkeypatch):
+    """Typesense leve une exception -> fallback silencieux sur mapping vide."""
+    synonyms_loader.reset_cache_for_test()
+
+    def raise_exc(**kw):
+        raise RuntimeError("Typesense unreachable")
+
+    monkeypatch.setattr(synonyms_loader.typesense_client, "list_synonyms", raise_exc)
+    assert synonyms_loader.synonyms_available() is False
+    assert synonyms_loader.expand_tokens({"foo"}) == {"foo"}
+
+
+def test_loads_synonyms_and_builds_mapping(monkeypatch):
+    """Cas nominal : un cluster grue/crane est charge et mappe."""
+    synonyms_loader.reset_cache_for_test()
+    clusters = [
+        {"id": "manual-grue", "synonyms": ["grue", "grues", "grutier", "crane", "cranes", "e-crane"]},
+        {"id": "manual-medical", "synonyms": ["medical", "medicale", "medicaux", "medicales"]},
+    ]
+    monkeypatch.setattr(
+        synonyms_loader.typesense_client,
+        "list_synonyms",
+        lambda **kw: _typesense_response(clusters),
+    )
+
+    assert synonyms_loader.synonyms_available() is True
+    m = synonyms_loader.get_synonyms_map()
+
+    # "crane" doit pointer vers le cluster complet (apres tokenize)
+    # "e-crane" est tokenise en "crane" (e de longueur 1 est filtre)
+    # donc le set effectif est {grue, grues, grutier, crane, cranes}
+    assert "crane" in m
+    assert m["crane"] == {"grue", "grues", "grutier", "crane", "cranes"}
+    # symmetric : grue pointe aussi vers crane
+    assert m["grue"] == {"grue", "grues", "grutier", "crane", "cranes"}
+    # medical cluster
+    assert m["medicale"] == {"medical", "medicale", "medicaux", "medicales"}
+
+
+def test_expand_tokens_returns_union(monkeypatch):
+    """expand_tokens({crane}) -> {crane, grue, grues, grutier, cranes}."""
+    synonyms_loader.reset_cache_for_test()
+    clusters = [{"id": "manual-grue", "synonyms": ["grue", "grues", "grutier", "crane", "cranes"]}]
+    monkeypatch.setattr(
+        synonyms_loader.typesense_client,
+        "list_synonyms",
+        lambda **kw: _typesense_response(clusters),
+    )
+
+    result = synonyms_loader.expand_tokens({"crane"})
+    assert result == {"grue", "grues", "grutier", "crane", "cranes"}
+
+
+def test_expand_tokens_unknown_token(monkeypatch):
+    """Token absent du mapping -> retourne le set inchange."""
+    synonyms_loader.reset_cache_for_test()
+    clusters = [{"id": "manual-grue", "synonyms": ["grue", "crane"]}]
+    monkeypatch.setattr(
+        synonyms_loader.typesense_client,
+        "list_synonyms",
+        lambda **kw: _typesense_response(clusters),
+    )
+
+    # "perceuse" pas dans le mapping
+    result = synonyms_loader.expand_tokens({"perceuse"})
+    assert result == {"perceuse"}
+
+
+def test_cluster_with_root_field(monkeypatch):
+    """Cluster avec 'root' (one-way synonym) : root inclus dans le set."""
+    synonyms_loader.reset_cache_for_test()
+    clusters = [
+        {"id": "manual-minipelle", "root": "minipelle", "synonyms": ["mini pelle", "mini-pelle"]},
+    ]
+    monkeypatch.setattr(
+        synonyms_loader.typesense_client,
+        "list_synonyms",
+        lambda **kw: _typesense_response(clusters),
+    )
+
+    m = synonyms_loader.get_synonyms_map()
+    # "minipelle" doit etre dans le mapping (vient du root + synonymes)
+    # "mini-pelle" tokenize -> "mini" + "pelle"
+    assert "minipelle" in m
+    assert "pelle" in m
+    # tous se referent au meme set
+    assert "minipelle" in m["pelle"]


### PR DESCRIPTION
## Contexte

Audit du 20/05/2026 sur la query \`e-crane\` (marque de grue Mantsinen) :
- Typesense ramène bien des grues XCMG/Zoomlion via le synonyme `manual-grue` (`crane=grue`).
- **MAIS** le reranker Python les rétrograde car il recalcule `name_match` en mode texte strict (le doc "Grue XCMG" n'a pas le mot "crane" → name_match=0 → score pénalisé).

→ Résultat front : du bruit sémantique (Cuves tronconiques, Coupe-branches, etc.) au lieu des vraies grues que le RAG Milvus trouve naturellement.

## Fix

### `app/services/synonyms_loader.py` (NEW)

- Lazy-load les synonymes Typesense au runtime (`GET /collections/<col>/synonyms`)
- Construit un mapping `token -> Set[tokens équivalents]` après `tokenize()`
- Expose `get_synonyms_map()`, `synonyms_available()`, `expand_tokens(set)`
- **Fallback safe** : si Typesense KO → `{}` → reranker tombe sur le matching strict (= comportement A4 sans A6, **aucune régression possible**)

### `app/services/reranker.py` (MOD)

`_idf_weighted_match()` accepte un nouveau param `syn_map`. Un token query est "couvert" si :
- lui-même est dans `doc_tokens` (direct), OU
- un de ses synonymes y apparaît (via `syn_map`)

Le **dénominateur IDF reste basé sur les q_tokens originaux** → un cluster à 10 synonymes ne dilue pas le score.

## Effet attendu

| Cas | Avant | Après |
|---|---|---|
| `crane` + doc "Grue XCMG QY50KA" | name_match=0 | **name_match=1.0** ✅ |
| `crane` + doc "Cuve tronconique" | name_match=0 + vec~0.3 (bruit) | name_match=0 (inchangé) |
| `screen` + doc "Écran tactile" (si synonyme défini) | name_match=0 | name_match=1.0 |
| `medical` + doc "Armoire médicale" | déjà OK via fold accents | inchangé |

## Tests

```
31 passed (4 nouveaux pour synonymes dans reranker, 6 pour synonyms_loader)
```

Mocks pour `typesense_client.list_synonyms()` et `reranker.get_synonyms_map()`. Tous les tests A3/A4 existants continuent à passer (backward-compat).

## Ops après merge sur la VM

```bash
git pull origin features/poc
cd apps-microservices/opti-moteur-front

docker compose build opti-moteur-front
docker compose up -d --force-recreate opti-moteur-front

# Vérification — déclenche une recherche pour lazy-load les synonymes :
curl -s -X POST http://localhost:8570/search/text \
  -H "Content-Type: application/json" \
  -d '{"query":"crane","top_k":3,"use_vector":true}' > /dev/null

docker compose logs --tail 20 opti-moteur-front | grep -i "Synonyms loaded"
# Attendu : "Synonyms loaded from Typesense: N clusters, M tokens, avg X.X equivalents/token"
```

Puis test décisif :

```bash
curl -s -X POST http://localhost:8570/search/text \
  -H "Content-Type: application/json" \
  -d '{"query":"crane","top_k":10,"use_vector":true}' \
  | python3 -c "import sys,json; d=json.load(sys.stdin); [print(f' {h[\"nom_produit\"][:70]} | name={h[\"scores_detail\"][\"name_match\"]} | score={h[\"score\"]}') for h in d['results']]"
```

→ Tu devrais voir des **Grues XCMG, Zoomlion, Speed Crane** en top, avec name_match=1.0 grâce au synonyme.

## Plan de rollback

Si problème :
- `docker compose restart opti-moteur-front` → resette le cache synonymes
- Ou rollback Git (revert du commit) → reranker repasse en mode strict A4

## Ne touche pas

- A3 seuil fallback adaptatif (search_service.py)
- A4 IDF tokens rares (idf_loader.py)
- Garde-fous P1 PHP (côté front Ecritel)
- Pipeline d'ingestion Typesense / Milvus

🤖 Generated with [Claude Code](https://claude.com/claude-code)