### PR TITLE
fix(crawler-monitor): emettre job_update WS sur les messages crawl_up…

### DIFF
--- a/apps-microservices/crawler-monitor-backend/internal/ws/pubsub.go
+++ b/apps-microservices/crawler-monitor-backend/internal/ws/pubsub.go
@@ -120,6 +120,16 @@ func (p *PubSub) broadcastTransformed(payload string) {
 
 	msgType, _ := raw["type"].(string)
 	if msgType != "heartbeat" {
+		// crawler-service publie les changements de statut sur crawl_updates
+		// au format {crawl_id, status, timestamp} sans champ type. Le frontend
+		// React ne reagit qu aux messages {type:job_update, crawl_id}. On les
+		// traduit donc en job_update type : sans ca, les transitions de statut
+		// (finished/failed/archived/stopping/restarting_oom) n atteignent jamais
+		// le dashboard (aucun polling REST de secours n existe).
+		if cid := stringOrNum(raw["crawl_id"]); cid != "" {
+			p.emitJobUpdate(cid)
+			return
+		}
 		p.hub.Broadcast([]byte(payload))
 		return
 	}

--- a/apps-microservices/crawler-monitor-backend/tests/ws_pubsub_test.go
+++ b/apps-microservices/crawler-monitor-backend/tests/ws_pubsub_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -28,6 +29,37 @@ func TestWSPubSub_BroadcastsToHub(t *testing.T) {
 	case msg := <-c.SendForTest():
 		if string(msg) != `{"x":1}` {
 			t.Errorf("msg = %s", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no broadcast received")
+	}
+}
+
+func TestWSPubSub_CrawlUpdateEmitsJobUpdate(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+	hub := ws.NewHub()
+	c := ws.NewClientForTest()
+	hub.Register(c)
+	ps := ws.NewPubSub(rdb, hub, "crawl_updates")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ps.Run(ctx)
+	time.Sleep(150 * time.Millisecond)
+	rdb.Publish(context.Background(), "crawl_updates", `{"crawl_id":"abc","status":"finished","timestamp":"2026-06-09T10:00:00Z"}`)
+	select {
+	case raw := <-c.SendForTest():
+		var msg map[string]any
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if msg["type"] != "job_update" {
+			t.Errorf("expected type=job_update, got %v", msg["type"])
+		}
+		if msg["crawl_id"] != "abc" {
+			t.Errorf("expected crawl_id=abc, got %v", msg["crawl_id"])
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("no broadcast received")


### PR DESCRIPTION
…dates

crawler-service publie les changements de statut sur le canal Redis crawl_updates au format {crawl_id, status, timestamp} (sans champ type). broadcastTransformed ne reconnaissait que type:heartbeat et rebroadcastait ces messages bruts, que le frontend React ignore (il n ecoute que type:job_update). Le heartbeat envoie toujours status:running, donc les transitions terminales (finished/failed/archived/stopping/restarting_oom) n atteignaient jamais le dashboard, qui restait fige (aucun polling REST de secours).

Tout message non-heartbeat portant un crawl_id est desormais traduit en {type:job_update, crawl_id} via emitJobUpdate. Test de regression ajoute.