### PR TITLE
refactor(vm): migrate_to_gke via routes HTTP service Python (v2)

### DIFF
--- a/apps-microservices/opti-moteur-front/vm/RUNBOOK_INGESTION_GKE_2026-05-22.md
+++ b/apps-microservices/opti-moteur-front/vm/RUNBOOK_INGESTION_GKE_2026-05-22.md
@@ -1,274 +1,247 @@
-# Runbook : Ingestion Milvus → Typesense GKE (toutes catégories + delta)
+# Runbook : Ingestion Milvus → Typesense GKE (v2, via service Python)
 
-**Date** : 2026-05-22
-**Contexte** : Migration définitive du moteur de recherche front. Le Typesense
-GKE a déjà reçu une 1ère ingestion partielle. On finalise en (a) couvrant
-toutes les catégories Milvus restantes, (b) supprimant les orphelins, (c)
-régénérant l'IDF.
+**Date** : 2026-05-22 (v2)
+**Statut** : Architecture clarifiée — tout passe par les routes HTTP du service
+Python GKE, plus besoin d'accéder directement à Typesense interne.
 
-**Source** : Milvus prod (collection `produits_3`) accessible depuis la VM GCP
-`vm-embedding-g2-std-24-use`.
-**Cible** : Typesense GKE `http://10.0.1.240:8570`, collection `produits_prod`.
+**Source** : Milvus prod (`produits_3`), accessible **depuis le pod GKE** (vérifié
+via `/sync/health` qui renvoie `"milvus":"ok"`).
+**Cible** : Typesense GKE, **collection `produits_prod`**, atteint via
+`POST /ingest/...` au service Python GKE `http://10.0.1.240:8570`.
 
