### PR TITLE
fix(crawler-monitor): stopper l'agitation des pastilles coherence (de…

### DIFF
--- a/apps-microservices/crawler-monitor-frontend/src/coherence/CoherenceProvider.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/coherence/CoherenceProvider.jsx
@@ -9,6 +9,11 @@ import { RULES } from './rules';
 
 export const CoherenceContext = createContext(null);
 
+// FIX A: évaluation découplée du flux 1 Hz (tick toutes les EVAL_INTERVAL_MS)
+const EVAL_INTERVAL_MS = 5000;
+// FIX B: une violation doit persister >= HYSTERESIS_MS avant d'être affichée
+const HYSTERESIS_MS = 4000;
+
 /**
  * Runs all coherence rules against the current sources.
  * Each rule's evaluate() is wrapped in try/catch: a bug in one rule does not
@@ -29,6 +34,39 @@ function runRules(sources) {
   return result;
 }
 
+/**
+ * Stable key for a single violation used by the hysteresis map.
+ * Combines ruleId + itemKey (per-item rules) + kind/message to distinguish
+ * violations of the same rule on different items.
+ */
+function violationKey(ruleId, violation) {
+  return `${ruleId}|${violation.itemKey ?? ''}|${violation.data?.kind ?? violation.message}`;
+}
+
+/**
+ * Deep-equality check for verdicts objects via a stable JSON projection.
+ * Projects { ruleId: [{itemKey, message, data}][] } and compares as JSON.
+ */
+function verdictsEqual(a, b) {
+  if (a === b) return true;
+  const project = (v) =>
+    Object.fromEntries(
+      Object.entries(v).map(([ruleId, violations]) => [
+        ruleId,
+        violations.map((viol) => ({
+          itemKey: viol.itemKey,
+          message: viol.message,
+          data: viol.data,
+        })),
+      ]),
+    );
+  try {
+    return JSON.stringify(project(a)) === JSON.stringify(project(b));
+  } catch {
+    return false;
+  }
+}
+
 export function CoherenceProvider({ token, replicas, children }) {
   const queryClient = useQueryClient();
   // Read sources from React Query caches. `useCapacityPlanningQuery` uses a
@@ -38,17 +76,78 @@ export function CoherenceProvider({ token, replicas, children }) {
   const capacityQuery = useCapacityQuery(token);
   const capacityPlanningQuery = useCapacityPlanningQuery(token, '1h');
 
+  // FIX A: garde la dernière valeur de replicas dans un ref mis à jour à chaque render.
+  // Cela permet à sources de ne lire replicas qu'au rythme du tick (pas au rythme 1 Hz).
+  const replicasRef = useRef(replicas);
+  replicasRef.current = replicas;
+
+  // FIX A: tick incrémenté toutes les EVAL_INTERVAL_MS pour déclencher une réévaluation.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const i = setInterval(() => setTick((t) => t + 1), EVAL_INTERVAL_MS);
+    return () => clearInterval(i);
+  }, []);
+
+  // FIX A: sources dépend du tick (+ données REST qui, elles, peuvent changer
+  // indépendamment du tick). replicasRef.current est lu à l'intérieur du memo
+  // au moment du tick — pas en dep directe, pour rompre le couplage 1 Hz.
   const sources = useMemo(
     () => ({
-      replicas: replicas || {},
+      replicas: replicasRef.current || {},
       jobs: jobsQuery.data ?? null,
       capacity: capacityQuery.data ?? null,
       capacityPlanning: capacityPlanningQuery.data ?? null,
     }),
-    [replicas, jobsQuery.data, capacityQuery.data, capacityPlanningQuery.data],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tick, jobsQuery.data, capacityQuery.data, capacityPlanningQuery.data],
   );
 
