### PR TITLE
feat(vm): runbook + script ingestion Milvus -> Typesense GKE

### DIFF
--- a/apps-microservices/opti-moteur-front/vm/RUNBOOK_INGESTION_GKE_2026-05-22.md
+++ b/apps-microservices/opti-moteur-front/vm/RUNBOOK_INGESTION_GKE_2026-05-22.md
@@ -1,0 +1,274 @@
+# Runbook : Ingestion Milvus → Typesense GKE (toutes catégories + delta)
+
+**Date** : 2026-05-22
+**Contexte** : Migration définitive du moteur de recherche front. Le Typesense
+GKE a déjà reçu une 1ère ingestion partielle. On finalise en (a) couvrant
+toutes les catégories Milvus restantes, (b) supprimant les orphelins, (c)
+régénérant l'IDF.
+
+**Source** : Milvus prod (collection `produits_3`) accessible depuis la VM GCP
+`vm-embedding-g2-std-24-use`.
+**Cible** : Typesense GKE `http://10.0.1.240:8570`, collection `produits_prod`.
+
+**Durée totale estimée** : 6-10 h (dont 5-8 h en background pour l'ingestion).
+
+---
+
+## Pré-requis sur la VM (à valider AVANT)
+
+### A. `.env` à jour
+Le `.env` de la VM doit contenir (au-delà des Milvus et embedding existants) :
+
+```bash
+# Cible Typesense GKE (NEW 2026-05-22)
+TYPESENSE_HOST=10.0.1.240
+TYPESENSE_PORT=8570
+TYPESENSE_API_KEY=P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=
+TYPESENSE_COLLECTION=produits_prod
+```
+
+⚠️ La sortie `grep -E "TYPESENSE|EMBEDDING" .env` du 22/05 ne montrait que :
+```
+EMBEDDING_API_URL="https://api.hellopro.eu/embedding-service/embedding"
+EMBEDDING_API_KEY="your_optional_embedding_api_key"
+```
+→ **Action** : ajouter le bloc TYPESENSE_* ci-dessus.
+
+### B. Connectivité réseau
+
+```bash
+# Health Typesense GKE depuis la VM
+curl -sf "http://10.0.1.240:8570/health" \
+  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" | jq .
+# Attendu : {"ok":true}
+```
+
+Si timeout → contacter Tafita pour vérifier le firewall GCP (VPC privé).
+
+### C. Inventaire actuel Typesense GKE
+
+```bash
+# Total docs
+curl -s "http://10.0.1.240:8570/collections/produits_prod" \
+  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" | jq '.num_documents'
+
+# Nb catégories distinctes (facet)
+curl -s "http://10.0.1.240:8570/collections/produits_prod/documents/search?q=*&facet_by=categorie&per_page=0&max_facet_values=2000" \
+  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
+  | jq '.facet_counts[0].counts | length'
+```
+
+Noter les chiffres → comparaison avant/après.
+
+---
+
+## Étape 1 — Diff catégories Milvus vs Typesense (5 min)
+
+```bash
+cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
+
+# Charger les credentials Milvus
+export $(grep -E '^(ZILLIZ_|MILVUS_)' ../.env | xargs)
+export MILVUS_HOST="$ZILLIZ_URI" MILVUS_PORT="$ZILLIZ_PORT"
+export MILVUS_USER="$ZILLIZ_USER" MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+
+# Lister catégories absentes du Typesense GKE
+# NOTE : list_missing_categories.py compare avec rubriques/categories_from_roots*.txt
+# Pour comparer dynamiquement avec Typesense GKE, voir migrate_to_gke.sh ci-dessous
+python3 list_missing_categories.py
+
+# Output :
+#   ../../../rubriques/categories_missing.txt          (1 ligne / catégorie)
+#   ../../../rubriques/categories_missing_chunks_NN.txt (lots de 100)
+
+wc -l ../../../rubriques/categories_missing.txt
+```
+
+---
+
+## Étape 2 — Ingestion (5-8 h en background)
+
+```bash
+# 1. Pointer Typesense GKE
+export TS_HOST=10.0.1.240
+export TS_PORT=8570
+export TS_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
+export TS_COLLECTION=produits_prod
+
+# 2. (Optionnel) filtre etat pour ne prendre que produits actifs
+export EXTRA_FILTER='etat in ["Client","Pause","Prospect"]'
+
+# 3. Lancer en nohup, log timestampé
+LOG=/tmp/ingest_gke_$(date +%Y%m%d_%H%M).log
+nohup python3 ingest_by_categories.py \
+  CATEGORIES_FILE=../../../rubriques/categories_missing.txt \
+  > $LOG 2>&1 &
+echo "PID : $!"
+echo "Log : $LOG"
+```
+
+### Monitoring en parallèle
+
+```bash
+# Suivre les logs
+tail -f /tmp/ingest_gke_*.log
+
+# Compteur Typesense GKE (toutes les 5 min)
+watch -n 300 'curl -s "http://10.0.1.240:8570/collections/produits_prod" \
+  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
+  | jq ".num_documents"'
+
+# RAM/CPU
+docker stats opti-moteur-front 2>/dev/null
+```
+
+### Reprise après interruption
+
+`ingest_by_categories.py` est idempotent (upsert + SKIP_EXISTING optionnel) :
+
+```bash
+SKIP_EXISTING=1 nohup python3 ingest_by_categories.py \
+  CATEGORIES_FILE=../../../rubriques/categories_missing.txt \
+  > /tmp/ingest_gke_resume_$(date +%Y%m%d_%H%M).log 2>&1 &
+```
+
+---
+
+## Étape 3 — Cleanup orphelins (30 min)
+
+```bash
+cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
+
+export $(grep -E '^(ZILLIZ_|MILVUS_)' ../.env | xargs)
+export MILVUS_HOST="$ZILLIZ_URI" MILVUS_PORT="$ZILLIZ_PORT"
+export MILVUS_USER="$ZILLIZ_USER" MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
+export TS_HOST=10.0.1.240 TS_PORT=8570
+export TS_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
+export TS_COLLECTION=produits_prod
+
+# DRY-RUN d'abord (compte sans supprimer)
+DRY_RUN=1 python3 delete_orphans.py
+# Doit afficher : "X orphelins detectes (dry-run, aucune suppression)"
+
+# Si le X est raisonnable (< 5 % du total), supprimer pour de vrai
+python3 delete_orphans.py
+```
+
+⚠️ Si X > 10 % du total → STOP, analyser pourquoi avant suppression.
+Cas connus : filtre EXTRA_FILTER différent entre runs successifs.
+
+---
+
+## Étape 4 — Régénérer IDF (1-5 min)
+
+Le fichier `app/data/idf_nom_produit.json` est **actuellement absent** sur la
+VM (vérifié 22/05). Le reranker tourne donc en mode strict (perte de la
+qualité A4 IDF). Régénération obligatoire après l'ingestion :
+
+```bash
+cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front
+
+# 1. Pointer le script sur le Typesense GKE (sinon il pointe par défaut sur
+#    le Typesense de la VM legacy)
+export TYPESENSE_HOST=10.0.1.240
+export TYPESENSE_PORT=8570
+export TYPESENSE_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
+
+# 2. Génération via le container (toutes les deps déjà là)
+docker compose exec opti-moteur-front python scripts/compute_idf.py
+
+# 3. Vérifier que le fichier est apparu côté hôte (bind-mount)
+ls -lh app/data/idf_nom_produit.json
+# Attendu : ~20 MB, fraîchement créé
+
+# 4. Recharger le service pour reprise du nouveau dict
+docker compose restart opti-moteur-front
+docker compose logs --tail 30 opti-moteur-front | grep -i "IDF"
+# Attendu : "IDF loaded from idf_nom_produit.json : NNNN tokens, ..."
+```
+
+---
+
+## Étape 5 — Sync synonymes GKE (5 min)
+
+Vérifier que les synonymes sont bien sur le Typesense GKE :
+
+```bash
+curl -s "http://10.0.1.240:8570/collections/produits_prod/synonyms" \
+  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
+  | jq '.synonyms | length'
+# Attendu : ~2000 clusters (1993 + synonymes manuels)
+```
+
+Si 0 ou très faible → lancer le script PHP de sync (côté hellopro.fr) :
+```bash
+# Sur le serveur hellopro.fr
+php site/script/typesense/sync_synonyms_daily.php
+```
+
+---
+
+## Étape 6 — Smoke test (10 min, depuis Windows)
+
+Une fois tout déployé, vérifier que ça fonctionne via :
+
+```powershell
+cd C:\RIJA\CLAUDE_CODE\opti_moteur\RAG-HP-PUB
+.\bench_production\smoke_test_bascule.ps1 -Phase post
+```
+
+Critère succès : tous les `armoire medicale`, `ritmo`, `urinoir delabie`,
+`e-crane`, `lockers bagagerie` retournent leurs top-1 attendus.
+
+---
+
+## Étape 7 — Bascule par défaut (PR #622)
+
+Une fois les étapes 1-6 vertes :
+
+```bash
+# Sur le serveur Ecritel
+# 1. Vérifier le flag dans le PHP (doit être true post-merge PR #622)
+grep "HP_USE_HYBRID_SEARCH" /var/www/.../hellopro_fr/moteur_recherche.php
+# Attendu : if (!defined('HP_USE_HYBRID_SEARCH')) define('HP_USE_HYBRID_SEARCH', true);
+
+# 2. Test URL legacy (rollback fonctionne)
+curl -s "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles=ritmo&legacy=1" \
+  | grep -i "HP_QUALITY_P1"
+
+# 3. Test URL default (doit utiliser hybride)
+curl -s "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles=ritmo" \
+  | grep -i "HP_QUALITY_P1"
+# Attendu : présence du marker HP_QUALITY_P1
+```
+
+---
+
+## Monitoring J+1 post-ingestion
+
+| Métrique | Source | Seuil alerte |
+|---|---|---|
+| `num_documents` Typesense GKE | `/collections/produits_prod` | < 95 % du target |
+| Latence p95 `/search` | logs opti-moteur-front | > 1.5 s |
+| Taux 5xx | gateway api.hellopro.eu | > 1 % |
+| Plaintes Elena | Slack #moteur-recherche | 0 attendu |
+
+---
+
+## Plan de rollback (urgence)
+
+Si dégradation détectée :
+
+1. **Quick** (URL niveau) : passer toutes les URLs en `?legacy=1` côté front
+2. **Medium** (5 min) : passer `HP_USE_HYBRID_SEARCH=false` + redéploy PHP
+3. **Heavy** (10 min) : Tafita repointe la gateway sur l'ancien backend Milvus
+
+---
+
+## Fichiers liés
+
+- Script wrapper : [`migrate_to_gke.sh`](./migrate_to_gke.sh) — orchestration auto
+- Scripts d'ingestion existants : `ingest_by_categories.py`, `delete_orphans.py`,
+  `list_missing_categories.py`, `compute_idf.py`
+- Doc bascule : [`../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md`](../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md)
+- PR #622 : https://github.com/Hellopro-fr/RAG-HP-PUB/pull/622

--- a/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
+++ b/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# migrate_to_gke.sh
+# =================
+# Orchestre l'ingestion Milvus -> Typesense GKE en une commande,
+# avec checkpoints et logs separes par etape.
+#
+# Pre-requis :
+#   - Tourner sur la VM GCP (acces Milvus + reseau prive GCP)
+#   - .env contient ZILLIZ_* + TYPESENSE_* + EMBEDDING_API_*
+#   - Connectivite VM -> 10.0.1.240:8570 (Typesense GKE) validee
+#
+# Usage :
+#   cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
+#   bash migrate_to_gke.sh
+#
+# Etapes interactives (Y/N a chaque palier). Pour run non-interactif :
+#   AUTO=1 bash migrate_to_gke.sh
+#
+# Reprise :
+#   Si une etape echoue, relancer le script : il detectera les fichiers
+#   de checkpoint dans /tmp/migrate_gke_checkpoints/ et proposera de
+#   reprendre.
+
+set -eu
+set -o pipefail
+
+# ========== CONFIG ==========
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+VM_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPTI_FRONT_DIR="$(cd "$VM_DIR/.." && pwd)"
+
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/tmp/migrate_gke_checkpoints}"
+LOG_DIR="${LOG_DIR:-/tmp/migrate_gke_logs}"
+mkdir -p "$CHECKPOINT_DIR" "$LOG_DIR"
+
+AUTO="${AUTO:-0}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+# Cible Typesense GKE (peut etre override par .env / env vars)
+TS_HOST="${TS_HOST:-10.0.1.240}"
+TS_PORT="${TS_PORT:-8570}"
+TS_API_KEY="${TS_API_KEY:-${TYPESENSE_API_KEY:-}}"
+TS_COLLECTION="${TS_COLLECTION:-${TYPESENSE_COLLECTION:-produits_prod}}"
+
+# Source Milvus (depuis .env de opti-moteur-front)
+if [ -f "$OPTI_FRONT_DIR/.env" ]; then
+    set -o allexport
+    # shellcheck disable=SC1091
+    source "$OPTI_FRONT_DIR/.env"
+    set +o allexport
+fi
+export MILVUS_HOST="${ZILLIZ_URI:-${MILVUS_HOST:-}}"
+export MILVUS_PORT="${ZILLIZ_PORT:-${MILVUS_PORT:-19530}}"
+export MILVUS_USER="${ZILLIZ_USER:-${MILVUS_USER:-}}"
+export MILVUS_PASSWORD="${ZILLIZ_PASSWORD:-${MILVUS_PASSWORD:-}}"
+export MILVUS_COLLECTION="${MILVUS_COLLECTION:-produits_3}"
+
+# ========== HELPERS ==========
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+err() { echo "[$(date +%H:%M:%S)] ERROR: $*" >&2; }
+
+confirm() {
+    if [ "$AUTO" = "1" ]; then return 0; fi
+    local msg="$1"
+    read -r -p "$msg [y/N] " ans
+    case "$ans" in [yY]*) return 0 ;; *) return 1 ;; esac
+}
+
+step_done() {
+    touch "$CHECKPOINT_DIR/$1.done"
+}
+
+step_pending() {
+    [ ! -f "$CHECKPOINT_DIR/$1.done" ]
+}
+
+# ========== ETAPES ==========
+preflight() {
+    log "=== Preflight ==="
+    [ -n "$TS_API_KEY" ] || { err "TS_API_KEY (ou TYPESENSE_API_KEY) manquant"; exit 1; }
+    [ -n "$MILVUS_HOST" ] || { err "MILVUS_HOST (ou ZILLIZ_URI) manquant dans .env"; exit 1; }
+
+    log "TS target  : http://$TS_HOST:$TS_PORT/$TS_COLLECTION"
+    log "Milvus src : $MILVUS_HOST:$MILVUS_PORT/$MILVUS_COLLECTION"
+
+    if ! curl -sf "http://$TS_HOST:$TS_PORT/health" \
+              -H "X-TYPESENSE-API-KEY: $TS_API_KEY" >/dev/null 2>&1; then
+        err "Typesense GKE injoignable : http://$TS_HOST:$TS_PORT/health"
+        err "Verifier le firewall GCP / VPC privee avec Tafita."
+        exit 1
+    fi
+    log "Typesense GKE OK"
+
+    # Inventaire actuel
+    local cur_docs
+    cur_docs=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION" \
+                    -H "X-TYPESENSE-API-KEY: $TS_API_KEY" 2>/dev/null \
+               | jq -r '.num_documents // 0')
+    log "Typesense GKE actuellement : $cur_docs docs"
+    echo "$cur_docs" > "$CHECKPOINT_DIR/docs_before.txt"
+}
+
+step_1_diff_categories() {
+    if ! step_pending "step1"; then log "step1 deja fait, skip"; return; fi
+    log "=== Etape 1 : diff catégories Milvus vs Typesense GKE ==="
+    confirm "Lancer list_missing_categories.py ?" || return
+
+    cd "$VM_DIR"
+    python3 list_missing_categories.py 2>&1 | tee "$LOG_DIR/step1_${TIMESTAMP}.log"
+
+    local missing_file="$REPO_ROOT/rubriques/categories_missing.txt"
+    if [ ! -f "$missing_file" ]; then
+        err "categories_missing.txt non genere"
+        return 1
+    fi
+    local n_missing
+    n_missing=$(wc -l < "$missing_file")
+    log "Catégories manquantes : $n_missing"
+    step_done "step1"
+}
+
+step_2_ingest() {
+    if ! step_pending "step2"; then log "step2 deja fait, skip"; return; fi
+    log "=== Etape 2 : ingestion delta ==="
+    local missing_file="$REPO_ROOT/rubriques/categories_missing.txt"
+    [ -f "$missing_file" ] || { err "$missing_file absent, refaire step 1"; return 1; }
+
+    local n_missing
+    n_missing=$(wc -l < "$missing_file")
+    confirm "Ingerer $n_missing catégories ? (~5-8h)" || return
+
+    cd "$VM_DIR"
+    export TS_HOST TS_PORT TS_API_KEY TS_COLLECTION
+    export EXTRA_FILTER="${EXTRA_FILTER:-etat in [\"Client\",\"Pause\",\"Prospect\"]}"
+
+    local logfile="$LOG_DIR/step2_ingest_${TIMESTAMP}.log"
+    log "Lancement en nohup : $logfile"
+    nohup python3 ingest_by_categories.py \
+        CATEGORIES_FILE="$missing_file" \
+        > "$logfile" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$CHECKPOINT_DIR/step2.pid"
+    log "PID : $pid"
+    log "Suivre : tail -f $logfile"
+    log "Quand termine, relance ce script pour passer a l'etape 3."
+
+    # On ne marque PAS step2 done ici (asynchrone). On verifie a la
+    # prochaine invocation.
+}
+
+step_2_check() {
+    if [ ! -f "$CHECKPOINT_DIR/step2.pid" ]; then return; fi
+    if step_pending "step2"; then
+        local pid
+        pid=$(cat "$CHECKPOINT_DIR/step2.pid")
+        if kill -0 "$pid" 2>/dev/null; then
+            log "Ingestion encore en cours (PID $pid). Patientez puis relancez."
+            exit 0
+        else
+            log "Ingestion terminee (PID $pid). Verification logs..."
+            local logfile
+            logfile=$(ls -1t "$LOG_DIR"/step2_ingest_*.log 2>/dev/null | head -1)
+            tail -20 "$logfile"
+            confirm "Marquer l'etape 2 comme done ?" && step_done "step2"
+        fi
+    fi
+}
+
+step_3_orphans() {
+    if ! step_pending "step3"; then log "step3 deja fait, skip"; return; fi
+    log "=== Etape 3 : cleanup orphelins ==="
+    confirm "Lancer delete_orphans.py en DRY-RUN ?" || return
+
+    cd "$VM_DIR"
+    export TS_HOST TS_PORT TS_API_KEY TS_COLLECTION
+
+    DRY_RUN=1 python3 delete_orphans.py 2>&1 | tee "$LOG_DIR/step3_dryrun_${TIMESTAMP}.log"
+
+    confirm "Lancer la suppression reelle des orphelins ?" || return
+    python3 delete_orphans.py 2>&1 | tee "$LOG_DIR/step3_real_${TIMESTAMP}.log"
+    step_done "step3"
+}
+
+step_4_idf() {
+    if ! step_pending "step4"; then log "step4 deja fait, skip"; return; fi
+    log "=== Etape 4 : regenerer IDF ==="
+    confirm "Generer idf_nom_produit.json sur Typesense GKE ?" || return
+
+    cd "$OPTI_FRONT_DIR"
+    docker compose exec -e TYPESENSE_HOST="$TS_HOST" \
+                        -e TYPESENSE_PORT="$TS_PORT" \
+                        -e TYPESENSE_API_KEY="$TS_API_KEY" \
+                        opti-moteur-front \
+                        python scripts/compute_idf.py \
+        2>&1 | tee "$LOG_DIR/step4_idf_${TIMESTAMP}.log"
+
+    if [ -f "$OPTI_FRONT_DIR/app/data/idf_nom_produit.json" ]; then
+        local size
+        size=$(du -h "$OPTI_FRONT_DIR/app/data/idf_nom_produit.json" | cut -f1)
+        log "IDF cree : $size"
+        docker compose restart opti-moteur-front
+        sleep 5
+        docker compose logs --tail 30 opti-moteur-front | grep -i "IDF" || true
+        step_done "step4"
+    else
+        err "idf_nom_produit.json non genere, voir log"
+        return 1
+    fi
+}
+
+step_5_synonyms() {
+    if ! step_pending "step5"; then log "step5 deja fait, skip"; return; fi
+    log "=== Etape 5 : verif synonymes ==="
+    local n_syn
+    n_syn=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION/synonyms" \
+                 -H "X-TYPESENSE-API-KEY: $TS_API_KEY" \
+            | jq -r '.synonyms | length // 0')
+    log "Synonymes Typesense GKE : $n_syn clusters"
+    if [ "$n_syn" -lt 100 ]; then
+        err "Synonymes anormalement bas. Lancer cote PHP :"
+        err "  php site/script/typesense/sync_synonyms_daily.php"
+    else
+        log "Synonymes OK"
+        step_done "step5"
+    fi
+}
+
+summary() {
+    log "=== Resume ==="
+    local docs_before docs_after
+    docs_before=$(cat "$CHECKPOINT_DIR/docs_before.txt" 2>/dev/null || echo "?")
+    docs_after=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION" \
+                      -H "X-TYPESENSE-API-KEY: $TS_API_KEY" \
+                 | jq -r '.num_documents // "?"')
+    log "Docs Typesense GKE : $docs_before -> $docs_after"
+    log ""
+    log "Etapes :"
+    for s in step1 step2 step3 step4 step5; do
+        if [ -f "$CHECKPOINT_DIR/$s.done" ]; then
+            log "  [OK] $s"
+        else
+            log "  [..] $s en attente"
+        fi
+    done
+    log ""
+    log "Pour reset checkpoints (refaire from scratch) :"
+    log "  rm -rf $CHECKPOINT_DIR"
+}
+
+# ========== MAIN ==========
+preflight
+step_2_check
+step_1_diff_categories
+step_2_ingest
+step_3_orphans
+step_4_idf
+step_5_synonyms
+summary