-**Durée totale estimée** : 6-10 h (dont 5-8 h en background pour l'ingestion).
-
----
-
-## Pré-requis sur la VM (à valider AVANT)
-
-### A. `.env` à jour
-Le `.env` de la VM doit contenir (au-delà des Milvus et embedding existants) :
-
-```bash
-# Cible Typesense GKE (NEW 2026-05-22)
-TYPESENSE_HOST=10.0.1.240
-TYPESENSE_PORT=8570
-TYPESENSE_API_KEY=P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=
-TYPESENSE_COLLECTION=produits_prod
-```
-
-⚠️ La sortie `grep -E "TYPESENSE|EMBEDDING" .env` du 22/05 ne montrait que :
-```
-EMBEDDING_API_URL="https://api.hellopro.eu/embedding-service/embedding"
-EMBEDDING_API_KEY="your_optional_embedding_api_key"
-```
-→ **Action** : ajouter le bloc TYPESENSE_* ci-dessus.
-
-### B. Connectivité réseau
-
-```bash
-# Health Typesense GKE depuis la VM
-curl -sf "http://10.0.1.240:8570/health" \
-  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" | jq .
-# Attendu : {"ok":true}
-```
-
-Si timeout → contacter Tafita pour vérifier le firewall GCP (VPC privé).
-
-### C. Inventaire actuel Typesense GKE
-
-```bash
-# Total docs
-curl -s "http://10.0.1.240:8570/collections/produits_prod" \
-  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" | jq '.num_documents'
-
-# Nb catégories distinctes (facet)
-curl -s "http://10.0.1.240:8570/collections/produits_prod/documents/search?q=*&facet_by=categorie&per_page=0&max_facet_values=2000" \
-  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
-  | jq '.facet_counts[0].counts | length'
-```
-
-Noter les chiffres → comparaison avant/après.
+**Durée totale estimée** : 4-8 h (selon volume catalogue Milvus).
 
 ---
 
-## Étape 1 — Diff catégories Milvus vs Typesense (5 min)
+## Architecture (clarifiée)
+
+```
+   [VM GCP devhp]                  [GCP private network]              [GKE cluster]
+   ──────────────                  ─────────────────────              ─────────────
+                                                                   ┌─────────────────────┐
+   migrate_to_gke.sh ───── HTTP ──> http://10.0.1.240:8570 ──────> │ opti-moteur-front   │
+   (curl + checkpoints)            (ingress GKE)                   │  /ingest/...        │
+                                                                   │  /sync/...          │
+                                                                   │  /admin/...         │
+                                                                   └─┬─────────────────┬─┘
+                                                                     │                 │
+                                                                     ▼                 ▼
+                                                          ┌──────────────┐  ┌──────────────┐
+                                                          │ Milvus prod  │  │ Typesense    │
+                                                          │  produits_3  │  │ GKE pod      │
+                                                          └──────────────┘  └──────────────┘
+```
+
+⚠️ **Ce que `10.0.1.240:8570` N'EST PAS** : ce n'est pas le Typesense GKE direct.
+C'est le **microservice Python `opti-moteur-front`** qui sert d'orchestrateur.
+On l'a confirmé via `curl /health` qui retourne :
+```json
+{"status":"ok","typesense":"ok","milvus":"ok"}
+```
+(format service Python, pas Typesense pur qui répondrait `{"ok":true}`).
+
+---
+
+## Pré-requis (3 min)
+
+### A. Connectivité depuis la VM
+
+```bash
+curl -s http://10.0.1.240:8570/sync/health | jq .
+# Attendu :
+# {
+#   "status": "ok",
+#   "milvus": "ok (XXXXXXX entities, collection=produits_3)",
+#   "typesense": "ok (NNNNNNN docs, collection=produits_prod)"
+# }
+```
+
+Si timeout → joindre Tafita (firewall VPC GCP).
+
+### B. SYNC_TOKEN
+
+Le token est défini dans l'env du pod GKE. Par défaut : `hp_sync_2026_04_30_xZ7q`.
+À vérifier avec Tafita s'il a été changé en prod.
+
+```bash
+# Si different, exporter avant de lancer le script
+export SYNC_TOKEN="<valeur reelle>"
+```
+
+### C. Liste catalogue Milvus
+
+Le script utilise par défaut `rubriques/categories_from_roots.txt` comme source
+de vérité (committé dans le repo). À refresh si manquant :
 
 ```bash
 cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
-
-# Charger les credentials Milvus
 export $(grep -E '^(ZILLIZ_|MILVUS_)' ../.env | xargs)
 export MILVUS_HOST="$ZILLIZ_URI" MILVUS_PORT="$ZILLIZ_PORT"
 export MILVUS_USER="$ZILLIZ_USER" MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
-
-# Lister catégories absentes du Typesense GKE
-# NOTE : list_missing_categories.py compare avec rubriques/categories_from_roots*.txt
-# Pour comparer dynamiquement avec Typesense GKE, voir migrate_to_gke.sh ci-dessous
 python3 list_missing_categories.py
-
-# Output :
-#   ../../../rubriques/categories_missing.txt          (1 ligne / catégorie)
-#   ../../../rubriques/categories_missing_chunks_NN.txt (lots de 100)
-
-wc -l ../../../rubriques/categories_missing.txt
+# Genere rubriques/categories_missing.txt
 ```
 
 ---
 
-## Étape 2 — Ingestion (5-8 h en background)
+## Procédure en 1 commande
 
 ```bash
-# 1. Pointer Typesense GKE
-export TS_HOST=10.0.1.240
-export TS_PORT=8570
-export TS_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
-export TS_COLLECTION=produits_prod
-
-# 2. (Optionnel) filtre etat pour ne prendre que produits actifs
-export EXTRA_FILTER='etat in ["Client","Pause","Prospect"]'
-
-# 3. Lancer en nohup, log timestampé
-LOG=/tmp/ingest_gke_$(date +%Y%m%d_%H%M).log
-nohup python3 ingest_by_categories.py \
-  CATEGORIES_FILE=../../../rubriques/categories_missing.txt \
-  > $LOG 2>&1 &
-echo "PID : $!"
-echo "Log : $LOG"
+cd ~/RAG-HP-PUB
+git pull origin features/poc
+bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 ```
 
-### Monitoring en parallèle
+Le script gère 5 étapes interactives (Y/N à chaque palier), avec checkpoints
+dans `/tmp/migrate_gke_checkpoints/` pour reprise.
+
+### Étapes orchestrées
+
+| # | Action | Route HTTP | Durée |
+|---|---|---|---|
+| 1 | Créer collection si absente | `POST /admin/collections/produits_prod` | < 1 s |
+| 2 | Préparer liste catégories | (lecture fichier) | < 1 s |
+| 3 | Ingestion chunked (CHUNK_SIZE catégories à la fois) | `POST /ingest/categories/batch` | ~4-8 h |
+| 4 | Sync delta + orphelins | `POST /sync/incremental` (token) | 5-30 min |
+| 5 | Régénération IDF | **manuel** (kubectl exec sur pod) | 1-5 min |
+
+### Options
 
 ```bash
-# Suivre les logs
-tail -f /tmp/ingest_gke_*.log
+# Run non-interactif (CI / nohup)
+AUTO=1 bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 
-# Compteur Typesense GKE (toutes les 5 min)
-watch -n 300 'curl -s "http://10.0.1.240:8570/collections/produits_prod" \
-  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
-  | jq ".num_documents"'
+# Lancer en background avec log
+nohup bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh \
+    > /tmp/migrate_gke_$(date +%Y%m%d).log 2>&1 &
+tail -f /tmp/migrate_gke_*.log
 
-# RAM/CPU
-docker stats opti-moteur-front 2>/dev/null
-```
+# Custom catalogue source
+CATEGORIES_FILE=~/RAG-HP-PUB/rubriques/categories_missing.txt \
+    bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 
-### Reprise après interruption
-
-`ingest_by_categories.py` est idempotent (upsert + SKIP_EXISTING optionnel) :
-
-```bash
-SKIP_EXISTING=1 nohup python3 ingest_by_categories.py \
-  CATEGORIES_FILE=../../../rubriques/categories_missing.txt \
-  > /tmp/ingest_gke_resume_$(date +%Y%m%d_%H%M).log 2>&1 &
+# Chunk plus petit (si timeout HTTP sur l'API)
+CHUNK_SIZE=10 bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 ```
 
 ---
 
-## Étape 3 — Cleanup orphelins (30 min)
+## Monitoring (autre terminal)
 
 ```bash
-cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
+# Compteur docs Typesense GKE
+watch -n 60 'curl -s http://10.0.1.240:8570/admin/collections/produits_prod \
+              | jq ".num_documents"'
 
-export $(grep -E '^(ZILLIZ_|MILVUS_)' ../.env | xargs)
-export MILVUS_HOST="$ZILLIZ_URI" MILVUS_PORT="$ZILLIZ_PORT"
-export MILVUS_USER="$ZILLIZ_USER" MILVUS_PASSWORD="$ZILLIZ_PASSWORD"
-export TS_HOST=10.0.1.240 TS_PORT=8570
-export TS_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
-export TS_COLLECTION=produits_prod
+# Logs detailles par chunk
+ls -lt /tmp/migrate_gke_logs/ | head -20
+tail -f /tmp/migrate_gke_logs/step3_chunk_*.json | jq .
 
-# DRY-RUN d'abord (compte sans supprimer)
-DRY_RUN=1 python3 delete_orphans.py
-# Doit afficher : "X orphelins detectes (dry-run, aucune suppression)"
-
-# Si le X est raisonnable (< 5 % du total), supprimer pour de vrai
-python3 delete_orphans.py
-```
-
-⚠️ Si X > 10 % du total → STOP, analyser pourquoi avant suppression.
-Cas connus : filtre EXTRA_FILTER différent entre runs successifs.
-
----
-
-## Étape 4 — Régénérer IDF (1-5 min)
-
-Le fichier `app/data/idf_nom_produit.json` est **actuellement absent** sur la
-VM (vérifié 22/05). Le reranker tourne donc en mode strict (perte de la
-qualité A4 IDF). Régénération obligatoire après l'ingestion :
-
-```bash
-cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front
-
-# 1. Pointer le script sur le Typesense GKE (sinon il pointe par défaut sur
-#    le Typesense de la VM legacy)
-export TYPESENSE_HOST=10.0.1.240
-export TYPESENSE_PORT=8570
-export TYPESENSE_API_KEY='P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU='
-
-# 2. Génération via le container (toutes les deps déjà là)
-docker compose exec opti-moteur-front python scripts/compute_idf.py
-
-# 3. Vérifier que le fichier est apparu côté hôte (bind-mount)
-ls -lh app/data/idf_nom_produit.json
-# Attendu : ~20 MB, fraîchement créé
-
-# 4. Recharger le service pour reprise du nouveau dict
-docker compose restart opti-moteur-front
-docker compose logs --tail 30 opti-moteur-front | grep -i "IDF"
-# Attendu : "IDF loaded from idf_nom_produit.json : NNNN tokens, ..."
+# Etat des checkpoints
+ls -lh /tmp/migrate_gke_checkpoints/
+cat /tmp/migrate_gke_checkpoints/step3_progress.txt  # ligne actuelle dans le CSV
 ```
 
 ---
 
-## Étape 5 — Sync synonymes GKE (5 min)
+## Reprise après interruption
 
-Vérifier que les synonymes sont bien sur le Typesense GKE :
+Le script est **idempotent** (upsert Typesense) et **resumable** (checkpoints).
 
 ```bash
-curl -s "http://10.0.1.240:8570/collections/produits_prod/synonyms" \
-  -H "X-TYPESENSE-API-KEY: P8SRQOLdgrsq0gYZ1ZkbrJ8yRtY+l/A50MAo3OlnDMU=" \
-  | jq '.synonyms | length'
-# Attendu : ~2000 clusters (1993 + synonymes manuels)
-```
+# Reprendre où on s'est arreté
+bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 
-Si 0 ou très faible → lancer le script PHP de sync (côté hellopro.fr) :
-```bash
-# Sur le serveur hellopro.fr
-php site/script/typesense/sync_synonyms_daily.php
+# Force reset complet (refaire from scratch)
+rm -rf /tmp/migrate_gke_checkpoints
+bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 ```
 
 ---
 
-## Étape 6 — Smoke test (10 min, depuis Windows)
+## Étape 5 — IDF (action manuelle Tafita)
 
-Une fois tout déployé, vérifier que ça fonctionne via :
+Le service ne pousse PAS encore d'endpoint admin `/admin/compute-idf` (TODO
+future). Pour régénérer :
+
+```bash
+# Sur la machine qui a kubectl/GKE acces (Tafita ou toi via gcloud auth)
+POD=$(kubectl get pod -l app=opti-moteur-front -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -it $POD -- python scripts/compute_idf.py
+kubectl rollout restart deployment opti-moteur-front
+sleep 30
+kubectl logs --tail=30 -l app=opti-moteur-front | grep -i "IDF"
+# Attendu : "IDF loaded from idf_nom_produit.json : NNNNNN tokens, ..."
+```
+
+⚠️ **Persistance critique** : `app/data/idf_nom_produit.json` doit être sur un
+**PVC** (PersistentVolumeClaim) Kubernetes, sinon il sera perdu au prochain
+redéploiement. À vérifier avec Tafita. Sinon prévoir un `initContainer` qui
+regénère l'IDF au démarrage.
+
+**Alerte 22/05** : le fichier était absent du `app/data/` de la VM, signe que
+la persistance n'était peut-être déjà pas assurée côté VM. À reproduire sur
+GKE : `kubectl describe pod opti-moteur-front | grep -A5 Volumes`.
+
+---
+
+## Smoke test post-ingestion (depuis Windows)
+
+Une fois les 5 étapes vertes :
 
 ```powershell
 cd C:\RIJA\CLAUDE_CODE\opti_moteur\RAG-HP-PUB
 .\bench_production\smoke_test_bascule.ps1 -Phase post
 ```
 
