### PR TITLE
feat(opti-moteur-front): R3 coverage strict + R2 marque comme contrainte

### DIFF
--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -177,3 +177,41 @@ curl -X PUT "http://10.0.130.66:8108/collections/produits_prod/synonyms/manual-g
 
 docker compose restart opti-moteur-front
 ```
+
+## A7 R3 -- Coverage strict des tokens query (2026-05-21)
+
+Si la majorite des tokens query ne sont pas couverts par le doc (ni en
+direct ni via synonyme), penalite progressive sur le score final :
+- coverage < 50% : score * 0.5  (penalty `low_coverage_50`)
+- coverage < 70% : score * 0.75 (penalty `low_coverage_70`)
+
+Resout les faux amis semantiques type `barre laser a led` -> scanner code-barre
+(la query a 3 tokens, le scanner n'en matche que 2/3 -> penalite). Le produit
+qui matche les 3 tokens passe devant.
+
+Logique dans `_is_covered()` et `rerank_candidates()` (reranker.py).
+
+## A8 R2 -- Marque comme contrainte forte (2026-05-21)
+
+Quand une query contient une marque connue + un autre token (type produit),
+le doc doit egalement couvrir le type. Sinon penalite forte (score * 0.3,
+penalty `missing_type_with_brand`).
+
+Resout `urinoir delabie` -> Distributeur Delabie en pos 1 (le distributeur
+matche "delabie" mais pas "urinoir" -> penalite).
+
+### Source des marques
+
+`app/services/brands_loader.py` charge la liste des marques mono-token via
+facets Typesense (`marque` + `fournisseur`). Lazy + cache singleton, fallback
+safe si Typesense KO (R2 inactif sans regression).
+
+### Comportement
+
+- Query "delabie" seule (juste une marque) -> R2 inactif (pas de type token)
+- Query "urinoir delabie" -> brand={delabie}, type={urinoir} -> R2 actif
+- Query "armoire medicale" (pas de marque) -> R2 inactif
+
+Pour les marques multi-mots (ex: "Saint Gobain"), elles sont skipees pour
+l'instant (detection multi-token plus complexe). A enrichir plus tard si
+necessaire business.

--- a/apps-microservices/opti-moteur-front/app/services/brands_loader.py
+++ b/apps-microservices/opti-moteur-front/app/services/brands_loader.py
@@ -1,0 +1,132 @@
+"""
+brands_loader.py
+================
+Charge la liste des marques (mono-token) depuis Typesense au runtime.
+Permet au reranker de detecter quand une query contient une marque
+("urinoir delabie") et d'exiger que le TYPE produit soit egalement
+satisfait (sinon le produit Delabie qui n'est pas un urinoir remonte
+en pos 1).
+
+Source : facets Typesense sur `marque` + `fournisseur` (les 2 sources
+de "marques" dans le schema actuel). Mono-token uniquement pour l'instant
+(detection rapide en O(1) sur les tokens query).
+
+Comportement si Typesense indisponible : `get_brands_set()` retourne set()
+-> R2 brand_filter inactif -> reranker comporte comme avant (aucune
+regression).
+"""
+import logging
+from typing import Optional, Set
+
+from app.core.credentials import settings
+from app.core.typesense_client import typesense_client
+from app.utils.text import tokenize
+
+logger = logging.getLogger(__name__)
+
+
+# Etat global (singleton, charge a la 1ere demande)
+_brands_set: Optional[Set[str]] = None
+_load_attempted: bool = False
+
+
+def _load_brands() -> Set[str]:
+    """
+    Charge la liste des marques mono-token depuis Typesense via facets.
+    Cache singleton. Fallback safe en cas d'erreur.
+    """
+    global _brands_set, _load_attempted
+
+    if _brands_set is not None:
+        return _brands_set
+    if _load_attempted:
+        return _brands_set or set()
+    _load_attempted = True
+
+    try:
+        # Charge facets marque + fournisseur via multi_search
+        params = {
+            "collection": settings.TYPESENSE_COLLECTION,
+            "q": "*",
+            "query_by": "nom_produit",
+            "per_page": 1,
+            "facet_by": "marque,fournisseur",
+            "max_facet_values": 10000,
+        }
+        res = typesense_client.multi_search({"searches": [params]})
+        result = res.get("results", [{}])[0] if res.get("results") else {}
+        facets = result.get("facet_counts", [])
+
+        brands: Set[str] = set()
+        n_multi_token_skipped = 0
+
+        for facet in facets:
+            for c in facet.get("counts", []):
+                value = (c.get("value") or "").strip()
+                if not value:
+                    continue
+                # Tokenise la marque (filtre min 2 chars, normalise accents/casse)
+                tokens = tokenize(value)
+                # Pour l'instant on garde uniquement les marques MONO-TOKEN
+                # (ex: "delabie", "xcmg", "zoomlion"). Les marques multi-mots
+                # comme "Saint Gobain" sont skip car la detection serait plus
+                # complexe (matching de sequence). A enrichir plus tard si
+                # besoin business.
+                if len(tokens) == 1:
+                    brands |= tokens
+                else:
+                    n_multi_token_skipped += 1
+
+        _brands_set = brands
+        logger.info(
+            "Brands loaded from Typesense facets: %d single-token brands (skipped %d multi-token brands)",
+            len(brands), n_multi_token_skipped,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to load brands from Typesense (%s) - reranker will skip brand detection (R2 inactive)",
+            e,
+        )
+        _brands_set = set()
+
+    return _brands_set
+
+
+def get_brands_set() -> Set[str]:
+    """Retourne le set des marques mono-token connues."""
+    return _load_brands()
+
+
+def is_brand(token: str) -> bool:
+    """True si le token est une marque connue (mono-token, normalise)."""
+    return token in _load_brands()
+
+
+def split_query_brand_type(q_tokens: Set[str]) -> "tuple[Set[str], Set[str]]":
+    """
+    Separe les tokens query en (brand_tokens, type_tokens).
+
+    Ex : query "urinoir delabie" + brands set incluant "delabie" ->
+         brand_tokens = {"delabie"}, type_tokens = {"urinoir"}
+
+    Si la query ne contient aucune marque connue : brand_tokens vide,
+    type_tokens = q_tokens (R2 inactif sur cette query).
+    """
+    brands = _load_brands()
+    if not brands:
+        return set(), set(q_tokens)
+    brand_tokens = q_tokens & brands
+    type_tokens = q_tokens - brand_tokens
+    return brand_tokens, type_tokens
+
+
+def brands_available() -> bool:
+    """True si la liste des marques est chargee."""
+    return bool(_load_brands())
+
+
+def reset_cache_for_test():
+    """Helper tests : force le rechargement au prochain appel."""
+    global _brands_set, _load_attempted
+    _brands_set = None
+    _load_attempted = False

--- a/apps-microservices/opti-moteur-front/app/services/reranker.py
+++ b/apps-microservices/opti-moteur-front/app/services/reranker.py
@@ -9,39 +9,48 @@ Formule (hybrid, use_vector=True) :
 Penalite si vec < 0.20 AND name_match < 0.50 -> x 0.3
 
 Formule (BM25 only, use_vector=False) :
-    final = 0.00 * vec_score  (pas de signal vecteur disponible)
+    final = 0.00 * vec_score
           + 0.20 * bm25_score
           + 0.60 * name_match
           + 0.20 * cat_match
 Penalite si name_match < 0.20 AND cat_match < 0.50 -> x 0.3
-(sans vecteur, on s'appuie davantage sur le nom qui est le signal le plus
- robuste pour les queries de type "categorie + adjectif").
 
 A4 (2026-05-18) -- Ponderation IDF des tokens
 ---------------------------------------------
-name_match et cat_match sont ponderes par l'IDF des tokens query (inverse
-document frequency calculee offline sur l'ensemble des nom_produit).
-
-Exemple "melangeur conique" :
-  - "conique" rare dans le catalogue -> idf eleve (~3.0)
-  - "melangeur" plus commun           -> idf moyen (~1.5)
-  Produit "Saleuse a cuve conique" (matche conique, pas melangeur) :
-    name_match_simple = 1/2 = 0.50
-    name_match_idf    = 3.0 / (3.0 + 1.5) = 0.67
+name_match et cat_match sont ponderes par l'IDF des tokens query. Le token
+rare ("conique") pese plus que le token commun ("melangeur").
 
 A6 (2026-05-20) -- Support synonymes dans le matching
 ------------------------------------------------------
-Un token query est considere "couvert" par le doc si lui-meme OU un de ses
-synonymes Typesense apparait dans nom_produit / categorie. Resout les cas
-multilingues comme "crane" -> "Grue XCMG" (le synonyme manual-grue contient
-"crane" + "grue" + "grues" + ...).
+Un token query est considere "couvert" si lui-meme OU un de ses synonymes
+Typesense apparait dans le doc. Resout "crane" -> "Grue XCMG" (multilingue).
 
-Sans synonymes (Typesense indisponible ou pas configure) : fallback sur le
-matching strict (= comportement A4). Aucune regression possible.
+A7 (2026-05-21) -- R3 : Coverage strict sur tokens query
+---------------------------------------------------------
+Si la majorite des tokens query ne sont PAS couverts (ni en direct, ni via
+synonyme, ni dans nom_produit, ni dans categorie), on applique une penalite
+progressive sur final_score. Resout `barre laser a led` -> scanner code-barre
+(la query a 3 tokens, le scanner n'en matche que 2/3 -> penalite).
+
+Seuils :
+  coverage < 50% : score * 0.5  (50% penalty)
+  coverage < 70% : score * 0.75 (25% penalty)
+  coverage >= 70%: pas de penalite
+
+A8 (2026-05-21) -- R2 : Marque comme contrainte forte
+------------------------------------------------------
+Quand une query contient une marque connue + au moins un autre token (type
+produit), on exige que le TYPE soit egalement couvert. Sinon penalite forte.
+Resout `urinoir delabie` -> Distributeur Delabie en pos 1 (le distributeur
+matche "delabie" mais pas "urinoir" -> penalite).
+
+Si pas de marque dans la query OU pas de type token (juste une marque) :
+R2 inactif sur cette query, comportement A7 standard.
 """
 from typing import Dict, List, Any, Set, Optional
 
 from app.core.credentials import settings
+from app.services.brands_loader import split_query_brand_type, brands_available
 from app.services.idf_loader import get_idf, idf_available
 from app.services.synonyms_loader import get_synonyms_map
 from app.utils.text import tokenize
@@ -53,6 +62,35 @@ _W_BM25_NOVEC   = 0.20
 _W_NAME_NOVEC   = 0.60
 _W_CAT_NOVEC    = 0.20
 
+# A7 R3 : seuils de pénalité coverage strict
+_R3_COVERAGE_STRONG_PENALTY  = 0.50  # < 50% des tokens couverts -> score * 0.5
+_R3_COVERAGE_WEAK_PENALTY    = 0.70  # < 70% -> score * 0.75
+_R3_STRONG_FACTOR = 0.5
+_R3_WEAK_FACTOR   = 0.75
+
+# A8 R2 : penalite si marque presente dans query mais type produit absent du doc
+_R2_MISSING_TYPE_FACTOR = 0.3
+
+
+def _is_covered(
+    token: str,
+    name_tokens: Set[str],
+    cat_tokens: Set[str],
+    syn_map: Optional[Dict[str, Set[str]]],
+) -> bool:
+    """
+    True si `token` est couvert par le doc :
+    - directement dans nom_produit ou categorie, OU
+    - via un synonyme present dans nom_produit ou categorie.
+    """
+    if token in name_tokens or token in cat_tokens:
+        return True
+    if syn_map:
+        equivs = syn_map.get(token)
+        if equivs and (not equivs.isdisjoint(name_tokens) or not equivs.isdisjoint(cat_tokens)):
+            return True
+    return False
+
 
 def _idf_weighted_match(
     q_tokens: Set[str],
@@ -60,17 +98,12 @@ def _idf_weighted_match(
     syn_map: Optional[Dict[str, Set[str]]] = None,
 ) -> float:
     """
-    Ratio de match pondere par IDF, avec support synonymes optionnel.
+    Ratio de match pondere par IDF avec support synonymes.
 
-    Logique :
-      - Pour chaque token query, on verifie s'il est "couvert" par le doc.
-        Un token est couvert si lui-meme OU un de ses synonymes est dans doc_tokens.
-      - Score = somme des IDF des tokens couverts / somme des IDF de TOUS les tokens query.
+    Un token query est "couvert" s'il-meme ou un de ses synonymes est dans
+    doc_tokens. Score = sum(idf(t)) pour t couvert / sum(idf(t)) pour t in q_tokens.
 
-    Si IDF non disponible -> fallback ratio simple (= comportement historique).
-    Si syn_map non fourni -> matching strict (comportement A4 sans A6).
-
-    Resultat entre 0.0 (aucun token couvert) et 1.0 (tous couverts).
+    Resultat entre 0.0 et 1.0. Fallback ratio simple si IDF indispo.
     """
     if not q_tokens:
         return 0.0
@@ -84,24 +117,19 @@ def _idf_weighted_match(
         weight = get_idf(t) if use_idf else 1.0
         sum_total += weight
 
-        # Direct match (token litteral dans le doc)
         if t in doc_tokens:
             sum_matched += weight
             n_matched += 1
             continue
 
-        # Synonym match (un equivalent du token est dans le doc)
         if syn_map is not None:
             equivs = syn_map.get(t)
             if equivs and not equivs.isdisjoint(doc_tokens):
                 sum_matched += weight
                 n_matched += 1
-                continue
 
     if sum_total <= 0:
-        # Garde-fou (theoriquement impossible avec idf lisse >= 1)
         return n_matched / len(q_tokens)
-
     return sum_matched / sum_total
 
 
@@ -113,17 +141,18 @@ def rerank_candidates(
     """
     groups = Typesense `grouped_hits` (par id_produit).
     Retourne une liste d'objets scored tries par final_score desc.
-
-    Si `use_vector=False`, applique une formule rebalancee (name_match domine)
-    et une penalite adaptee (sans signal vectoriel, le bruit BM25 se detecte
-    via name_match + cat_match).
     """
     q_tokens = tokenize(query)
     if not q_tokens or not groups:
         return []
 
-    # A6 : charge le mapping synonymes (lazy + cache). {} si non disponible.
+    # A6 : mapping synonymes (lazy + cache)
     syn_map = get_synonyms_map() or None
+
+    # A8 R2 : detection marque dans la query (et separation brand/type tokens)
+    brand_tokens, type_tokens = split_query_brand_type(q_tokens) if brands_available() else (set(), set(q_tokens))
+    # R2 actif uniquement si la query contient une marque ET au moins un autre token (type)
+    r2_active = bool(brand_tokens) and bool(type_tokens)
 
     # Choix des poids
     if use_vector:
@@ -146,16 +175,34 @@ def rerank_candidates(
         doc = hit["document"]
 
         vec_dist = hit.get("vector_distance")
-        # Quand use_vector=False : vector_distance est absent -> score 0.
         vec_score = 1 - min(vec_dist or 1.0, 1.0) if use_vector else 0.0
         tm_raw = hit.get("text_match", 0) or 0
 
-        # A4+A6 : name_match et cat_match ponderes par IDF + expansion synonymes.
         name_tokens = tokenize(doc.get("nom_produit", ""))
-        name_match = _idf_weighted_match(q_tokens, name_tokens, syn_map=syn_map)
-
         cat_tokens = tokenize(doc.get("categorie", ""))
+
+        # A4+A6 : matching IDF + synonymes
+        name_match = _idf_weighted_match(q_tokens, name_tokens, syn_map=syn_map)
         cat_match = _idf_weighted_match(q_tokens, cat_tokens, syn_map=syn_map)
+
+        # A7 R3 : ratio strict de tokens couverts (sans ponderation IDF)
+        # Un token est couvert si dans name OU cat OU via synonyme.
+        n_covered = sum(
+            1 for t in q_tokens
+            if _is_covered(t, name_tokens, cat_tokens, syn_map)
+        )
+        coverage_ratio = n_covered / len(q_tokens)
+
+        # A8 R2 : verifier que les type_tokens sont couverts si une marque est presente
+        # Si R2 actif et type_tokens NON couverts -> doc ne satisfait pas l'intention
+        # "type X de la marque Y" -> penalite forte.
+        r2_missing_type = False
+        if r2_active:
+            type_covered = any(
+                _is_covered(t, name_tokens, cat_tokens, syn_map) for t in type_tokens
+            )
+            if not type_covered:
+                r2_missing_type = True
 
         raw.append({
             "doc": doc,
@@ -163,6 +210,8 @@ def rerank_candidates(
             "tm_raw": tm_raw,
             "name_match": name_match,
             "cat_match": cat_match,
+            "coverage_ratio": coverage_ratio,
+            "r2_missing_type": r2_missing_type,
         })
 
     # Normalisation BM25 par batch
@@ -176,17 +225,32 @@ def rerank_candidates(
             + w_name * r["name_match"]
             + w_cat  * r["cat_match"]
         )
-        # Penalite bruit (adaptee selon presence du signal vecteur)
+
+        penalties = []
+
+        # Penalite bruit historique (A1) — vec faible + name_match faible
         if use_vector:
             noise = r["vec_score"] < 0.20 and r["name_match"] < 0.50
         else:
-            # Sans vecteur : on flag un bruit si aucun signal textuel fort
             noise = r["name_match"] < 0.20 and r["cat_match"] < 0.50
         if noise:
             r["final_score"] *= 0.3
-            r["penalty"] = "noise_bm25" if use_vector else "noise_text"
-        else:
-            r["penalty"] = ""
+            penalties.append("noise_bm25" if use_vector else "noise_text")
+
+        # A7 R3 : penalite coverage stricte
+        if r["coverage_ratio"] < _R3_COVERAGE_STRONG_PENALTY:
+            r["final_score"] *= _R3_STRONG_FACTOR
+            penalties.append("low_coverage_50")
+        elif r["coverage_ratio"] < _R3_COVERAGE_WEAK_PENALTY:
+            r["final_score"] *= _R3_WEAK_FACTOR
+            penalties.append("low_coverage_70")
+
+        # A8 R2 : penalite si marque presente mais type produit absent
+        if r["r2_missing_type"]:
+            r["final_score"] *= _R2_MISSING_TYPE_FACTOR
+            penalties.append("missing_type_with_brand")
+
+        r["penalty"] = " ".join(penalties)
 
     raw.sort(key=lambda x: -x["final_score"])
     return raw

--- a/apps-microservices/opti-moteur-front/tests/test_brands_loader.py
+++ b/apps-microservices/opti-moteur-front/tests/test_brands_loader.py
@@ -1,0 +1,97 @@
+"""Tests unitaires du loader de marques (R2)."""
+from app.services import brands_loader
+
+
+def _typesense_facet_response(brand_values, fournisseur_values):
+    """Helper : construit la reponse Typesense multi_search avec facets."""
+    return {
+        "results": [{
+            "facet_counts": [
+                {"field_name": "marque", "counts": [{"value": v, "count": 1} for v in brand_values]},
+                {"field_name": "fournisseur", "counts": [{"value": v, "count": 1} for v in fournisseur_values]},
+            ],
+        }],
+    }
+
+
+def test_no_brands_when_typesense_returns_empty(monkeypatch):
+    brands_loader.reset_cache_for_test()
+    monkeypatch.setattr(
+        brands_loader.typesense_client,
+        "multi_search",
+        lambda body: _typesense_facet_response([], []),
+    )
+    assert brands_loader.brands_available() is False
+    assert brands_loader.get_brands_set() == set()
+    assert brands_loader.is_brand("delabie") is False
+
+
+def test_no_brands_when_typesense_fails(monkeypatch):
+    brands_loader.reset_cache_for_test()
+
+    def raise_exc(body):
+        raise RuntimeError("Typesense unreachable")
+
+    monkeypatch.setattr(brands_loader.typesense_client, "multi_search", raise_exc)
+    assert brands_loader.brands_available() is False
+    assert brands_loader.is_brand("delabie") is False
+
+
+def test_loads_single_token_brands(monkeypatch):
+    """Marques mono-token : ajoutees au set. Marques multi-mots : skip."""
+    brands_loader.reset_cache_for_test()
+    monkeypatch.setattr(
+        brands_loader.typesense_client,
+        "multi_search",
+        lambda body: _typesense_facet_response(
+            ["DELABIE", "XCMG", "Saint Gobain"],  # 2 mono + 1 multi
+            ["Zoomlion", "Liebherr", "Officity Z2"],  # 2 mono + 1 multi
+        ),
+    )
+    assert brands_loader.brands_available() is True
+    brands = brands_loader.get_brands_set()
+    # Marques mono-token (normalisees lowercase, sans accent)
+    assert "delabie" in brands
+    assert "xcmg" in brands
+    assert "zoomlion" in brands
+    assert "liebherr" in brands
+    # Multi-tokens : skipees pour l'instant
+    assert "saint" not in brands or "gobain" not in brands
+
+
+def test_is_brand_normalized(monkeypatch):
+    """is_brand est case-insensitive et fold accents."""
+    brands_loader.reset_cache_for_test()
+    monkeypatch.setattr(
+        brands_loader.typesense_client,
+        "multi_search",
+        lambda body: _typesense_facet_response(["DELABIE", "Liebherr"], []),
+    )
+    assert brands_loader.is_brand("delabie") is True
+    assert brands_loader.is_brand("liebherr") is True
+    assert brands_loader.is_brand("xcmg") is False
+
+
+def test_split_query_brand_type(monkeypatch):
+    """split_query_brand_type separe correctement brand vs type tokens."""
+    brands_loader.reset_cache_for_test()
+    monkeypatch.setattr(
+        brands_loader.typesense_client,
+        "multi_search",
+        lambda body: _typesense_facet_response(["DELABIE", "Liebherr"], []),
+    )
+
+    # Query "urinoir delabie" -> brand={delabie}, type={urinoir}
+    brand, type_ = brands_loader.split_query_brand_type({"urinoir", "delabie"})
+    assert brand == {"delabie"}
+    assert type_ == {"urinoir"}
+
+    # Query "delabie" seule -> brand={delabie}, type={} (R2 inactif)
+    brand, type_ = brands_loader.split_query_brand_type({"delabie"})
+    assert brand == {"delabie"}
+    assert type_ == set()
+
+    # Query "armoire medicale" sans marque -> brand={}, type=tout
+    brand, type_ = brands_loader.split_query_brand_type({"armoire", "medicale"})
+    assert brand == set()
+    assert type_ == {"armoire", "medicale"}

--- a/apps-microservices/opti-moteur-front/tests/test_reranker.py
+++ b/apps-microservices/opti-moteur-front/tests/test_reranker.py
@@ -40,8 +40,10 @@ class TestRerank:
         ]
         ranked = rerank_candidates(groups, "armoire medicale")
         # Le noise doit etre penalise (vec<0.20 AND name_match<0.50)
+        # Apres A7 R3, le penalty contient aussi "low_coverage_50" car
+        # aucun token query n'est dans le doc -> on verifie l'inclusion.
         noise_entry = next(r for r in ranked if r["doc"]["id_produit"] == "noise")
-        assert noise_entry["penalty"] == "noise_bm25"
+        assert "noise_bm25" in noise_entry["penalty"]
         # Good doit etre premier
         assert ranked[0]["doc"]["id_produit"] == "good"
 
@@ -220,3 +222,151 @@ class TestSynonymsInReranker:
             # name_match = 0 (nom_produit ne contient ni crane ni grue ni grues)
             # cat_match = 1.0 (categorie contient "grues" qui est synonyme de "crane")
             assert ranked[0]["cat_match"] == 1.0
+
+
+class TestR3CoverageStrict:
+    """
+    A7 R3 (2026-05-21) : penalite coverage stricte si la majorite des tokens
+    query ne sont pas couverts (ni en direct ni via synonymes).
+    """
+
+    def test_full_coverage_no_penalty(self):
+        """Tous les tokens query couverts -> pas de penalite R3."""
+        groups = [
+            make_group("good", "Armoire medicale Optimea", "Armoires medicales",
+                       vec_dist=0.3, text_match=900000),
+        ]
+        ranked = rerank_candidates(groups, "armoire medicale")
+        # coverage = 2/2 = 1.0 -> pas de "low_coverage_*"
+        assert "low_coverage" not in ranked[0]["penalty"]
+        assert ranked[0]["coverage_ratio"] == 1.0
+
+    def test_partial_coverage_70_percent_weak_penalty(self):
+        """3 tokens query, 2 couverts (67%) -> weak penalty (* 0.75)."""
+        groups = [
+            # Query "barre laser led" : doc OPTICON matche "barre" + "laser" mais pas "led"
+            make_group("opticon", "OPTICON Lecteur code barre laser OPL 6845R", "Lecteurs codes-barres",
+                       vec_dist=0.3, text_match=800000),
+        ]
+        ranked = rerank_candidates(groups, "barre laser led")
+        # coverage = 2/3 = 0.67 (entre 0.5 et 0.7) -> weak penalty
+        assert ranked[0]["coverage_ratio"] < 0.70
+        assert ranked[0]["coverage_ratio"] >= 0.50
+        assert "low_coverage_70" in ranked[0]["penalty"]
+
+    def test_low_coverage_strong_penalty(self):
+        """3 tokens query, 1 couvert (33%) -> strong penalty (* 0.5)."""
+        groups = [
+            # Query "barre laser led" : doc "Veilleuse LED bureau" matche que "led"
+            make_group("led_only", "Veilleuse LED de bureau elegante", "Lampes",
+                       vec_dist=0.3, text_match=400000),
+        ]
+        ranked = rerank_candidates(groups, "barre laser led")
+        # coverage = 1/3 = 0.33 (< 0.5) -> strong penalty
+        assert ranked[0]["coverage_ratio"] < 0.50
+        assert "low_coverage_50" in ranked[0]["penalty"]
+
+    def test_full_match_outranks_partial(self):
+        """Avec R3, un produit qui matche TOUS les tokens passe devant ceux qui en ratent."""
+        groups = [
+            # 3 tokens couverts (barre + laser + led present dans le nom)
+            make_group("full", "Barre LED laser pour eclairage scenique", "Eclairage",
+                       vec_dist=0.3, text_match=500000),
+            # Seulement 2 tokens couverts (barre + laser, pas led)
+            make_group("partial", "OPTICON Lecteur code barre laser OPL 6845R", "Lecteurs codes-barres",
+                       vec_dist=0.3, text_match=800000),
+        ]
+        ranked = rerank_candidates(groups, "barre laser led")
+        # Le full doit etre premier malgre son BM25 plus faible (pas de penalite)
+        assert ranked[0]["doc"]["id_produit"] == "full"
+
+
+class TestR2BrandAsHardFilter:
+    """
+    A8 R2 (2026-05-21) : si la query contient une marque connue + un type
+    produit, le doc doit aussi couvrir le type (sinon penalite forte).
+
+    Resout `urinoir delabie` -> Distributeur Delabie en pos 1 (matche marque
+    mais pas le type).
+    """
+
+    def test_brand_only_no_r2_penalty(self):
+        """Query avec seulement une marque (sans type) -> R2 inactif."""
+        with mock.patch.object(reranker, "brands_available", return_value=True), \
+             mock.patch.object(reranker, "split_query_brand_type",
+                               return_value=({"delabie"}, set())):
+            groups = [
+                make_group("any", "Distributeur Delabie", "Distributeurs",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "delabie")
+            # R2 inactif (pas de type token) -> pas de missing_type_with_brand
+            assert "missing_type_with_brand" not in ranked[0]["penalty"]
+            assert ranked[0]["r2_missing_type"] is False
+
+    def test_brand_plus_type_missing_in_doc_strong_penalty(self):
+        """Query brand+type, doc matche brand mais pas type -> penalite R2 forte."""
+        with mock.patch.object(reranker, "brands_available", return_value=True), \
+             mock.patch.object(reranker, "split_query_brand_type",
+                               return_value=({"delabie"}, {"urinoir"})):
+            groups = [
+                # Doc matche "delabie" mais pas "urinoir"
+                make_group("distributeur", "Distributeur Essuie Mains Hypereco Delabie",
+                           "Distributeurs", vec_dist=0.3, text_match=900000),
+            ]
+            ranked = rerank_candidates(groups, "urinoir delabie")
+            assert ranked[0]["r2_missing_type"] is True
+            assert "missing_type_with_brand" in ranked[0]["penalty"]
+
+    def test_brand_plus_type_both_in_doc_no_penalty(self):
+        """Query brand+type, doc matche les deux -> pas de penalite R2."""
+        with mock.patch.object(reranker, "brands_available", return_value=True), \
+             mock.patch.object(reranker, "split_query_brand_type",
+                               return_value=({"delabie"}, {"urinoir"})):
+            groups = [
+                # Doc matche "urinoir" ET "delabie"
+                make_group("urinoir_delabie", "Urinoir Delabie inox suspendu",
+                           "Urinoirs", vec_dist=0.3, text_match=500000),
+            ]
+            ranked = rerank_candidates(groups, "urinoir delabie")
+            assert ranked[0]["r2_missing_type"] is False
+            assert "missing_type_with_brand" not in ranked[0]["penalty"]
+
+    def test_brand_with_type_match_via_categorie(self):
+        """Le type peut etre couvert via la categorie (pas seulement nom_produit).
+
+        Note : ici la categorie est "Urinoir" (singulier exact). Si la cat
+        est "Urinoirs" pluriel, faut un synonyme `urinoir↔urinoirs` (gere
+        par les clusters Typesense en prod, non actif dans ce test unitaire).
+        """
+        with mock.patch.object(reranker, "brands_available", return_value=True), \
+             mock.patch.object(reranker, "split_query_brand_type",
+                               return_value=({"delabie"}, {"urinoir"})):
+            groups = [
+                # Le nom_produit contient "delabie" mais pas "urinoir"
+                # MAIS la categorie est "Urinoir" -> type couvert via cat
+                make_group("delabie_cat_urinoir", "Modele Premium Delabie",
+                           "Urinoir suspendu", vec_dist=0.3, text_match=500000),
+            ]
+            ranked = rerank_candidates(groups, "urinoir delabie")
+            assert ranked[0]["r2_missing_type"] is False
+
+    def test_r2_full_e2e_urinoir_delabie_correct_order(self):
+        """
+        E2E : sur "urinoir delabie", le vrai urinoir doit passer devant
+        le distributeur essuie-mains (penalite R2 forte sur le distributeur).
+        """
+        with mock.patch.object(reranker, "brands_available", return_value=True), \
+             mock.patch.object(reranker, "split_query_brand_type",
+                               return_value=({"delabie"}, {"urinoir"})):
+            groups = [
+                # Distributeur essuie-mains Delabie : BM25 elevé sur "delabie" + "distributeur"
+                make_group("distributeur", "Distributeur Essuie Mains Hypereco Delabie",
+                           "Distributeurs", vec_dist=0.3, text_match=900000),
+                # Urinoir Delabie : BM25 plus moyen mais matche les 2 tokens
+                make_group("urinoir", "Urinoir Delabie inox", "Urinoirs",
+                           vec_dist=0.3, text_match=400000),
+            ]
+            ranked = rerank_candidates(groups, "urinoir delabie")
+            # Avec R2 : le vrai urinoir doit etre premier malgre son BM25 plus faible
+            assert ranked[0]["doc"]["id_produit"] == "urinoir"


### PR DESCRIPTION
## Contexte

Audit BDD v3 (20/05/2026) confirme la trajectoire : **6.01 → 6.23 → 6.54** (+0.5 vs baseline). Mais **4 cas critiques persistent** :
- `mantsinen` : 0/10 — pas de produit en BDD, log obsolète (pas un bug)
- `gadus s2 v220 2` : 2/10 — pollution token "S2"
- `barre laser à led` : 5.5/10 — top 1 = scanner code-barre (faux ami)
- `urinoir delabie` : 7.6/10 — top 1 = distributeur essuie-mains Delabie

Cette PR adresse les **2 plus impactants** (`barre laser à led` + `urinoir delabie`) via 2 changements complémentaires dans le reranker.

## A7 R3 — Coverage strict des tokens query

Pénalité progressive si la **majorité des tokens query ne sont pas couverts** par le doc (ni en direct, ni via synonyme, ni dans nom_produit, ni dans catégorie) :

| Coverage | Pénalité |
|---|---|
| < 50% | × 0.5 (`low_coverage_50`) |
| < 70% | × 0.75 (`low_coverage_70`) |
| ≥ 70% | aucune |

**Effet sur `barre laser à led`** :
- Scanner OPTICON matche `barre` + `laser` mais **pas `led`** → 2/3 = 67% → pénalité -25%
- Le vrai bandeau LED laser matche 3/3 = 100% → pas de pénalité → passe en pos 1

## A8 R2 — Marque comme contrainte forte

Quand une query contient **une marque connue + au moins un autre token** (type produit), le doc doit également couvrir le type. Sinon **pénalité forte** (× 0.3, `missing_type_with_brand`).

**Effet sur `urinoir delabie`** :
- Distributeur Delabie matche `delabie` (marque ✓) mais **pas `urinoir`** (type ✗) → pénalité -70%
- Vrai urinoir Delabie matche les 2 → pas de pénalité → passe en pos 1

### Source des marques

`app/services/brands_loader.py` (NEW) charge la liste des marques mono-token via facets Typesense (champs `marque` + `fournisseur`). Lazy + cache singleton. **Fallback safe** : si Typesense KO, R2 inactif sans régression. Marques multi-mots ("Saint Gobain") skipées pour l'instant.

## Fichiers

```
apps-microservices/opti-moteur-front/
├── app/services/brands_loader.py   (NEW)
├── app/services/reranker.py        (MOD — _is_covered, R3 logic, R2 logic)
├── tests/test_brands_loader.py     (NEW — 5 tests)
├── tests/test_reranker.py          (MOD — +8 tests R3+R2)
└── CLAUDE.md                       (MOD — sections A7 + A8)
```

## Tests

```
$ pytest tests/ -v
============================== 45 passed in 4.37s ==============================
```

3 nouveaux tests R3 coverage + 5 nouveaux tests R2 brand + 5 tests brands_loader. Tous les tests A3/A4/A6 existants continuent à passer (backward-compat).

## Ops après merge sur la VM

```bash
git pull origin features/poc
cd apps-microservices/opti-moteur-front

