### PR TITLE
fix(vm): migrate_to_gke utilise /health au lieu de /sync/health

### DIFF
--- a/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
+++ b/apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh
@@ -94,21 +94,46 @@ preflight() {
     log "Target API : $GKE_API"
     log "Collection : $TS_COLLECTION"
 
+    # On utilise /health (main.py) qui est universel : format
+    # {"status":"ok","typesense":"ok","milvus":"ok"}
+    # /sync/health donne plus de detail mais peut etre absent sur d'anciennes
+    # versions deployees sur GKE.
     local health
-    health=$(api_get "/sync/health") || {
-        err "Service Python GKE injoignable a $GKE_API/sync/health"
+    health=$(api_get "/health") || {
+        err "Service Python GKE injoignable a $GKE_API/health"
         err "  -> joindre Tafita pour verifier le pod + ingress + firewall"
         exit 1
     }
     log "Health: $(echo "$health" | jq -c .)"
-    if ! echo "$health" | jq -e '.milvus | startswith("ok")' >/dev/null; then
-        err "Milvus pas accessible depuis le service GKE"
+    if ! echo "$health" | jq -e '.milvus == "ok"' >/dev/null; then
+        err "Milvus pas OK depuis le service GKE"
         err "$(echo "$health" | jq -r .milvus)"
         exit 1
     fi
-    if ! echo "$health" | jq -e '.typesense | startswith("ok")' >/dev/null; then
-        err "Typesense pas accessible depuis le service GKE"
+    if ! echo "$health" | jq -e '.typesense == "ok"' >/dev/null; then
+        err "Typesense pas OK depuis le service GKE"
         err "$(echo "$health" | jq -r .typesense)"
+        exit 1
+    fi
+
+    # Verifier que les routes admin/ingest/sync sont bien deployees
+    # (image GKE potentiellement plus ancienne que le code repo).
+    log "Verification des routes deployees..."
+    local routes_ok=1
+    for route in "/admin/collections" "/ingest/category"; do
+        if curl -sf -o /dev/null -w "%{http_code}" "$GKE_API$route" 2>&1 \
+           | grep -qE "^(200|405|422)"; then
+            log "  OK $route"
+        else
+            err "  KO $route (route absente ou erreur)"
+            routes_ok=0
+        fi
+    done
+    if [ "$routes_ok" -eq 0 ]; then
+        err "L'image GKE n'expose pas toutes les routes attendues."
+        err "  -> Tafita doit redeployer avec l'image actuelle (features/poc HEAD)"
+        err "  -> En attendant, voir routes dispo via :"
+        err "     curl $GKE_API/openapi.json | jq '.paths | keys'"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Suite a la PR #624 mergee : test sur la VM a revele que `/sync/health` retourne erreur sur le GKE actuellement deploye. Probable cause : l'image GKE en prod est plus ancienne que le code repo et n'inclut pas encore le sync router.

## Fix

- Utiliser `/health` (defini dans main.py, toujours present, deja confirme OK par curl de la VM)
- Ajouter verification preflight des routes `/admin/collections` et `/ingest/category` pour detecter une image GKE obsolete avant de lancer l'ingestion
- Message d'erreur explicite avec hint pour redeploiement Tafita

## Test plan

- [ ] `git pull` sur la VM
- [ ] `curl http://10.0.1.240:8570/openapi.json | jq '.paths | keys[]'` pour voir routes vraiment exposees
- [ ] Si `/ingest/*` ou `/sync/*` manquent -> Tafita redeploye
- [ ] Sinon : relancer `bash apps-microservices/opti-moteur-front/vm/migrate_to_gke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)