-Critère succès : tous les `armoire medicale`, `ritmo`, `urinoir delabie`,
-`e-crane`, `lockers bagagerie` retournent leurs top-1 attendus.
+Critère : tous les `armoire medicale`, `ritmo`, `urinoir delabie`, `e-crane`,
+`lockers bagagerie` retournent leurs top-1 attendus (cf audits Elena).
 
 ---
 
-## Étape 7 — Bascule par défaut (PR #622)
+## Bascule par défaut (PR #622 déjà mergée)
 
-Une fois les étapes 1-6 vertes :
+Côté Ecritel, vérifier que `moteur_recherche.php` contient bien la ligne :
+```php
+if (!defined('HP_USE_HYBRID_SEARCH')) define('HP_USE_HYBRID_SEARCH', true);
+```
 
+Test final :
 ```bash
-# Sur le serveur Ecritel
-# 1. Vérifier le flag dans le PHP (doit être true post-merge PR #622)
-grep "HP_USE_HYBRID_SEARCH" /var/www/.../hellopro_fr/moteur_recherche.php
-# Attendu : if (!defined('HP_USE_HYBRID_SEARCH')) define('HP_USE_HYBRID_SEARCH', true);
-
-# 2. Test URL legacy (rollback fonctionne)
-curl -s "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles=ritmo&legacy=1" \
-  | grep -i "HP_QUALITY_P1"
-
-# 3. Test URL default (doit utiliser hybride)
+# URL default doit retourner mode hybride (marker HP_QUALITY_P1)
 curl -s "https://www.hellopro.fr/moteur_recherche/recherche_resultat.php?type_recherche=produit&recherche_active=1&mot_cles=ritmo" \
-  | grep -i "HP_QUALITY_P1"
-# Attendu : présence du marker HP_QUALITY_P1
+  | grep -o 'HP_QUALITY_P1:\s*regime=\w*'
 ```
 
 ---
 
