### PR TITLE
feat(reranker): A9 boost cert vendeur certifié (×1.5) - aligne Solr V2 bq^8000

### DIFF
--- a/apps-microservices/opti-moteur-front/app/services/reranker.py
+++ b/apps-microservices/opti-moteur-front/app/services/reranker.py
@@ -71,6 +71,26 @@ _R3_WEAK_FACTOR   = 0.75
 # A8 R2 : penalite si marque presente dans query mais type produit absent du doc
 _R2_MISSING_TYPE_FACTOR = 0.3
 
+# A9 (2026-05-28) : boost cert vendeur (alignement avec le boost bq^8000 cote Solr V2)
+# Un produit est "cert" si :
+#   - etat == 'Client' (vendeur certifie actif)
+#   - OU etat == 'Pause' AND affichage == 'Complet' (vendeur en pause mais fiche
+#     complete = qualite OK)
+# Boost final_score x 1.5. Note : Solr V2 utilise bq^8000 ce qui est tres fort.
+# Cote Python on reste plus modeste pour ne pas ecraser les autres signaux.
+_CERT_BOOST_FACTOR = 1.5
+
+
+def _is_cert_seller(doc: Dict[str, Any]) -> bool:
+    """Reproduit la logique PHP : etat=Client OU (etat=Pause AND affichage=Complet)."""
+    etat = (doc.get("etat") or "").strip().lower()
+    affichage = (doc.get("affichage") or "").strip().lower()
+    if etat == "client":
+        return True
+    if etat == "pause" and affichage == "complet":
+        return True
+    return False
+
 
 def _is_covered(
     token: str,
@@ -249,6 +269,13 @@ def rerank_candidates(
         if r["r2_missing_type"]:
             r["final_score"] *= _R2_MISSING_TYPE_FACTOR
             penalties.append("missing_type_with_brand")
+
+        # A9 (NEW 2026-05-28) : boost cert vendeur certifié (alignement Solr V2 bq^8000)
+        is_cert = _is_cert_seller(r["doc"])
+        r["is_cert"] = is_cert
+        if is_cert:
+            r["final_score"] *= _CERT_BOOST_FACTOR
+            penalties.append("cert_boost")
 
         r["penalty"] = " ".join(penalties)
 

--- a/apps-microservices/opti-moteur-front/app/services/search_service.py
+++ b/apps-microservices/opti-moteur-front/app/services/search_service.py
@@ -119,6 +119,9 @@ def search(
             # (etat == 'Client' OU (etat == 'Pause' AND affichage == 'Complet')).
             "etat":          d.get("etat") or "",
             "affichage":     d.get("affichage") or "",
+            # is_cert (NEW 2026-05-28) : booleen pre-calcule cote Python, evite
+            # au PHP de refaire la logique. True si etat=Client OU etat=Pause+Complet.
+            "is_cert":       r.get("is_cert", False),
             "prix_ht":       d.get("prix_ht"),
             "score":         round(r["final_score"], 4),
             "scores_detail": {


### PR DESCRIPTION
## Symptôme observé
Sur `?v2=1` (URL armoire+medicale), des produits de vendeurs NON-certifiés en HAUT, des produits CERTIFIÉS en milieu :

**Non-certifiés en haut (regrettable)** :
- refrigerateur-er1400 (id_fournisseur=2007191)
- armoire-de-refroidissement-imagerie-medicale (id_fournisseur=2003362)
- armoire-vitrine-2-portes (id_fournisseur=2007191)

**Certifiés au milieu (devrait être en haut)** :
- armoire-medicale-grande-hauteur (id_fournisseur=2007191)
- armoire-medicale-400-avec-tiroirs (id_fournisseur=2007191)
- systeme-d-armoire-mobile-medical (id_fournisseur=1002233)

## Cause racine
Le reranker Python n'avait AUCUNE logique de boost cert. La formule :
```
final = 0.55*vec + 0.10*bm25 + 0.25*name_match + 0.10*cat_match
+ pénalités A7 (coverage) et A8 (R2 missing type)
```
Aucun signal du "vendeur certifié" qui existe côté Solr V2 (bq^8000).

## Fix (A9)
- Constante `_CERT_BOOST_FACTOR = 1.5`
- Helper `_is_cert_seller(doc)` reproduit la logique PHP : `etat=='Client' OU (etat=='Pause' ET affichage=='Complet')`
- Boost final_score ×1.5 si certifié
- Ajout `is_cert: bool` dans le JSON output pour faciliter le debug

## Choix du facteur 1.5
Solr V2 utilise bq^8000 (très fort). Python à 1.5 reste modéré pour ne pas écraser les autres signaux (IDF, synonymes, coverage). Si pas suffisant après test, on monte à 1.8 ou 2.0.

## Test plan post-déploiement
- [ ] Tafita rebuild + redeploy
- [ ] Test URL `?mot_cles=armoire+medicale&v2=1`
- [ ] Vérifier que les 3 armoires médicales certifiées remontent en top
- [ ] Vérifier que les 3 produits non-pertinents non-certifiés descendent

🤖 Generated with [Claude Code](https://claude.com/claude-code)