### PR TITLE
feat(idf): persistance GCS bucket (alternative au Filestore RWX)

### DIFF
--- a/apps-microservices/opti-moteur-front/CLAUDE.md
+++ b/apps-microservices/opti-moteur-front/CLAUDE.md
@@ -354,13 +354,39 @@ curl "https://api.hellopro.eu/optimoteur-service/admin/compute-idf/status"
 
 Optionnel : passer `?collection=produits_prod_v2` pour cibler une autre collection.
 
+### Persistance via GCS bucket (NEW 2026-05-26)
+
+Pour partager l'IDF entre plusieurs pods sans Filestore couteux, le service
+upload/download le JSON via un bucket GCS. Activation via env var :
+
+```yaml
+env:
+  - name: GCS_IDF_BUCKET
+    value: "hellopro-rag-project-opti-moteur-data"  # nom bucket
+  - name: GCS_IDF_OBJECT
+    value: "idf_nom_produit.json"  # defaut
+```
+
+Auth via Workload Identity : le SA Kubernetes du pod doit avoir le role
+`roles/storage.objectAdmin` sur le bucket.
+
+Flux :
+1. Pod A recoit `POST /admin/compute-idf` -> genere localement -> upload GCS
+2. Pour propager au pod B : appeler `POST /admin/reload-idf` (n fois pour
+   couvrir tous les pods via LoadBalancer)
+3. Au demarrage de tout pod : si fichier local absent, download depuis GCS
+
+Si `GCS_IDF_BUCKET` est vide, persistance desactivee, fallback fichier local.
+
 ### Cron PHP hebdomadaire
 
 `site/script/typesense/compute_idf_weekly.php` est appele 1x/semaine
 (dimanche 4h, apres le sync quotidien synonymes 3h30). Il :
 - Verifie qu'aucune regen n'est en cours (via /admin/compute-idf/status)
 - POST sur /admin/compute-idf avec le X-Admin-Token