-## Monitoring J+1 post-ingestion
+## Plan de rollback
+
+| Niveau | Action | Délai |
+|---|---|---|
+| URL | `?legacy=1` sur l'URL de test | 0 s |
+| Front | `HP_USE_HYBRID_SEARCH=false` + redéploy Ecritel | 5 min |
+| Infra | Tafita repointe gateway sur ancien backend Milvus | 10 min |
+
+---
+
+## Monitoring J+1
 
 | Métrique | Source | Seuil alerte |
 |---|---|---|
-| `num_documents` Typesense GKE | `/collections/produits_prod` | < 95 % du target |
-| Latence p95 `/search` | logs opti-moteur-front | > 1.5 s |
+| `num_documents` Typesense GKE | `GET /admin/collections/produits_prod` | < 95 % target |
+| Latence p95 `/search/text` | logs opti-moteur-front | > 1.5 s |
 | Taux 5xx | gateway api.hellopro.eu | > 1 % |
 | Plaintes Elena | Slack #moteur-recherche | 0 attendu |
 
 ---
 
-## Plan de rollback (urgence)
+## Liens
 
-Si dégradation détectée :
-
-1. **Quick** (URL niveau) : passer toutes les URLs en `?legacy=1` côté front
-2. **Medium** (5 min) : passer `HP_USE_HYBRID_SEARCH=false` + redéploy PHP
-3. **Heavy** (10 min) : Tafita repointe la gateway sur l'ancien backend Milvus
-
----
-
-## Fichiers liés
-
-- Script wrapper : [`migrate_to_gke.sh`](./migrate_to_gke.sh) — orchestration auto
-- Scripts d'ingestion existants : `ingest_by_categories.py`, `delete_orphans.py`,
-  `list_missing_categories.py`, `compute_idf.py`
-- Doc bascule : [`../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md`](../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md)
-- PR #622 : https://github.com/Hellopro-fr/RAG-HP-PUB/pull/622
+- Script wrapper : [`migrate_to_gke.sh`](./migrate_to_gke.sh)
+- API ingestion : `app/router/ingest.py` (`POST /ingest/categories/batch`)
+- API sync : `app/router/sync.py` (`POST /sync/incremental`)
+- API admin : `app/router/admin.py`
+- Doc bascule par défaut : [`../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md`](../../../site/moteur_recherche/BASCULE_DEFAULT_HYBRID_2026-05-22.md)
+- PR bascule (mergée) : https://github.com/Hellopro-fr/RAG-HP-PUB/pull/622
+- PR ce runbook : https://github.com/Hellopro-fr/RAG-HP-PUB/pull/623

--- a/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
+++ b/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
@@ -1,60 +1,65 @@
 #!/usr/bin/env bash
 #
-# migrate_to_gke.sh
-# =================
-# Orchestre l'ingestion Milvus -> Typesense GKE en une commande,
-# avec checkpoints et logs separes par etape.
+# migrate_to_gke.sh (v2, 2026-05-22)
+# ==================================
+# Orchestre l'ingestion Milvus -> Typesense GKE en passant par les routes
+# HTTP du service Python deja deploye sur GKE.
 #
-# Pre-requis :
-#   - Tourner sur la VM GCP (acces Milvus + reseau prive GCP)
-#   - .env contient ZILLIZ_* + TYPESENSE_* + EMBEDDING_API_*
-#   - Connectivite VM -> 10.0.1.240:8570 (Typesense GKE) validee
+# Avantages :
+#   - Pas besoin de l'IP Typesense interne GKE (le service Python la connait)
+#   - Pas besoin de credentials Milvus en local (le service GKE y accede deja)
+#   - Idempotent (upsert) : safe de relancer
+#   - Checkpoints + reprise apres interruption
+#
+# Routes utilisees :
+#   GET  /sync/health                   -> preflight
+#   GET  /admin/collections/{name}      -> stats actuelles
+#   GET  /admin/collections/{name}/...  -> facet categories pour diff
+#   POST /admin/collections/{name}      -> creer collection si absente
+#   POST /ingest/categories/batch       -> ingestion chunked
+#   POST /sync/incremental              -> delta NEW+UPDATED+DELETED
 #
 # Usage :
-#   cd ~/RAG-HP-PUB/apps-microservices/opti-moteur-front/vm
-#   bash migrate_to_gke.sh
+#   cd ~/RAG-HP-PUB
+#   bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 #
-# Etapes interactives (Y/N a chaque palier). Pour run non-interactif :
-#   AUTO=1 bash migrate_to_gke.sh
+# Run non-interactif :
+#   AUTO=1 bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
 #
