### PR TITLE
feat(search): mode vector_only pour /?v2=1 (complémentaire Solr V2)

### DIFF
--- a/apps-microservices/opti-moteur-front/app/router/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/router/search_text.py
@@ -55,6 +55,15 @@ def search_by_text(req: SearchTextRequest):
             )
             vector = None  # = equivalent use_vector=False, do_search gere
 
+    # vector_only requires un vecteur valide ; sinon on tombe en BM25 par securite
+    effective_vector_only = req.vector_only and (vector is not None)
+    if req.vector_only and vector is None:
+        logger.warning(
+            "vector_only=True mais vecteur indisponible (use_vector=%s, "
+            "fallback=%s). Bascule en BM25.",
+            req.use_vector, embedding_fallback_reason,
+        )
+
     # 2. Search (reutilise le service existant, vector=None si use_vector=False)
     try:
         return do_search(
@@ -65,6 +74,7 @@ def search_by_text(req: SearchTextRequest):
             candidates=req.candidates,
             offset=req.offset or 0,
             apply_filter_by_category=req.apply_filter_by_category,
+            vector_only=effective_vector_only,
         )
     except Exception as e:
         logger.error("Search failed: %s", e, exc_info=True)

--- a/apps-microservices/opti-moteur-front/app/schemas/search_text.py
+++ b/apps-microservices/opti-moteur-front/app/schemas/search_text.py
@@ -36,3 +36,14 @@ class SearchTextRequest(BaseModel):
             "plus rapide d'environ 300-500 ms, perd la remontee semantique de synonymes)."
         ),
     )
+    vector_only: bool = Field(
+        False,
+        description=(
+            "Si True : pas de BM25 textuel cote Typesense (q=*), uniquement kNN "
+            "vecteur + reranker Python. Use case : quand Solr V2 fait deja le "
+            "match exact en page 1, on veut que Typesense apporte uniquement la "
+            "valeur semantique en complement (pages 2-4 + extensions). "
+            "Si vector_only=True ET use_vector=False -> warning + fallback BM25 "
+            "(coherence : vector_only sans vecteur = pas de recherche)."
+        ),
+    )

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -49,13 +49,17 @@ def search(
     candidates: Optional[int] = None,
     offset: int = 0,
     apply_filter_by_category: bool = True,
+    vector_only: bool = False,
 ) -> Dict[str, Any]:
     """
-    Execute une recherche hybride (BM25 + kNN vecteur) OU BM25 pur selon la
-    presence de query_vector. Fallback sans filter_by si trop restrictif.
+    Execute une recherche selon 3 modes :
+    - hybrid (defaut) : BM25 + kNN vector + reranker
+    - bm25_only : query_vector=None -> pas de kNN, BM25 pur + reranker
+    - vector_only : vector_only=True ET query_vector!=None -> q=* + kNN vector pur
+      + reranker. Use case : Solr V2 fait deja le match exact en page 1, Typesense
+      apporte uniquement la valeur semantique en complement.
 
-    Si `query_vector` est None -> pipeline BM25 pur (pas d'appel vectoriel a
-    Typesense, reranker sans poids vecteur). Utile pour benchmark sans embedding.
+    Fallback automatique sans filter_by si trop restrictif.
     """
     collection = collection or settings.TYPESENSE_COLLECTION
     top_k = top_k or settings.DEFAULT_TOP_K
