### PR TITLE
feat(embedding): envoyer SERVICE_NAME + timeout 30s pour la priorisation

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/embedding_client.py
+++ b/apps-microservices/opti-moteur-front/app/services/embedding_client.py
@@ -19,7 +19,13 @@ EMBEDDING_SERVICE_URL = os.getenv(
     "EMBEDDING_SERVICE_URL",
     "http://rag-hp-pub-api-embedding-service-1:8555",
 )
-EMBEDDING_TIMEOUT = int(os.getenv("EMBEDDING_TIMEOUT", "10"))
+EMBEDDING_TIMEOUT = int(os.getenv("EMBEDDING_TIMEOUT", "30"))  # 10 -> 30 (service lent ~13s/req)
+
+# Identifiant du caller envoye au service embedding pour priorisation.
+# Sur GKE : defini via env var SERVICE_NAME dans le deployment.
+# Le service embedding utilise cette info pour prioriser nos requetes
+# (configurable cote serveur dans sa liste de "services prioritaires").
+SERVICE_NAME = os.getenv("SERVICE_NAME", "opti-moteur-front")
 
 
 def _extract_vector(resp) -> List[float]:
@@ -74,10 +80,23 @@ def embed_text(text: str, timeout: int = None) -> List[float]:
         raise ValueError("Le texte a embedder ne peut pas etre vide")
 
     url = f"{EMBEDDING_SERVICE_URL.rstrip('/')}/embedding"
+    # On envoie SERVICE_NAME aux 3 emplacements possibles (header HTTP +
+    # body JSON) pour que le serveur le retrouve quel que soit le format
+    # qu'il attend. Format definitif a confirmer avec le collegue embedding.
+    headers = {
+        "Content-Type": "application/json",
+        "X-Service-Name": SERVICE_NAME,
+    }
+    body = {
+        "text": text,
+        "source_service": SERVICE_NAME,
+        "service_name": SERVICE_NAME,
+    }
     try:
         r = requests.post(
             url,
-            json={"text": text},
+            json=body,
+            headers=headers,
             timeout=timeout or EMBEDDING_TIMEOUT,
         )
         r.raise_for_status()


### PR DESCRIPTION
## Contexte
Le service embedding sur la VM met ~13s/requete (mesure depuis localhost). Notre timeout client GKE etait a 10s -> systematiquement 503 sur /search/text.

Le collegue embedding va prioriser les requetes en lisant SERVICE_NAME. Tafita a deja ajoute SERVICE_NAME=opti-moteur-front au deployment, mais notre code Python ne le passait pas.

## Fix
1. Envoyer SERVICE_NAME au service embedding via :
   - Header HTTP : `X-Service-Name: opti-moteur-front`
   - Body JSON : `{"text":"...", "source_service":"...", "service_name":"..."}`
   On envoie aux 3 emplacements pour maximiser les chances que le serveur l'utilise (format definitif a confirmer avec le collegue).
2. EMBEDDING_TIMEOUT par defaut 10s -> 30s. Couvre le pire cas observe (~13s).

## Apres merge
- Tafita rebuild image (ex tag v1.0.4-280526-prod) + redeploy
- Test /search/text : devrait repondre dans ~5-15s (vs timeout actuel)
- Une fois la priorisation activee cote serveur embedding, devrait baisser a <2s

## Test plan
- [x] Syntax check Python OK
- [ ] Apres redeploy : POST /search/text fonctionne sans 503
- [ ] Confirmer avec collegue embedding le bon format de SERVICE_NAME (header ou body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)