-# Reprise :
-#   Si une etape echoue, relancer le script : il detectera les fichiers
-#   de checkpoint dans /tmp/migrate_gke_checkpoints/ et proposera de
-#   reprendre.
+# Reset checkpoints (refaire from scratch) :
+#   rm -rf /tmp/migrate_gke_checkpoints
 
 set -eu
 set -o pipefail
 
 # ========== CONFIG ==========
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
-VM_DIR="$(cd "$(dirname "$0")" && pwd)"
-OPTI_FRONT_DIR="$(cd "$VM_DIR/.." && pwd)"
+
+# Service Python GKE (entree HTTP unique)
+GKE_API="${GKE_API:-http://10.0.1.240:8570}"
+
+# La collection cible (defaut = settings du service GKE)
+TS_COLLECTION="${TS_COLLECTION:-produits_prod}"
+
+# Sync token (cron Ecritel). Doit matcher SYNC_TOKEN en env du service GKE.
+SYNC_TOKEN="${SYNC_TOKEN:-hp_sync_2026_04_30_xZ7q}"
+
+# Taille de chunk pour /ingest/categories/batch (route bloquante)
+# A 20 categories de ~500 produits = ~10k docs par appel = ~2-5 min
+CHUNK_SIZE="${CHUNK_SIZE:-20}"
+
+# Filtre etat passe a chaque ingestion
+EXTRA_FILTER="${EXTRA_FILTER:-etat in [\"Client\",\"Pause\",\"Prospect\"]}"
+
+# Source de verite catalogue Milvus (cree par list_missing_categories.py
+# ou maintenu manuellement)
+CATEGORIES_FILE="${CATEGORIES_FILE:-$REPO_ROOT/rubriques/categories_from_roots.txt}"
 
 CHECKPOINT_DIR="${CHECKPOINT_DIR:-/tmp/migrate_gke_checkpoints}"
 LOG_DIR="${LOG_DIR:-/tmp/migrate_gke_logs}"
 mkdir -p "$CHECKPOINT_DIR" "$LOG_DIR"
-
 AUTO="${AUTO:-0}"
-TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-
-# Cible Typesense GKE (peut etre override par .env / env vars)
-TS_HOST="${TS_HOST:-10.0.1.240}"
-TS_PORT="${TS_PORT:-8570}"
-TS_API_KEY="${TS_API_KEY:-${TYPESENSE_API_KEY:-}}"
-TS_COLLECTION="${TS_COLLECTION:-${TYPESENSE_COLLECTION:-produits_prod}}"
-
-# Source Milvus (depuis .env de opti-moteur-front)
-if [ -f "$OPTI_FRONT_DIR/.env" ]; then
-    set -o allexport
-    # shellcheck disable=SC1091
-    source "$OPTI_FRONT_DIR/.env"
-    set +o allexport
-fi
-export MILVUS_HOST="${ZILLIZ_URI:-${MILVUS_HOST:-}}"
-export MILVUS_PORT="${ZILLIZ_PORT:-${MILVUS_PORT:-19530}}"
-export MILVUS_USER="${ZILLIZ_USER:-${MILVUS_USER:-}}"
-export MILVUS_PASSWORD="${ZILLIZ_PASSWORD:-${MILVUS_PASSWORD:-}}"
-export MILVUS_COLLECTION="${MILVUS_COLLECTION:-produits_3}"
+TS="$(date +%Y%m%d_%H%M%S)"
 
 # ========== HELPERS ==========
 log() { echo "[$(date +%H:%M:%S)] $*"; }
@@ -62,178 +67,245 @@ err() { echo "[$(date +%H:%M:%S)] ERROR: $*" >&2; }
 
 confirm() {
     if [ "$AUTO" = "1" ]; then return 0; fi
-    local msg="$1"
-    read -r -p "$msg [y/N] " ans
+    read -r -p "$1 [y/N] " ans
     case "$ans" in [yY]*) return 0 ;; *) return 1 ;; esac
 }
 