### PR DESCRIPTION
## Summary
- Procedure complete pour ingerer toutes les categories Milvus dans le Typesense GKE (`10.0.1.240:8570`)
- Wrapper bash `migrate_to_gke.sh` avec checkpoints (idempotent, resumable)
- Runbook detaille 7 etapes : diff categories, ingestion, orphelins, IDF, synonymes, smoke, bascule

## Pourquoi
Le Typesense GKE a recu une 1ere ingestion partielle. On finalise pour :
- Couvrir TOUTES les categories Milvus restantes
- Supprimer les orphelins (produits desactives dans Milvus mais encore en Typesense)
- Regenerer `idf_nom_produit.json` qui est actuellement **absent** sur la VM (verifie 22/05) — sans lui le reranker A4 IDF est inactif

## Alertes detectees
- `app/data/idf_nom_produit.json` absent sur VM -> task #11 ouvert
- `.env` VM ne contient pas TYPESENSE_* (seulement EMBEDDING_*) -> bloc a ajouter avant run

## Test plan
- [ ] Valider connectivite VM -> 10.0.1.240:8570 (Tafita si timeout)
- [ ] Ajouter bloc TYPESENSE_* dans `.env` VM (cf RUNBOOK section 'Pre-requis')
- [ ] Lancer `bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh`
- [ ] Smoke test final post-ingestion via `bench_production/smoke_test_bascule.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)