docker compose build opti-moteur-front
docker compose up -d --force-recreate opti-moteur-front

# Trigger lazy-load (charge IDF, synonymes, ET marques)
curl -s -X POST http://localhost:8570/search/text \
  -H "Content-Type: application/json" \
  -d '{"query":"urinoir delabie","top_k":3,"use_vector":true}' > /dev/null

# Vérification
docker compose logs --tail 40 opti-moteur-front | grep -iE "Brands loaded|Synonyms loaded|IDF loaded"
```

Attendu :
```
IDF loaded from idf_nom_produit.json : 665825 tokens...
Synonyms loaded from Typesense: 1993 clusters, 21967 unique tokens...
Brands loaded from Typesense facets: NN single-token brands (skipped M multi-token brands)
```

## Test décisif post-déploiement

```bash
# Cas urinoir delabie
curl -s -X POST http://localhost:8570/search/text \
  -H "Content-Type: application/json" \
  -d '{"query":"urinoir delabie","top_k":10,"use_vector":true}' \
  | python3 -c "import sys,json; d=json.load(sys.stdin); [print(f' {h[\"nom_produit\"][:70]} | penalty={h[\"scores_detail\"][\"penalty\"]} | score={h[\"score\"]}') for h in d['results']]"
```

→ Top 1 doit être un VRAI urinoir Delabie. Distributeur essuie-mains doit avoir penalty `missing_type_with_brand`.

```bash
# Cas barre laser à led
curl -s -X POST http://localhost:8570/search/text \
  -H "Content-Type: application/json" \
  -d '{"query":"barre laser à led","top_k":10,"use_vector":true}' \
  | python3 -c "import sys,json; d=json.load(sys.stdin); [print(f' {h[\"nom_produit\"][:70]} | penalty={h[\"scores_detail\"][\"penalty\"]} | score={h[\"score\"]}') for h in d['results']]"
```

→ Top 10 doit contenir des bandeaux LED (les scanners gardent une pénalité `low_coverage_70`).

## Plan de rollback

- `docker compose restart` → reset cache mais code reste à R3/R2
- Vrai rollback : `git revert <commit>` sur features/poc → reranker reprend en mode A4+A6 (sans R3/R2)

## Ne touche pas

- A3 / A4 / A6 (synonymes, IDF, garde-fous PHP) inchangés
- Pipeline d'ingestion
- Front PHP

🤖 Generated with [Claude Code](https://claude.com/claude-code)