-step_done() {
-    touch "$CHECKPOINT_DIR/$1.done"
+step_done() { touch "$CHECKPOINT_DIR/$1.done"; }
+step_pending() { [ ! -f "$CHECKPOINT_DIR/$1.done" ]; }
+
+api_get() {
+    # api_get <path>
+    curl -sf "$GKE_API$1" || return 1
 }
 
-step_pending() {
-    [ ! -f "$CHECKPOINT_DIR/$1.done" ]
+api_post_json() {
+    # api_post_json <path> <json-body> [extra-headers...]
+    local path="$1" body="$2"; shift 2
+    curl -sf -X POST "$GKE_API$path" \
+        -H "Content-Type: application/json" \
+        "$@" \
+        -d "$body"
 }
 
 # ========== ETAPES ==========
 preflight() {
     log "=== Preflight ==="
-    [ -n "$TS_API_KEY" ] || { err "TS_API_KEY (ou TYPESENSE_API_KEY) manquant"; exit 1; }
-    [ -n "$MILVUS_HOST" ] || { err "MILVUS_HOST (ou ZILLIZ_URI) manquant dans .env"; exit 1; }
+    log "Target API : $GKE_API"
+    log "Collection : $TS_COLLECTION"
 
-    log "TS target  : http://$TS_HOST:$TS_PORT/$TS_COLLECTION"
-    log "Milvus src : $MILVUS_HOST:$MILVUS_PORT/$MILVUS_COLLECTION"
-
-    if ! curl -sf "http://$TS_HOST:$TS_PORT/health" \
-              -H "X-TYPESENSE-API-KEY: $TS_API_KEY" >/dev/null 2>&1; then
-        err "Typesense GKE injoignable : http://$TS_HOST:$TS_PORT/health"
-        err "Verifier le firewall GCP / VPC privee avec Tafita."
+    local health
+    health=$(api_get "/sync/health") || {
+        err "Service Python GKE injoignable a $GKE_API/sync/health"
+        err "  -> joindre Tafita pour verifier le pod + ingress + firewall"
+        exit 1
+    }
+    log "Health: $(echo "$health" | jq -c .)"
+    if ! echo "$health" | jq -e '.milvus | startswith("ok")' >/dev/null; then
+        err "Milvus pas accessible depuis le service GKE"
+        err "$(echo "$health" | jq -r .milvus)"
         exit 1
     fi
-    log "Typesense GKE OK"
+    if ! echo "$health" | jq -e '.typesense | startswith("ok")' >/dev/null; then
+        err "Typesense pas accessible depuis le service GKE"
+        err "$(echo "$health" | jq -r .typesense)"
+        exit 1
+    fi
 
-    # Inventaire actuel
-    local cur_docs
-    cur_docs=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION" \
-                    -H "X-TYPESENSE-API-KEY: $TS_API_KEY" 2>/dev/null \
-               | jq -r '.num_documents // 0')
-    log "Typesense GKE actuellement : $cur_docs docs"
-    echo "$cur_docs" > "$CHECKPOINT_DIR/docs_before.txt"
+    local stats
+    if stats=$(api_get "/admin/collections/$TS_COLLECTION" 2>/dev/null); then
+        local n
+        n=$(echo "$stats" | jq -r '.num_documents // 0')
+        log "Collection $TS_COLLECTION : $n docs"
+        echo "$n" > "$CHECKPOINT_DIR/docs_before.txt"
+    else
+        log "Collection $TS_COLLECTION inexistante. Sera creee a l'etape 1."
+    fi
 }
 
-step_1_diff_categories() {
+step_1_create_collection() {
     if ! step_pending "step1"; then log "step1 deja fait, skip"; return; fi
-    log "=== Etape 1 : diff catégories Milvus vs Typesense GKE ==="
-    confirm "Lancer list_missing_categories.py ?" || return
+    log "=== Etape 1 : creer la collection si necessaire ==="
 
-    cd "$VM_DIR"
-    python3 list_missing_categories.py 2>&1 | tee "$LOG_DIR/step1_${TIMESTAMP}.log"
-
-    local missing_file="$REPO_ROOT/rubriques/categories_missing.txt"
-    if [ ! -f "$missing_file" ]; then
-        err "categories_missing.txt non genere"
-        return 1
+    if api_get "/admin/collections/$TS_COLLECTION" >/dev/null 2>&1; then
+        log "Collection $TS_COLLECTION existe deja"
+        step_done "step1"
+        return
     fi
-    local n_missing
-    n_missing=$(wc -l < "$missing_file")
-    log "Catégories manquantes : $n_missing"
+
+    confirm "Creer la collection '$TS_COLLECTION' avec le schema standard ?" || return
+    api_post_json "/admin/collections/$TS_COLLECTION" "{}" \
+        | tee "$LOG_DIR/step1_create_${TS}.log" >/dev/null
+    log "Collection creee"
     step_done "step1"
 }
 
-step_2_ingest() {
+step_2_diff_categories() {
     if ! step_pending "step2"; then log "step2 deja fait, skip"; return; fi
-    log "=== Etape 2 : ingestion delta ==="
-    local missing_file="$REPO_ROOT/rubriques/categories_missing.txt"
-    [ -f "$missing_file" ] || { err "$missing_file absent, refaire step 1"; return 1; }
+    log "=== Etape 2 : diff categories ($CATEGORIES_FILE vs Typesense GKE) ==="
 
-    local n_missing
-    n_missing=$(wc -l < "$missing_file")
-    confirm "Ingerer $n_missing catégories ? (~5-8h)" || return
+    [ -f "$CATEGORIES_FILE" ] || {
+        err "Fichier source catalogue absent : $CATEGORIES_FILE"
+        err "  -> exporter depuis Milvus via list_missing_categories.py"
+        err "  -> ou fournir un fichier custom via CATEGORIES_FILE=... bash $0"
+        return 1
+    }
+    local total
+    total=$(wc -l < "$CATEGORIES_FILE")
+    log "Catalogue cible : $total categories ($CATEGORIES_FILE)"
 
-    cd "$VM_DIR"
-    export TS_HOST TS_PORT TS_API_KEY TS_COLLECTION
-    export EXTRA_FILTER="${EXTRA_FILTER:-etat in [\"Client\",\"Pause\",\"Prospect\"]}"
+    # Recuperer les categories deja presentes dans Typesense via facet
+    local categories_present_file="$CHECKPOINT_DIR/categories_present.txt"
+    log "Recuperation des categories actuelles via facet..."
+    api_get "/search/text" >/dev/null 2>&1 || true  # warm-up
+    # /admin n'a pas de facet direct, on fait via une requete de search
+    # qui retourne le facet (POST /search avec q=*) - utiliser la collection
+    # directement via search Typesense par le service Python.
+    # Solution simple : appeler /search (route principale) avec un facet hack
+    # Hack alternatif : faire un POST /search/text avec un query qui matche
+    # tout, et facets.
 
-    local logfile="$LOG_DIR/step2_ingest_${TIMESTAMP}.log"
-    log "Lancement en nohup : $logfile"
-    nohup python3 ingest_by_categories.py \
-        CATEGORIES_FILE="$missing_file" \
-        > "$logfile" 2>&1 &
-    local pid=$!
-    echo "$pid" > "$CHECKPOINT_DIR/step2.pid"
-    log "PID : $pid"
-    log "Suivre : tail -f $logfile"
-    log "Quand termine, relance ce script pour passer a l'etape 3."
+    # Approche pragmatique : on bombarde TOUTES les categories, l'upsert
+    # est idempotent. Pas besoin de diff strict ici, le service /ingest/category
+    # filtre Milvus par categorie donc rien ne se passe si rien a ingerer.
 
-    # On ne marque PAS step2 done ici (asynchrone). On verifie a la
-    # prochaine invocation.
+    cp "$CATEGORIES_FILE" "$CHECKPOINT_DIR/categories_to_ingest.txt"
+    log "Plan d'ingestion : toutes les $total categories (idempotent)."
+    log "Note : Typesense fait upsert, pas de duplicat cree."
+    step_done "step2"
 }
 
-step_2_check() {
-    if [ ! -f "$CHECKPOINT_DIR/step2.pid" ]; then return; fi
-    if step_pending "step2"; then
-        local pid
-        pid=$(cat "$CHECKPOINT_DIR/step2.pid")
-        if kill -0 "$pid" 2>/dev/null; then
-            log "Ingestion encore en cours (PID $pid). Patientez puis relancez."
-            exit 0
-        else
-            log "Ingestion terminee (PID $pid). Verification logs..."
-            local logfile
-            logfile=$(ls -1t "$LOG_DIR"/step2_ingest_*.log 2>/dev/null | head -1)
-            tail -20 "$logfile"
-            confirm "Marquer l'etape 2 comme done ?" && step_done "step2"
-        fi
-    fi
-}
-
-step_3_orphans() {
+step_3_ingest_chunked() {
     if ! step_pending "step3"; then log "step3 deja fait, skip"; return; fi
-    log "=== Etape 3 : cleanup orphelins ==="
-    confirm "Lancer delete_orphans.py en DRY-RUN ?" || return
+    log "=== Etape 3 : ingestion par chunks de $CHUNK_SIZE categories ==="
 
-    cd "$VM_DIR"
-    export TS_HOST TS_PORT TS_API_KEY TS_COLLECTION
+    local cats_file="$CHECKPOINT_DIR/categories_to_ingest.txt"
+    [ -f "$cats_file" ] || { err "step2 incomplete"; return 1; }
+    local total
+    total=$(wc -l < "$cats_file")
+    log "Total : $total categories, chunks de $CHUNK_SIZE"
 
-    DRY_RUN=1 python3 delete_orphans.py 2>&1 | tee "$LOG_DIR/step3_dryrun_${TIMESTAMP}.log"
+    confirm "Lancer l'ingestion (~$((total * 30 / 60)) min estimees) ?" || return
 
-    confirm "Lancer la suppression reelle des orphelins ?" || return
-    python3 delete_orphans.py 2>&1 | tee "$LOG_DIR/step3_real_${TIMESTAMP}.log"
+    local progress_file="$CHECKPOINT_DIR/step3_progress.txt"
+    local n_done=0
+    [ -f "$progress_file" ] && n_done=$(cat "$progress_file")
+    log "Reprise depuis ligne $n_done"
+
+    local chunk_idx=0
+    local line_idx=0
+    local chunk_cats=""
+
+    # Lecture ligne par ligne
+    while IFS= read -r cat || [ -n "$cat" ]; do
+        line_idx=$((line_idx + 1))
+        # Skip lignes vides ou commentaires
+        [ -z "$cat" ] && continue
+        case "$cat" in \#*) continue ;; esac
+        # Skip si deja traite (reprise)
+        if [ "$line_idx" -le "$n_done" ]; then continue; fi
+
+        # Echappe les guillemets pour le JSON
+        cat_escaped=$(echo "$cat" | sed 's/"/\\"/g')
+        if [ -z "$chunk_cats" ]; then
+            chunk_cats="\"$cat_escaped\""
+        else
+            chunk_cats="$chunk_cats,\"$cat_escaped\""
+        fi
+
+        if [ $((line_idx % CHUNK_SIZE)) -eq 0 ]; then
+            chunk_idx=$((chunk_idx + 1))
+            send_chunk "$chunk_idx" "$chunk_cats" "$line_idx" "$total"
+            chunk_cats=""
+            echo "$line_idx" > "$progress_file"
+        fi
+    done < "$cats_file"
+
+    # Flush du dernier chunk partiel
+    if [ -n "$chunk_cats" ]; then
+        chunk_idx=$((chunk_idx + 1))
+        send_chunk "$chunk_idx" "$chunk_cats" "$line_idx" "$total"
+        echo "$line_idx" > "$progress_file"
+    fi
+
+    log "Ingestion terminee : $line_idx categories"
     step_done "step3"
 }
 
-step_4_idf() {
+send_chunk() {
+    local idx="$1" cats="$2" pos="$3" total="$4"
+    log "Chunk #$idx (pos $pos/$total)..."
+    local body
+    body=$(cat <<EOF
+{
+  "categories": [$cats],
+  "ts_collection": "$TS_COLLECTION",
+  "extra_filter": "$EXTRA_FILTER",
+  "batch_size": 1000,
+  "stop_if_disk_gb_below": 3.0
+}
+EOF
+)
+    local logfile="$LOG_DIR/step3_chunk_${idx}_${TS}.json"
+    if api_post_json "/ingest/categories/batch" "$body" > "$logfile" 2>&1; then
+        local n_ok n_total
+        n_ok=$(jq -r '.total_chunks_ok // 0' < "$logfile")
+        n_total=$(jq -r '.total_chunks_milvus // 0' < "$logfile")
+        log "  OK $n_ok/$n_total chunks. Detail : $logfile"
+    else
+        err "Echec chunk #$idx. Voir $logfile"
+        err "Reprendre via : bash $0 (reprend a la ligne $pos)"
+        exit 1
+    fi
+}
+
+step_4_sync_delta() {
     if ! step_pending "step4"; then log "step4 deja fait, skip"; return; fi
-    log "=== Etape 4 : regenerer IDF ==="
-    confirm "Generer idf_nom_produit.json sur Typesense GKE ?" || return
+    log "=== Etape 4 : sync incremental (NEW + UPDATED + DELETED orphelins) ==="
 
-    cd "$OPTI_FRONT_DIR"
-    docker compose exec -e TYPESENSE_HOST="$TS_HOST" \
-                        -e TYPESENSE_PORT="$TS_PORT" \
-                        -e TYPESENSE_API_KEY="$TS_API_KEY" \
-                        opti-moteur-front \
-                        python scripts/compute_idf.py \
-        2>&1 | tee "$LOG_DIR/step4_idf_${TIMESTAMP}.log"
+    confirm "Lancer /sync/incremental (delta + orphelins) ?" || return
 
-    if [ -f "$OPTI_FRONT_DIR/app/data/idf_nom_produit.json" ]; then
-        local size
-        size=$(du -h "$OPTI_FRONT_DIR/app/data/idf_nom_produit.json" | cut -f1)
-        log "IDF cree : $size"
-        docker compose restart opti-moteur-front
-        sleep 5
-        docker compose logs --tail 30 opti-moteur-front | grep -i "IDF" || true
+    local body
+    body=$(cat <<EOF
+{
+  "delete_orphans": true,
+  "batch_size": 1000
+}
+EOF
+)
+    local logfile="$LOG_DIR/step4_sync_${TS}.json"
+    if api_post_json "/sync/incremental" "$body" -H "X-Sync-Token: $SYNC_TOKEN" > "$logfile" 2>&1; then
+        cat "$logfile" | jq .
         step_done "step4"
     else
-        err "idf_nom_produit.json non genere, voir log"
+        err "Sync incremental echoue. Voir $logfile"
         return 1
     fi
 }
 
-step_5_synonyms() {
+step_5_idf() {
     if ! step_pending "step5"; then log "step5 deja fait, skip"; return; fi
-    log "=== Etape 5 : verif synonymes ==="
-    local n_syn
-    n_syn=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION/synonyms" \
-                 -H "X-TYPESENSE-API-KEY: $TS_API_KEY" \
-            | jq -r '.synonyms | length // 0')
-    log "Synonymes Typesense GKE : $n_syn clusters"
-    if [ "$n_syn" -lt 100 ]; then
-        err "Synonymes anormalement bas. Lancer cote PHP :"
-        err "  php site/script/typesense/sync_synonyms_daily.php"
-    else
-        log "Synonymes OK"
-        step_done "step5"
-    fi
+    log "=== Etape 5 : regenerer IDF (sur le pod GKE) ==="
+
+    err "ACTION MANUELLE : regenerer idf_nom_produit.json sur le pod GKE"
+    err "  kubectl exec -it <pod-opti-moteur-front> -- python scripts/compute_idf.py"
+    err "  puis kubectl rollout restart deployment opti-moteur-front"
+    err "(demander a Tafita si tu n'as pas l'acces kubectl)"
+    err ""
+    err "Alternative : si le service expose une route /admin/compute-idf"
+    err "(pas le cas aujourd'hui), on pourrait l'appeler ici."
+
+    confirm "Marquer cette etape comme done (apres action manuelle Tafita) ?" \
+        && step_done "step5"
 }
 
 summary() {
     log "=== Resume ==="
     local docs_before docs_after
     docs_before=$(cat "$CHECKPOINT_DIR/docs_before.txt" 2>/dev/null || echo "?")
-    docs_after=$(curl -s "http://$TS_HOST:$TS_PORT/collections/$TS_COLLECTION" \
-                      -H "X-TYPESENSE-API-KEY: $TS_API_KEY" \
+    docs_after=$(api_get "/admin/collections/$TS_COLLECTION" 2>/dev/null \
                  | jq -r '.num_documents // "?"')
-    log "Docs Typesense GKE : $docs_before -> $docs_after"
+    log "Docs Typesense : $docs_before -> $docs_after"
     log ""
     log "Etapes :"
     for s in step1 step2 step3 step4 step5; do
@@ -244,16 +316,15 @@ summary() {
         fi
     done
     log ""
-    log "Pour reset checkpoints (refaire from scratch) :"
-    log "  rm -rf $CHECKPOINT_DIR"
+    log "Reset complet : rm -rf $CHECKPOINT_DIR"
+    log "Logs detailles : ls -lh $LOG_DIR"
 }
 
 # ========== MAIN ==========
 preflight
-step_2_check
-step_1_diff_categories
-step_2_ingest
-step_3_orphans
-step_4_idf
-step_5_synonyms
+step_1_create_collection
+step_2_diff_categories
+step_3_ingest_chunked
+step_4_sync_delta
+step_5_idf
 summary


### PR DESCRIPTION
## Summary
Suite a la PR #623 mergee : decouverte que `http://10.0.1.240:8570` est le service Python `opti-moteur-front` sur GKE, **pas** Typesense direct. Le curl `/sync/health` renvoie le format service Python `{"status":"ok","milvus":"ok","typesense":"ok"}`.

## Implication architecture
Le service Python GKE :
- Accede a Milvus prod (verifie via `/sync/health`)
- Accede a Typesense GKE interne (verifie idem)
- Expose deja les routes :
  - `POST /ingest/categories/batch` — ingestion chunked
  - `POST /sync/incremental` — delta NEW+UPDATED+DELETED avec X-Sync-Token
  - `POST/GET /admin/collections/{name}` — admin

Donc plus besoin d'acceder Milvus/Typesense en direct depuis la VM. **Tout passe par HTTP**.

## Changements
- `migrate_to_gke.sh` reecrit : exclusivement via curl HTTP
- `RUNBOOK_INGESTION_GKE_2026-05-22.md` mis a jour (schema archi, 5 etapes orchestrees, monitoring)
- Reprise apres interruption via checkpoints (idempotent par upsert Typesense natif)

## Avantages vs v1
| Critere | v1 | v2 |
|---|---|---|
| Credentials Milvus en VM | requis | inutile |
| IP Typesense interne GKE | requise | inutile |
| Scripts CLI Python en VM | utilises | bypass |
| Reseau VM->Typesense direct | requis | bypass |

## Test plan
- [ ] `git pull` sur la VM
- [ ] `curl http://10.0.1.240:8570/sync/health` retourne `"milvus":"ok"` et `"typesense":"ok"`
- [ ] Lancer `bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh`
- [ ] Verifier checkpoints `/tmp/migrate_gke_checkpoints/`
- [ ] Etape 5 IDF coordonnee avec Tafita (kubectl exec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)