-  const verdicts = useMemo(() => runRules(sources), [sources]);
+  // FIX B: hystérésis — une violation doit persister HYSTERESIS_MS avant affichage.
+  // seenSinceRef: Map<clé, timestamp première observation continue>
+  const seenSinceRef = useRef(new Map());
+
+  // Calcule rawVerdicts puis applique l'hystérésis pour produire verdicts filtré.
+  // prevVerdictsRef permet de stabiliser l'identité de l'objet verdicts exposé.
+  const prevVerdictsRef = useRef({});
+
+  const verdicts = useMemo(() => {
+    const rawVerdicts = runRules(sources);
+    const now = Date.now();
+    const seenSince = seenSinceRef.current;
+
+    // Collecte toutes les clés présentes dans rawVerdicts
+    const presentKeys = new Set();
+    for (const [ruleId, violations] of Object.entries(rawVerdicts)) {
+      for (const v of violations) {
+        presentKeys.add(violationKey(ruleId, v));
+      }
+    }
+
+    // Enregistre les nouvelles violations, purge les disparues
+    for (const key of seenSince.keys()) {
+      if (!presentKeys.has(key)) seenSince.delete(key);
+    }
+    for (const key of presentKeys) {
+      if (!seenSince.has(key)) seenSince.set(key, now);
+    }
+
+    // Filtre : ne garder que les violations persistantes (>= HYSTERESIS_MS)
+    const filtered = {};
+    for (const [ruleId, violations] of Object.entries(rawVerdicts)) {
+      filtered[ruleId] = violations.filter((v) => {
+        const key = violationKey(ruleId, v);
+        const since = seenSince.get(key);
+        return since !== undefined && now - since >= HYSTERESIS_MS;
+      });
+    }
+
+    // FIX A (stabilisation): réutilise la référence précédente si le contenu est identique
+    if (verdictsEqual(filtered, prevVerdictsRef.current)) {
+      return prevVerdictsRef.current;
+    }
+    prevVerdictsRef.current = filtered;
+    return filtered;
+  }, [sources]);
 
   const [ignoredRules, setIgnoredRules] = useState(() => new Set());
   const setIgnored = useCallback((ruleId, value) => {
@@ -75,8 +174,8 @@ export function CoherenceProvider({ token, replicas, children }) {
     [queryClient],
   );
 
-  // Auto-retry effect: watches verdicts, schedules retries for violated rules
-  // with autoRetry and not yet exhausted / ignored.
+  // FIX C: l'effet auto-retry référence verdicts stabilisé (post-hystérésis).
+  // Avec verdicts stable, le cleanup n'annule plus le setTimeout chaque seconde.
   useEffect(() => {
     for (const rule of RULES) {
       if (!rule.autoRetry) continue;

--- a/apps-microservices/crawler-monitor-frontend/src/coherence/CoherenceProvider.test.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/coherence/CoherenceProvider.test.jsx
@@ -5,6 +5,10 @@ import { CoherenceProvider } from './CoherenceProvider';
 import { useCoherenceVerdict, useCoherenceSummary } from './hooks';
 import { mkReplica } from './__fixtures__/mocks';
 
+// Constants mirrored from CoherenceProvider to compute timing expectations
+const EVAL_INTERVAL_MS = 5000;
+const HYSTERESIS_MS = 4000;
+
 const mkWrapper = ({ token = 'tok', replicas = {}, seed } = {}) => {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
@@ -26,14 +30,22 @@ const mkWrapper = ({ token = 'tok', replicas = {}, seed } = {}) => {
 };
 
 describe('CoherenceProvider', () => {
-  it('runs replicas_vs_max_slots and exposes the violation', () => {
+  it('runs replicas_vs_max_slots and exposes the violation', async () => {
+    vi.useFakeTimers();
     const wrapper = mkWrapper({
       replicas: { r1: mkReplica('r1') },
       seed: { capacity: { max_global_jobs: 3, running_jobs: 0 } },
     });
     const { result } = renderHook(() => useCoherenceVerdict('replicas_vs_max_slots'), { wrapper });
+    // Violation not shown yet (hysteresis not met at mount)
+    expect(result.current).toEqual([]);
+    // Advance past first eval tick + hysteresis
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
     expect(result.current).toHaveLength(1);
     expect(result.current[0].data.phantom).toBe(2);
+    vi.useRealTimers();
   });
 
   it('returns [] when sources have no issues', () => {
@@ -45,7 +57,8 @@ describe('CoherenceProvider', () => {
     expect(result.current).toEqual([]);
   });
 
-  it('ignored rule returns [] even if violated', () => {
+  it('ignored rule returns [] even if violated', async () => {
+    vi.useFakeTimers();
     const wrapper = mkWrapper({
       replicas: { r1: mkReplica('r1') },
       seed: { capacity: { max_global_jobs: 3, running_jobs: 0 } },
@@ -58,7 +71,10 @@ describe('CoherenceProvider', () => {
       },
       { wrapper },
     );
-    // Initially violated
+    // Advance past hysteresis so violation is exposed
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
     expect(result.current.verdict).toHaveLength(1);
     // Ignore it
     act(() => result.current.summary.setIgnored('replicas_vs_max_slots', true));
@@ -66,6 +82,7 @@ describe('CoherenceProvider', () => {
     // Un-ignore
     act(() => result.current.summary.setIgnored('replicas_vs_max_slots', false));
     expect(result.current.verdict).toHaveLength(1);
+    vi.useRealTimers();
   });
 
   it('renders children without crashing', () => {
@@ -74,15 +91,55 @@ describe('CoherenceProvider', () => {
     expect(container.textContent).toContain('hello');
   });
 
-  it('summary counts violations by severity excluding ignored', () => {
+  it('summary counts violations by severity excluding ignored', async () => {
+    vi.useFakeTimers();
     const wrapper = mkWrapper({
       replicas: { r1: mkReplica('r1') },
       seed: { capacity: { max_global_jobs: 3, running_jobs: 0 } },
     });
     const { result } = renderHook(() => useCoherenceSummary(), { wrapper });
+    // Advance past hysteresis
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
     expect(result.current.byStatus.warning).toBe(1);
     act(() => result.current.setIgnored('replicas_vs_max_slots', true));
     expect(result.current.byStatus.warning).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('ne fait pas remonter une violation transitoire (< hysteresis)', async () => {
+    vi.useFakeTimers();
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    // running_count_parity: capacity.running_jobs=5 vs 2 jobs => diff=3 > 1 => violation
+    qc.setQueryData(['capacity'], { running_jobs: 5 });
+    qc.setQueryData(['jobs'], [
+      { id: 'a', status: 'running' },
+      { id: 'b', status: 'running' },
+    ]);
+
+    const Wrapper = ({ children }) => (
+      <QueryClientProvider client={qc}>
+        <CoherenceProvider token="tok" replicas={{}}>
+          {children}
+        </CoherenceProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useCoherenceVerdict('running_count_parity'), { wrapper: Wrapper });
+
+    // At mount: violation not shown yet (hysteresis not met)
+    expect(result.current).toEqual([]);
+
+    // Advance past first eval + hysteresis => violation now persisted
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
+    expect(result.current).toHaveLength(1);
+
+    vi.useRealTimers();
   });
 });
 
@@ -98,7 +155,7 @@ describe('CoherenceProvider autoRetry', () => {
       { id: 'a', status: 'running' },
       { id: 'b', status: 'running' },
     ]);
-    // 5 vs 2 → running_count_parity violates (diff=3 > 1 tolerance)
+    // 5 vs 2 => running_count_parity violates (diff=3 > 1 tolerance)
 
     const Wrapper = ({ children }) => (
       <QueryClientProvider client={qc}>
@@ -112,11 +169,18 @@ describe('CoherenceProvider autoRetry', () => {
 
     // At mount: no invalidate yet
     expect(spy).not.toHaveBeenCalled();
-    // Fast-forward 3000ms (delayMs)
+
+    // First: advance past hysteresis so violation becomes visible (triggers auto-retry scheduling)
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
+
+    // Then advance delayMs (3000ms) for the retry timer to fire
     await act(async () => {
       vi.advanceTimersByTime(3000);
     });
-    // Should have called invalidate for capacity AND jobs (running_count_parity.autoRetry.invalidate)
+
+    // Should have called invalidate for capacity AND jobs
     const calledKeys = spy.mock.calls.map((c) => c[0].queryKey);
     expect(calledKeys).toContainEqual(['capacity']);
     expect(calledKeys).toContainEqual(['jobs']);
@@ -141,7 +205,9 @@ describe('CoherenceProvider autoRetry', () => {
     );
     const { result } = renderHook(() => useCoherenceSummary(), { wrapper: Wrapper });
 
-    // Advance enough for 3 tick cycles (only 2 should run, maxAttempts=2)
+    // Advance past hysteresis first
+    await act(async () => { vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100); });
+    // Now advance enough for 3 retry cycles (only 2 should run, maxAttempts=2)
     await act(async () => { vi.advanceTimersByTime(3000); });
     await act(async () => { vi.advanceTimersByTime(3000); });
     await act(async () => { vi.advanceTimersByTime(3000); });

--- a/apps-microservices/crawler-monitor-frontend/src/coherence/components/CoherenceHealthPage.test.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/coherence/components/CoherenceHealthPage.test.jsx
@@ -1,11 +1,15 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '../../components/ui/tooltip';
 import { CoherenceProvider } from '../CoherenceProvider';
 import CoherenceHealthPage from './CoherenceHealthPage';
 import { mkReplica } from '../__fixtures__/mocks';
+
+// Constants mirrored from CoherenceProvider to compute timing expectations
+const EVAL_INTERVAL_MS = 5000;
+const HYSTERESIS_MS = 4000;
 
 const renderPage = ({ replicas = {}, capacity = null } = {}) => {
   const qc = new QueryClient({
@@ -33,12 +37,18 @@ describe('CoherenceHealthPage', () => {
     expect(screen.getByText(/règles ·/i)).toBeInTheDocument();
   });
 
-  it('lists violating rule with its label and message', () => {
+  it('lists violating rule with its label and message', async () => {
+    vi.useFakeTimers();
     renderPage({
       replicas: { r1: mkReplica('r1') },
       capacity: { max_global_jobs: 3, running_jobs: 0 },
     });
+    // Advance past first eval tick + hysteresis before the violation is listed
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
+    });
     expect(screen.getByText(/Replicas vs slots/i)).toBeInTheDocument();
     expect(screen.getByText(/3 slots configurés mais 1 replicas/)).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/apps-microservices/crawler-monitor-frontend/src/coherence/components/CoherencePastille.test.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/coherence/components/CoherencePastille.test.jsx
@@ -1,11 +1,15 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '../../components/ui/tooltip';
 import { CoherenceProvider } from '../CoherenceProvider';
 import { CoherencePastille } from './CoherencePastille';
 import { mkReplica } from '../__fixtures__/mocks';
+
+// Constants mirrored from CoherenceProvider to compute timing expectations
+const EVAL_INTERVAL_MS = 5000;
+const HYSTERESIS_MS = 4000;
 
 const renderWith = (ui, { replicas = {}, capacity = null } = {}) => {
   const qc = new QueryClient({
@@ -37,10 +41,15 @@ describe('CoherencePastille', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders an icon + link when violated', () => {
+  it('renders an icon + link when violated', async () => {
+    vi.useFakeTimers();
     renderWith(<CoherencePastille ruleId="replicas_vs_max_slots" />, {
       replicas: { r1: mkReplica('r1') },
       capacity: { max_global_jobs: 3, running_jobs: 0 },
+    });
+    // Advance past first eval tick + hysteresis before the violation is shown
+    await act(async () => {
+      vi.advanceTimersByTime(EVAL_INTERVAL_MS + HYSTERESIS_MS + 100);
     });
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/health#rule-replicas_vs_max_slots');
@@ -48,6 +57,7 @@ describe('CoherencePastille', () => {
       'aria-label',
       expect.stringMatching(/Incohérence/),
     );
+    vi.useRealTimers();
   });
 
   it('renders nothing for unknown rule id', () => {


### PR DESCRIPTION
…couplage 1 Hz + hysteresis)

CapacityBar et les cartes replicas s'agitaient (clignotement de l'icone d'incoherence) en temps reel. Cause racine: App.jsx flush setReplicas toutes les 1s, donc CoherenceProvider recalculait tous les verdicts (objet neuf) chaque seconde -> la value du contexte changeait chaque seconde -> tous les CoherencePastille re-render a 1 Hz. De plus les regles comparent une source live (replicas, 1s) a une source REST stale (jobs/capacity, staleTime 30s), donc les verdicts basculaient present/absent pendant les fenetres de desync -> l'icone clignotait. L'effet auto-retry etait aussi neutralise (deps [verdicts] -> son setTimeout annule chaque seconde, jamais declenche).

Fix (src/coherence/CoherenceProvider.jsx):
- A: evaluation decouplee du flux 1 Hz. replicas lu via un ref; reevaluation cadencee par un tick toutes les EVAL_INTERVAL_MS (5s). Identite des verdicts stabilisee par egalite de contenu (reutilise la ref precedente) -> les pastilles ne re-render que sur changement reel.
- B: hysteresis. Une violation doit persister >= HYSTERESIS_MS (4s) avant d'etre affichee (seenSinceRef); disparition immediate. Supprime le clignotement transitoire WS/REST.
- C: auto-retry repare par effet de bord (verdicts stable -> le timer survit).

Tests src/coherence: 40/40 passent (regression d'hysteresis ajoutee; tests synchrones adaptes aux fake timers, regles individuelles intactes).