@@ -72,10 +76,11 @@ def search(
     if apply_filter_by_category and conf >= settings.CAT_FILTER_THRESHOLD and valid_cats:
         filter_cats = valid_cats
 
-    # 3. Hybrid or BM25-only search
+    # 3. Hybrid or BM25-only or Vector-only search
     t1 = time.time()
     ts_result = _hybrid_typesense_search(
-        query, query_vector, collection, candidates, filter_cats=filter_cats,
+        query, query_vector, collection, candidates,
+        filter_cats=filter_cats, vector_only=vector_only,
     )
     groups = ts_result.get("grouped_hits", [])
 
@@ -88,7 +93,8 @@ def search(
             len(groups), fallback_threshold, query,
         )
         ts_result = _hybrid_typesense_search(
-            query, query_vector, collection, candidates, filter_cats=None,
+            query, query_vector, collection, candidates,
+            filter_cats=None, vector_only=vector_only,
         )
         groups = ts_result.get("grouped_hits", [])
         filter_cats = None
@@ -161,12 +167,15 @@ def _hybrid_typesense_search(
     collection: str,
     candidates: int,
     filter_cats: Optional[List[str]] = None,
+    vector_only: bool = False,
 ) -> Dict[str, Any]:
     """
     Recherche paginee pour couvrir jusqu'a `candidates` documents uniques.
 
-    Si `query_vector` est None -> BM25 pur (pas de vector_query envoye).
-    Sinon -> hybrid BM25 + kNN sur embedding.
+    3 modes selon les parametres :
+    - `query_vector=None` -> BM25 pur (q=query, pas de vector_query)
+    - `vector_only=True` ET vector!=None -> kNN pur (q="*", vector_query envoye)
+    - sinon (defaut) -> hybrid BM25 + kNN (q=query + vector_query)
 
     Typesense capse `per_page` et `k` (vector kNN) a 250 pour les recherches
     hybrides. Pour remonter plus de candidats (utile pour les grosses
@@ -181,9 +190,14 @@ def _hybrid_typesense_search(
     num_pages = min((candidates + per_page - 1) // per_page, _MAX_PAGES)
     num_pages = max(num_pages, 1)
 
+    # Mode vector_only : q="*" pour neutraliser BM25 et ne garder que le kNN.
+    # Necessite un vecteur valide (sinon retour BM25 pur par securite).
+    effective_vector_only = vector_only and query_vector is not None
+    q_param = "*" if effective_vector_only else query
+
     base_params = {
         "collection": collection,
-        "q": query,
+        "q": q_param,
         "query_by": "nom_produit,categorie,text",
         "query_by_weights": "5,10,1",
         "per_page": per_page,
@@ -192,7 +206,7 @@ def _hybrid_typesense_search(
         "typo_tokens_threshold": 3,
         "drop_tokens_threshold": 2,
     }
-    # Ajoute le vector_query seulement si un vecteur est fourni (mode hybride)
+    # Ajoute le vector_query seulement si un vecteur est fourni (modes hybride OU vector_only)
     if query_vector is not None:
         vec_str = json.dumps(query_vector)
         base_params["vector_query"] = f"embedding:({vec_str}, k:{per_page})"


### PR DESCRIPTION
## Idée stratégique
Solr V2 fait déjà le match exact textuel en page 1. Faire encore du BM25 dans Typesense pour les pages 2-4 / extension est redondant. Mieux : faire du **vector pur** pour apporter la valeur sémantique en complément.

## 3 modes search/text désormais
| Mode | Param | Behavior |
|---|---|---|
| `hybrid` (defaut) | use_vector=true, vector_only=false | BM25 + kNN + reranker |
| `bm25_only` | use_vector=false | pas de vecteur, BM25 + reranker |
| **`vector_only` (NEW)** | vector_only=true | q="*", kNN pur + reranker |

## Côté PHP (Ecritel)
Quand l'URL contient `?v2=1`, le PHP doit envoyer `vector_only=true` au service Python pour /search/text. La page 1 reste sur Solr V2.

À adapter dans `site/moteur_recherche/search_extension.php` et `search_ajax.php` (l'utilisateur uploadera manuellement après merge).

## Sécurité
Si vector_only=true MAIS embedding indisponible -> fallback BM25 auto + WARNING log.

## Test plan
- [ ] Tafita rebuild + redeploy (ex v1.0.6-280526-prod)
- [ ] curl POST /search/text avec `"vector_only": true`
- [ ] Vérifier dans les logs Typesense : `q="*"` au lieu de la query
- [ ] Comparer top-1 cas Elena entre mode hybrid et vector_only

🤖 Generated with [Claude Code](https://claude.com/claude-code)