-- Logge le resultat (status + duree)
+- Polle `/admin/compute-idf/status` jusqu'a "ok" (max 15 min)
+- Appelle 5x `/admin/reload-idf` pour propager aux differents pods via LB
+- Logge le resultat (status + duree + nb pods reloaded)
 
 Configurer cron Ecritel :
 ```

--- a/apps-microservices/opti-moteur-front/app/core/credentials.py
+++ b/apps-microservices/opti-moteur-front/app/core/credentials.py
@@ -56,6 +56,14 @@ class Settings(BaseSettings):
     # Token jetable en header X-Admin-Token. A changer en prod via env var.
     ADMIN_TOKEN: str = "hp_admin_2026_05_22_xZ7q"
 
+    # --- Persistance IDF via GCS (alternative au PVC ReadWriteMany) ---
+    # Si defini, le service upload/download idf_nom_produit.json vers/depuis
+    # ce bucket. Le SA Kubernetes du pod doit avoir le role
+    # `roles/storage.objectAdmin` sur ce bucket (Workload Identity).
+    # Vide -> pas de persistance GCS, fallback fichier local du pod.
+    GCS_IDF_BUCKET: str = ""
+    GCS_IDF_OBJECT: str = "idf_nom_produit.json"
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/apps-microservices/opti-moteur-front/app/router/admin.py
+++ b/apps-microservices/opti-moteur-front/app/router/admin.py
@@ -180,6 +180,50 @@ def admin_compute_idf_status():
     return idf_service.get_state()
 
 
+@router.post(
+    "/reload-idf",
+    summary="Recharger l'IDF depuis GCS (propage l'update entre pods)",
+)
+def admin_reload_idf(
+    x_admin_token: Optional[str] = Header(None, description="Token jetable"),
+):
+    """
+    Force le re-download de l'IDF depuis GCS et reset le cache du loader.
+
+    Use case : apres `POST /admin/compute-idf`, le pod A genere et upload
+    sur GCS. Pour que les autres pods voient le nouvel IDF sans attendre
+    un restart, appeler cette route plusieurs fois (chaque appel atterit
+    sur un pod different via le LoadBalancer).
+
+    No-op si GCS non configure.
+    """
+    _check_admin_token(x_admin_token)
+
+    from pathlib import Path
+    from app.services import gcs_idf_storage, idf_loader
+
+    if not gcs_idf_storage.gcs_enabled():
+        return {
+            "status": "skipped",
+            "reason": "GCS_IDF_BUCKET non configure - reload n'a pas de sens en mode local",
+        }
+
+    local_path = Path(idf_loader._IDF_PATH)
+    downloaded = gcs_idf_storage.download(local_path)
+    if downloaded:
+        idf_loader.reset_cache_for_test()
+        idf_loader.idf_available()  # force lazy reload immediat pour logger la stat
+        return {
+            "status": "ok",
+            "downloaded_to": str(local_path),
+            "gcs_updated_at": gcs_idf_storage.get_blob_updated_at(),
+        }
+    return {
+        "status": "error",
+        "reason": "Download GCS echoue (blob absent ou erreur reseau)",
+    }
+
+
 # ---------- Synonymes auto-generation ----------
 
 @router.post(

--- a/apps-microservices/opti-moteur-front/app/services/gcs_idf_storage.py
+++ b/apps-microservices/opti-moteur-front/app/services/gcs_idf_storage.py
@@ -1,0 +1,116 @@
+"""
+Persistance du fichier IDF dans un bucket GCS.
+
+Alternative au PVC ReadWriteMany (qui necessiterait Filestore = couts
+~30-50EUR/mois). Avec GCS :
+  - Cout : qq centimes/mois pour ~20 MB
+  - Auth : Workload Identity (le SA Kubernetes du pod doit avoir
+    roles/storage.objectAdmin sur le bucket)
+  - Pattern : upload apres compute_idf, download au startup du pod
+
+Si `settings.GCS_IDF_BUCKET` est vide -> toutes les fonctions sont des
+no-op. Permet un mode "local-only" pour dev sans GCS.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from app.core.credentials import settings
+
+logger = logging.getLogger(__name__)
+
+
+def gcs_enabled() -> bool:
+    """True si la persistance GCS est configuree."""
+    return bool(settings.GCS_IDF_BUCKET)
+
+
+def _get_client():
+    """Lazy import du client GCS (evite l'import quand pas configure)."""
+    from google.cloud import storage
+    return storage.Client()
+
+
+def _get_blob():
+    """Retourne le blob target (bucket + object)."""
+    client = _get_client()
+    bucket = client.bucket(settings.GCS_IDF_BUCKET)
+    return bucket.blob(settings.GCS_IDF_OBJECT)
+
+
+def upload(local_path: Path) -> bool:
+    """
+    Upload le fichier local vers `gs://<GCS_IDF_BUCKET>/<GCS_IDF_OBJECT>`.
+
+    Returns:
+        True si upload reussi, False si GCS non configure ou echec.
+
+    Idempotent : ecrase le blob existant.
+    """
+    if not gcs_enabled():
+        logger.info("GCS upload skipped (GCS_IDF_BUCKET non defini)")
+        return False
+    if not local_path.exists():
+        logger.warning("GCS upload skipped (local file %s absent)", local_path)
+        return False
+
+    try:
+        blob = _get_blob()
+        blob.upload_from_filename(str(local_path), content_type="application/json")
+        size_mb = local_path.stat().st_size / (1024 * 1024)
+        logger.info(
+            "IDF uploaded to gs://%s/%s (%.1f MB)",
+            settings.GCS_IDF_BUCKET, settings.GCS_IDF_OBJECT, size_mb,
+        )
+        return True
+    except Exception as e:
+        logger.exception("GCS upload failed: %s", e)
+        return False
+
+
+def download(local_path: Path) -> bool:
+    """
+    Download le blob GCS vers `local_path`. Cree le dossier parent si besoin.
+
+    Returns:
+        True si download reussi (fichier disponible sur disque local),
+        False si GCS non configure, blob absent, ou erreur.
+    """
+    if not gcs_enabled():
+        return False
+
+    try:
+        blob = _get_blob()
+        if not blob.exists():
+            logger.info(
+                "IDF blob gs://%s/%s n'existe pas encore",
+                settings.GCS_IDF_BUCKET, settings.GCS_IDF_OBJECT,
+            )
+            return False
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        blob.download_to_filename(str(local_path))
+        size_mb = local_path.stat().st_size / (1024 * 1024)
+        logger.info(
+            "IDF downloaded from gs://%s/%s (%.1f MB) -> %s",
+            settings.GCS_IDF_BUCKET, settings.GCS_IDF_OBJECT, size_mb, local_path,
+        )
+        return True
+    except Exception as e:
+        logger.warning("GCS download failed: %s", e)
+        return False
+
+
+def get_blob_updated_at() -> Optional[str]:
+    """Retourne la date de derniere update du blob GCS (ISO string), ou None."""
+    if not gcs_enabled():
+        return None
+    try:
+        blob = _get_blob()
+        blob.reload()
+        if blob.updated:
+            return blob.updated.isoformat()
+    except Exception as e:
+        logger.debug("GCS get_blob_updated_at failed: %s", e)
+    return None

--- a/apps-microservices/opti-moteur-front/app/services/idf_loader.py
+++ b/apps-microservices/opti-moteur-front/app/services/idf_loader.py
@@ -60,6 +60,20 @@ def _load_idf() -> Dict[str, float]:
         return _idf_cache or {}
     _load_attempted = True
 
+    # Si le fichier local est absent, on tente un download depuis GCS
+    # (pour partager l'IDF entre les 2+ pods sans PVC ReadWriteMany).
+    # No-op si GCS_IDF_BUCKET non configure.
+    if not _IDF_PATH.exists():
+        try:
+            from app.services import gcs_idf_storage
+            if gcs_idf_storage.gcs_enabled():
+                if gcs_idf_storage.download(_IDF_PATH):
+                    logger.info("IDF downloaded from GCS at startup")
+                else:
+                    logger.info("GCS configured but no IDF blob yet")
+        except Exception as e:
+            logger.warning("GCS download attempt failed at startup: %s", e)
+
     if not _IDF_PATH.exists():
         logger.warning(
             "IDF file not found at %s - reranker will fallback to flat name_match (ratio simple). "

--- a/apps-microservices/opti-moteur-front/app/services/idf_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/idf_service.py
@@ -44,6 +44,7 @@ _state: Dict[str, Any] = {
     "stdout_tail": None,
     "stderr_tail": None,
     "error": None,
+    "gcs_uploaded": None,       # bool si upload GCS reussi (None = GCS desactive)
 }
 
 
@@ -121,6 +122,19 @@ def regenerate_idf_background(collection: Optional[str] = None) -> None:
             _state["finished_at"] = datetime.now(timezone.utc).isoformat()
 
         if result["status"] == "ok":
+            # Upload du nouveau JSON vers GCS pour partage entre pods.
+            # No-op si GCS_IDF_BUCKET non defini.
+            try:
+                from app.services import gcs_idf_storage
+                if gcs_idf_storage.gcs_enabled():
+                    upload_ok = gcs_idf_storage.upload(_OUT_PATH)
+                    with _lock:
+                        _state["gcs_uploaded"] = upload_ok
+                else:
+                    logger.info("GCS persistence disabled, IDF reste local au pod")
+            except Exception as e:
+                logger.warning("GCS upload failed: %s", e)
+
             # Reset cache du loader : force reload au prochain get_idf()
             try:
                 from app.services import idf_loader

--- a/apps-microservices/opti-moteur-front/requirements.txt
+++ b/apps-microservices/opti-moteur-front/requirements.txt
@@ -8,3 +8,4 @@ typesense==0.21.0
 requests
 httpx
 tqdm
+google-cloud-storage>=2.10.0

--- a/site/script/typesense/compute_idf_weekly.php
+++ b/site/script/typesense/compute_idf_weekly.php
@@ -141,12 +141,91 @@ $status = $data['status'] ?? 'unknown';
 $coll   = $data['collection'] ?? '?';
 $dt     = microtime(true) - $t0;
 
-if ($status === 'started') {
-    log_line('OK', sprintf("Regen IDF declenchee pour collection=%s (total cron=%.2fs)",
-                           $coll, $dt));
-    log_line('INFO', "Pour suivre l'avancement : curl $STATUS_URL");
-    exit(0);
-} else {
+if ($status !== 'started') {
     log_line('WARN', "Statut inattendu : $status (response: $raw)");
     exit(1);
 }
+
+log_line('INFO', sprintf("Regen IDF declenchee pour collection=%s en %.2fs", $coll, $dt));
+
+// =============================================================================
+// POLLING jusqu'a fin de la regeneration (timeout 15 min)
+// =============================================================================
+$RELOAD_URL    = 'https://api.hellopro.eu/optimoteur-service/admin/reload-idf';
+$POLL_TIMEOUT  = 900;   // 15 min max
+$POLL_INTERVAL = 15;    // 15s entre les polls
+$elapsed = 0;
+
+log_line('INFO', "Polling status (max {$POLL_TIMEOUT}s)...");
+while ($elapsed < $POLL_TIMEOUT) {
+    sleep($POLL_INTERVAL);
+    $elapsed += $POLL_INTERVAL;
+
+    $ch = curl_init($STATUS_URL);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 10,
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false,
+    ]);
+    $sRaw = curl_exec($ch);
+    curl_close($ch);
+
+    $sData = @json_decode($sRaw, true);
+    $sStatus = is_array($sData) ? ($sData['status'] ?? '?') : '?';
+
+    if ($sStatus === 'ok') {
+        $duration = $sData['duration_s'] ?? '?';
+        $gcs_ok   = $sData['gcs_uploaded'] ?? null;
+        log_line('OK', "compute-idf termine apres {$duration}s (gcs_uploaded=" .
+                       json_encode($gcs_ok) . ")");
+        break;
+    }
+    if ($sStatus === 'error' || $sStatus === 'exception') {
+        $stderr_tail = is_array($sData) ? ($sData['stderr_tail'] ?? '') : '';
+        log_line('ERROR', "compute-idf en erreur : $stderr_tail");
+        exit(1);
+    }
+    if ($elapsed % 60 === 0) {
+        log_line('INFO', "Toujours running apres {$elapsed}s...");
+    }
+}
+
+if ($elapsed >= $POLL_TIMEOUT) {
+    log_line('ERROR', "Timeout polling apres {$POLL_TIMEOUT}s");
+    exit(1);
+}
+
+// =============================================================================
+// PROPAGATION : appeler /admin/reload-idf plusieurs fois pour que les
+// differents pods (derriere le LoadBalancer) downloadent le nouvel IDF
+// depuis GCS. 5 appels = ~95% de chance que les 2 pods soient touches.
+// =============================================================================
+log_line('INFO', "Propagation aux autres pods via $RELOAD_URL...");
+$pods_reloaded = 0;
+for ($i = 1; $i <= 5; $i++) {
+    $ch = curl_init($RELOAD_URL);
+    curl_setopt_array($ch, [
+        CURLOPT_POST           => true,
+        CURLOPT_POSTFIELDS     => '',
+        CURLOPT_HTTPHEADER     => ['X-Admin-Token: ' . GKE_ADMIN_TOKEN],
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 30,
+        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYHOST => false,
+    ]);
+    $rRaw = curl_exec($ch);
+    $rHttp = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $rData = @json_decode($rRaw, true);
+    $rStatus = is_array($rData) ? ($rData['status'] ?? '?') : '?';
+    log_line('INFO', "  reload #$i : http=$rHttp status=$rStatus");
+    if ($rStatus === 'ok') $pods_reloaded++;
+    sleep(1);
+}
+
+$total = microtime(true) - $t0;
+log_line('OK', sprintf("Cron termine en %.2fs (compute + propagation %d/5 pods)",
+                       $total, $pods_reloaded));
+exit(0);


### PR DESCRIPTION
## Summary
Alternative au PVC ReadWriteMany Filestore (~30-50€/mois) : persistance via GCS bucket. Coût qq centimes/mois, auth via Workload Identity.

## Workflow
```
cron hebdo PHP
  └─> POST /admin/compute-idf  (atterit sur pod A)
      └─> pod A compute -> upload GCS
  └─> poll status jusqu'a 'ok'
  └─> POST /admin/reload-idf x5  (couvre les 2+ pods via LB)
      └─> chaque pod : download GCS + reset cache idf_loader
```

## Pre-requis Tafita (apres merge)
1. Creer bucket GCS (ex: `hellopro-rag-project-opti-moteur-data`)
2. Donner au SA `opti-moteur-sa` le role `roles/storage.objectAdmin` sur le bucket
3. Ajouter env var au deployment :
   ```yaml
   env:
   - name: GCS_IDF_BUCKET
     value: "hellopro-rag-project-opti-moteur-data"
   ```
4. Redeploy pod (rebuild image + rollout restart)

## Si GCS_IDF_BUCKET non defini
Tout reste local (regression neutre par rapport a aujourd'hui). Permet du dev/test sans GCS.

## Test plan
- [x] Syntax check Python OK
- [ ] Apres merge + redeploy Tafita : POST /admin/compute-idf reussit + upload GCS visible
- [ ] POST /admin/reload-idf retourne ok avec downloaded_to + gcs_updated_at
- [ ] Restart pod : log montre "IDF downloaded from GCS at startup"

🤖 Generated with [Claude Code](https://claude.com/claude-code)