### PR TITLE
feat(admin): route POST /admin/compute-idf + cron PHP hebdo

### DIFF
--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -329,6 +329,53 @@ Pages 2-4 (AJAX background)
     └── hp_classify_and_alternate_docs (avec exclude_low=$_strict_p2)
 ```
 
+## Regeneration IDF (industrialisee 2026-05-22)
+
+Le dict IDF doit etre regenere apres :
+- Une ingestion massive de nouvelles categories
+- Une evolution naturelle du catalogue (recommande : hebdomadaire)
+
+### Route HTTP self-service (NEW 2026-05-22)
+
+```bash
+# Trigger en background (~2-5 min, retour immediat)
+curl -X POST "https://api.hellopro.eu/optimoteur-service/admin/compute-idf" \
+  -H "X-Admin-Token: hp_admin_2026_05_22_xZ7q" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+# -> {"status":"started","collection":"produits_prod","note":"..."}
+
+# Suivi de l'avancement
+curl "https://api.hellopro.eu/optimoteur-service/admin/compute-idf/status"
+# -> {"status":"running","started_at":"...","finished_at":null,...}
+# Puis quand fini :
+# -> {"status":"ok","duration_s":127.3,"stdout_tail":"...","returncode":0,...}
+```
+
+Optionnel : passer `?collection=produits_prod_v2` pour cibler une autre collection.
+
+### Cron PHP hebdomadaire
+
+`site/script/typesense/compute_idf_weekly.php` est appele 1x/semaine
+(dimanche 4h, apres le sync quotidien synonymes 3h30). Il :
+- Verifie qu'aucune regen n'est en cours (via /admin/compute-idf/status)
+- POST sur /admin/compute-idf avec le X-Admin-Token
+- Logge le resultat (status + duree)
+
+Configurer cron Ecritel :
+```
+0 4 * * 0 wget -qO- "https://script.hellopro.fr/script/typesense/compute_idf_weekly.php?token=hp_idfcron_2026_05_22_xZ7q"
+```
+
+### CLI (toujours dispo, via kubectl exec sur le pod)
+
+```bash
+# Sur la machine qui a kubectl + GKE auth
+POD=$(kubectl get pod -l app=opti-moteur-front -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -it $POD -- python scripts/compute_idf.py
+kubectl rollout restart deployment opti-moteur-front
+```
+
 ## Rollback Milvus (procedure d'urgence)
 
 Depuis 2026-05-22, le pipeline hybride (Solr V2 + Typesense) est le **defaut**

--- a/apps-microservices/opti-moteur-front/app/core/credentials.py
+++ b/apps-microservices/opti-moteur-front/app/core/credentials.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
     # --- Service ---
     SERVICE_PORT: int = 8570
 
+    # --- Admin (routes d'administration sensibles : compute-idf, etc.) ---
+    # Token jetable en header X-Admin-Token. A changer en prod via env var.
+    ADMIN_TOKEN: str = "hp_admin_2026_05_22_xZ7q"
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/apps-microservices/opti-moteur-front/app/router/admin.py
+++ b/apps-microservices/opti-moteur-front/app/router/admin.py
@@ -1,14 +1,24 @@
 """Routes d'administration Typesense."""
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from app.core.credentials import settings
 from app.core.typesense_client import typesense_client
 from app.services.synonyms_service import auto_generate_synonyms
+from app.services import idf_service
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+def _check_admin_token(x_admin_token: Optional[str]) -> None:
+    """Verifie le header X-Admin-Token. Raise 403 si invalide."""
+    if not x_admin_token or x_admin_token != settings.ADMIN_TOKEN:
+        raise HTTPException(
+            status_code=403,
+            detail="Missing or invalid X-Admin-Token header",
+        )
 
 
 class SynonymRequest(BaseModel):
@@ -121,6 +131,56 @@ def delete_synonym(synonym_id: str, collection: Optional[str] = None):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
+# ---------- IDF (regeneration en background) ----------
+
+@router.post(
+    "/compute-idf",
+    summary="Regenerer le dict IDF en background (compute_idf.py + reload)",
+)
+def admin_compute_idf(
+    background_tasks: BackgroundTasks,
+    collection: Optional[str] = None,
+    x_admin_token: Optional[str] = Header(None, description="Token jetable"),
+):
+    """
+    Lance `scripts/compute_idf.py` en background pour regenerer
+    `app/data/idf_nom_produit.json` puis recharger le cache IDF en RAM.
+
+    Securite : header `X-Admin-Token` requis.
+    Duree typique : 2-5 min sur 2M docs.
+    Pour suivre l'avancement : `GET /admin/compute-idf/status`.
+
+    A appeler :
+      - Manuellement apres une ingestion massive (cf migrate_to_gke.sh)
+      - Automatiquement chaque semaine via cron PHP `compute_idf_weekly.php`
+    """
+    _check_admin_token(x_admin_token)
+
+    if idf_service.is_running():
+        raise HTTPException(
+            status_code=429,
+            detail="A regeneration is already running. See GET /admin/compute-idf/status",
+        )
+
+    background_tasks.add_task(idf_service.regenerate_idf_background, collection)
+    return {
+        "status": "started",
+        "collection": collection or settings.TYPESENSE_COLLECTION,
+        "note": "Run in background, ~2-5 min. Poll GET /admin/compute-idf/status",
+    }
+
+
+@router.get(
+    "/compute-idf/status",
+    summary="Statut de la derniere regeneration IDF",
+)
+def admin_compute_idf_status():
+    """Retourne l'etat de la derniere regeneration : never_run/running/ok/error."""
+    return idf_service.get_state()
+
+
+# ---------- Synonymes auto-generation ----------
 
 @router.post(
     "/synonyms/auto-generate",

--- a/apps-microservices/opti-moteur-front/app/services/idf_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/idf_service.py
@@ -1,0 +1,149 @@
+"""
+Service de regeneration IDF.
+============================
+
+Orchestration de la regeneration du fichier `app/data/idf_nom_produit.json`
+via le script `scripts/compute_idf.py`, avec reload du dict en RAM apres
+generation.
+
+Utilise par :
+  - app/router/admin.py :: POST /admin/compute-idf (background task)
+  - site/script/typesense/compute_idf_weekly.php (cron PHP hebdomadaire)
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Optional, Dict, Any
+
+from app.core.credentials import settings
+
+logger = logging.getLogger(__name__)
+
+
+# Chemins (resolus au runtime, marchent depuis container Docker ET hote)
+#   app/services/idf_service.py -> app/ -> root opti-moteur-front
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT_PATH = _SERVICE_ROOT / "scripts" / "compute_idf.py"
+_OUT_PATH = _SERVICE_ROOT / "app" / "data" / "idf_nom_produit.json"
+
+
+# Etat global (suivi des regenerations)
+_lock = Lock()
+_state: Dict[str, Any] = {
+    "status": "never_run",      # never_run | running | ok | error | exception
+    "started_at": None,         # ISO datetime
+    "finished_at": None,
+    "duration_s": None,
+    "collection": None,
+    "returncode": None,
+    "stdout_tail": None,
+    "stderr_tail": None,
+    "error": None,
+}
+
+
+def regenerate_idf_sync(collection: Optional[str] = None,
+                        timeout_s: int = 900) -> Dict[str, Any]:
+    """
+    Lance compute_idf.py en subprocess (bloquant).
+
+    Args:
+        collection: collection Typesense source (default = settings.TYPESENSE_COLLECTION).
+        timeout_s: timeout du subprocess (default 15 min, large pour 5M+ docs).
+
+    Returns:
+        dict avec status, returncode, stdout_tail, stderr_tail, duration_s.
+
+    Effet de bord : ecrit `app/data/idf_nom_produit.json`.
+    Le caller est responsable de recharger le cache idf_loader si besoin.
+    """
+    coll = collection or settings.TYPESENSE_COLLECTION
+    cmd = [sys.executable, str(_SCRIPT_PATH), "--collection", coll]
+    logger.info("Running: %s", " ".join(cmd))
+    t0 = datetime.now(timezone.utc)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            cwd=str(_SERVICE_ROOT),
+        )
+        duration = (datetime.now(timezone.utc) - t0).total_seconds()
+        return {
+            "status": "ok" if result.returncode == 0 else "error",
+            "returncode": result.returncode,
+            "duration_s": round(duration, 1),
+            "stdout_tail": (result.stdout or "")[-2000:],
+            "stderr_tail": (result.stderr or "")[-2000:],
+        }
+    except subprocess.TimeoutExpired as e:
+        duration = (datetime.now(timezone.utc) - t0).total_seconds()
+        return {
+            "status": "error",
+            "returncode": -1,
+            "duration_s": round(duration, 1),
+            "stdout_tail": (e.stdout or "")[-2000:] if e.stdout else "",
+            "stderr_tail": f"TIMEOUT after {timeout_s}s",
+        }
+
+
+def regenerate_idf_background(collection: Optional[str] = None) -> None:
+    """
+    Wrapper utilise par FastAPI BackgroundTasks :
+      1. Met a jour _state -> "running"
+      2. Lance regenerate_idf_sync()
+      3. Reload du cache idf_loader (force lazy reload au prochain get_idf)
+      4. Met a jour _state -> "ok" / "error" / "exception"
+
+    Thread-safe : protege par lock pour eviter 2 regen concurrentes.
+    """
+    with _lock:
+        _state["status"] = "running"
+        _state["collection"] = collection or settings.TYPESENSE_COLLECTION
+        _state["started_at"] = datetime.now(timezone.utc).isoformat()
+        _state["finished_at"] = None
+        _state["error"] = None
+
+    try:
+        result = regenerate_idf_sync(collection)
+        with _lock:
+            _state["returncode"] = result["returncode"]
+            _state["duration_s"] = result["duration_s"]
+            _state["stdout_tail"] = result["stdout_tail"]
+            _state["stderr_tail"] = result["stderr_tail"]
+            _state["status"] = result["status"]
+            _state["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+        if result["status"] == "ok":
+            # Reset cache du loader : force reload au prochain get_idf()
+            try:
+                from app.services import idf_loader
+                idf_loader.reset_cache_for_test()
+                # Trigger le reload tout de suite pour logger la stat
+                idf_loader.idf_available()
+                logger.info("IDF cache reset + reloaded successfully")
+            except Exception as e:
+                logger.warning("Could not reset IDF cache: %s", e)
+
+    except Exception as e:
+        logger.exception("regenerate_idf_background failed unexpectedly")
+        with _lock:
+            _state["status"] = "exception"
+            _state["error"] = str(e)
+            _state["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+
+def get_state() -> Dict[str, Any]:
+    """Retourne un snapshot de l'etat actuel (lecture, thread-safe)."""
+    with _lock:
+        return dict(_state)
+
+
+def is_running() -> bool:
+    return get_state()["status"] == "running"

--- a/site/script/typesense/compute_idf_weekly.php
+++ b/site/script/typesense/compute_idf_weekly.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * =============================================================================
+ * compute_idf_weekly.php
+ * -----------------------------------------------------------------------------
+ * Script cron HEBDOMADAIRE : trigger la regeneration du dict IDF Typesense
+ * sur le service GKE opti-moteur-front. Le service lance compute_idf.py en
+ * background task (FastAPI) et recharge le cache idf_loader en RAM apres.
+ *
+ * Pattern : meme que sync_synonyms_daily.php (curl HTTP vers service GKE).
+ *
+ * URL appelee (cron Ecritel) :
+ *   https://script.hellopro.fr/script/typesense/compute_idf_weekly.php?token=XXX
+ *
+ * Endpoint GKE appele :
+ *   POST https://api.hellopro.eu/optimoteur-service/admin/compute-idf
+ *   Header : X-Admin-Token: <ADMIN_TOKEN>
+ *
+ * Pourquoi un cron hebdomadaire :
+ *   L'IDF (Inverse Document Frequency) varie lentement avec le catalogue.
+ *   Le sync quotidien ajoute ~500-2000 produits/jour sur 2M docs = delta
+ *   negligeable. Une regeneration hebdo garde le dict frais sans surcout.
+ *   A declencher aussi manuellement apres toute ingestion massive de
+ *   nouvelles categories (cf migrate_to_gke.sh).
+ *
+ * Comportement :
+ *   - Verifie le token GET ?token=XXX (auth cron)
+ *   - POST sur /admin/compute-idf avec X-Admin-Token (auth service)
+ *   - Service GKE retourne {"status":"started"} immediatement
+ *   - Cron PHP exit 0 sans attendre la fin (la regen tourne en background)
+ *   - Logs : timestamp + status + duree (donnees observables via curl status apres)
+ *
+ * Cron suggere : dimanche 4h du matin (apres le sync quotidien synonymes qui
+ * tourne a 3h30) :
+ *   0 4 * * 0 wget -qO- "https://script.hellopro.fr/script/typesense/compute_idf_weekly.php?token=XXX"
+ * =============================================================================
+ */
+
+header('Content-Type: text/plain; charset=UTF-8');
+
+// =============================================================================
+// SECURITE : token jetable (cron PHP)
+// =============================================================================
+define('HTTP_TOKEN', 'hp_idfcron_2026_05_22_xZ7q');
+
+if (!isset($_GET['token']) || $_GET['token'] !== HTTP_TOKEN) {
+    http_response_code(403);
+    echo "FORBIDDEN - token manquant ou invalide\n";
+    exit;
+}
+
+// =============================================================================
+// CONFIG
+// =============================================================================
+// Token X-Admin-Token a passer au service GKE. DOIT matcher settings.ADMIN_TOKEN
+// dans app/core/credentials.py cote service Python (defaut : hp_admin_2026_05_22_xZ7q).
+define('GKE_ADMIN_TOKEN', 'hp_admin_2026_05_22_xZ7q');
+
+$IDF_URL = 'https://api.hellopro.eu/optimoteur-service/admin/compute-idf';
+$STATUS_URL = 'https://api.hellopro.eu/optimoteur-service/admin/compute-idf/status';
+$TIMEOUT_SEC = 30;
+
+$t0 = microtime(true);
+
+function log_line($level, $msg)
+{
+    echo '[' . date('Y-m-d\TH:i:s') . "] [$level] $msg\n";
+    @flush();
+}
+
+log_line('INFO', "POST $IDF_URL");
+
+// =============================================================================
+// CHECK STATUT AVANT (eviter double run si une regen est deja en cours)
+// =============================================================================
+$ch = curl_init($STATUS_URL);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_TIMEOUT        => $TIMEOUT_SEC,
+    CURLOPT_CONNECTTIMEOUT => 10,
+    CURLOPT_SSL_VERIFYPEER => false,
+    CURLOPT_SSL_VERIFYHOST => false,
+]);
+$rawStatus = curl_exec($ch);
+curl_close($ch);
+
+if ($rawStatus !== false) {
+    $statusData = @json_decode($rawStatus, true);
+    if (is_array($statusData) && isset($statusData['status']) && $statusData['status'] === 'running') {
+        log_line('WARN', "Une regeneration est deja en cours (started_at=" .
+                 ($statusData['started_at'] ?? '?') . "). Skip.");
+        http_response_code(409);
+        exit(0);
+    }
+}
+
+// =============================================================================
+// TRIGGER /admin/compute-idf
+// =============================================================================
+$ch = curl_init($IDF_URL);
+curl_setopt_array($ch, [
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => '{}',  // body vide, ts_collection prise dans settings
+    CURLOPT_HTTPHEADER     => [
+        'Content-Type: application/json',
+        'X-Admin-Token: ' . GKE_ADMIN_TOKEN,
+    ],
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_TIMEOUT        => $TIMEOUT_SEC,
+    CURLOPT_CONNECTTIMEOUT => 10,
+    CURLOPT_FAILONERROR    => true,
+    CURLOPT_SSL_VERIFYPEER => false,
+    CURLOPT_SSL_VERIFYHOST => false,
+]);
+$raw     = curl_exec($ch);
+$errno   = curl_errno($ch);
+$errstr  = curl_error($ch);
+$http    = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$total_t = curl_getinfo($ch, CURLINFO_TOTAL_TIME);
+curl_close($ch);
+
+if ($errno !== 0 || $raw === false) {
+    log_line('ERROR', "curl echoue (errno=$errno, http=$http) : $errstr");
+    http_response_code(502);
+    exit(1);
+}
+
+log_line('INFO', sprintf("trigger OK en %.2fs (http=%d, response=%s)", $total_t, $http, $raw));
+
+// =============================================================================
+// PARSE RESPONSE (200 = started, 429 = already running)
+// =============================================================================
+$data = @json_decode($raw, true);
+if (!is_array($data)) {
+    log_line('ERROR', "Reponse non-JSON : $raw");
+    http_response_code(502);
+    exit(1);
+}
+
+$status = $data['status'] ?? 'unknown';
+$coll   = $data['collection'] ?? '?';
+$dt     = microtime(true) - $t0;
+
+if ($status === 'started') {
+    log_line('OK', sprintf("Regen IDF declenchee pour collection=%s (total cron=%.2fs)",
+                           $coll, $dt));
+    log_line('INFO', "Pour suivre l'avancement : curl $STATUS_URL");
+    exit(0);
+} else {
+    log_line('WARN', "Statut inattendu : $status (response: $raw)");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
Industrialise la regeneration du dict IDF (`idf_nom_produit.json`). Plus besoin de `kubectl exec` manuel : appel HTTP self-service + cron hebdo automatique.

## Pourquoi
Aujourd'hui aucun mecanisme automatique pour regenerer l'IDF. Le fichier disparaissait apres restarts pod (volume ephemere ?). Resultat : reranker en mode strict, perte ~14% qualite A4.

## Implementation

### Service Python
- `app/services/idf_service.py` (NEW) : 
  - `regenerate_idf_sync()` : subprocess `python scripts/compute_idf.py` + timeout 15min
  - `regenerate_idf_background()` : wrapper FastAPI BackgroundTasks + reload cache idf_loader
  - `get_state()` : suivi de l'etat (thread-safe Lock)
- `app/router/admin.py` :
  - `POST /admin/compute-idf` : trigger background + X-Admin-Token auth + protection contre double-run (429 si en cours)
  - `GET /admin/compute-idf/status` : poll de l'etat

### Cron PHP
- `site/script/typesense/compute_idf_weekly.php` (NEW) :
  - Pattern identique a `sync_synonyms_daily.php` (token auth + curl)
  - Verifie qu'aucune regen en cours (via GET status)
  - POST sur /admin/compute-idf avec X-Admin-Token
  - Cron suggere : dimanche 4h apres sync synonymes 3h30

### Doc
- `CLAUDE.md` : section "Regeneration IDF (industrialisee)" avec 3 methodes (HTTP, cron PHP, CLI kubectl)

## Apres merge

1. **Tafita redeploie le pod GKE** avec cette nouvelle image (route /admin/compute-idf devient dispo)
2. **Premier trigger manuel** :
   ```bash
   curl -X POST https://api.hellopro.eu/optimoteur-service/admin/compute-idf \
     -H "X-Admin-Token: hp_admin_2026_05_22_xZ7q" \
     -H "Content-Type: application/json" -d '{}'
   ```
3. **Activer le cron Ecritel** :
   ```
   0 4 * * 0 wget -qO- "https://script.hellopro.fr/script/typesense/compute_idf_weekly.php?token=hp_idfcron_2026_05_22_xZ7q"
   ```

## Test plan
- [x] Verif syntaxe Python (py_compile OK)
- [ ] Apres redeploy Tafita : appel POST /admin/compute-idf -> {"status":"started"}
- [ ] GET /admin/compute-idf/status passe par "running" -> "ok" en ~2-5 min
- [ ] Verification logs : "IDF cache reset + reloaded successfully"
- [ ] Apres restart pod : `kubectl logs ... | grep IDF` montre "IDF loaded from idf_nom_produit.json : NNNNNN tokens"

🤖 Generated with [Claude Code](https://claude.com/claude-code)