### PR TITLE
feat(crawler-monitor): vague UX - capacite reelle, resilience WS, rou…

### DIFF
--- a/apps-microservices/crawler-monitor-frontend/src/App.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { RefreshCw } from 'lucide-react';
 import { setOnUnauthorized } from './lib/api';
 import { isReplicaLive } from './lib/replicas';
+import { wsBackoffDelay } from './lib/backoff';
 import { useCallbacksQuery, useWsInvalidator, queryKeys } from './hooks/queries';
 import LoginPage from './components/LoginPage';
 import Overview from './pages/Overview';
@@ -47,8 +48,11 @@ const PageFallback = () => (
 const App = () => {
   const [token, setToken] = useState(localStorage.getItem('authToken'));
   const [replicas, setReplicas] = useState({});
-  const [, setIsConnected] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef(null);
+  // Reconnexion WS : timer en attente et compteur de tentatives (backoff).
+  const reconnectTimerRef = useRef(null);
+  const reconnectAttemptRef = useRef(0);
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -87,19 +91,11 @@ const App = () => {
   const pendingReplicasRef = useRef({});
   const replicasFlushTimerRef = useRef(null);
 
-  // WebSocket connection
+  // WebSocket connection — avec reconnexion automatique (backoff exponentiel)
   useEffect(() => {
     if (!token) return;
 
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}/api?token=${token}`;
-    console.log('Connecting to WebSocket:', wsUrl);
-    wsRef.current = new WebSocket(wsUrl);
-
-    wsRef.current.onopen = () => {
-      console.log('Connected to WebSocket');
-      setIsConnected(true);
-    };
+    let cancelled = false; // fermé volontairement (cleanup) — propre à CETTE instance d'effet
 
     const flushReplicas = () => {
       replicasFlushTimerRef.current = null;
@@ -109,33 +105,61 @@ const App = () => {
       setReplicas(prev => ({ ...prev, ...pending }));
     };
 
-    wsRef.current.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        if (data.type === 'job_update') {
-          handleJobUpdate(data.crawl_id);
-        } else if (data.type === 'replica_heartbeat') {
-          const hb = data.data;
-          if (!hb || !hb.replicaId) return;
-          // Buffer: same replicaId collapses to the latest heartbeat only.
-          // Stamp browser-local receive time → liveness immune to clock skew
-          // between this machine and the crawler container (see lib/replicas).
-          pendingReplicasRef.current[hb.replicaId] = { ...hb, receivedAt: Date.now() };
-          if (!replicasFlushTimerRef.current) {
-            replicasFlushTimerRef.current = setTimeout(flushReplicas, 1000);
+    const connect = () => {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const wsUrl = `${protocol}//${window.location.host}/api?token=${token}`;
+      console.log('Connecting to WebSocket:', wsUrl);
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        console.log('Connected to WebSocket');
+        setIsConnected(true);
+        reconnectAttemptRef.current = 0; // reset du backoff après une connexion réussie
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'job_update') {
+            handleJobUpdate(data.crawl_id);
+          } else if (data.type === 'replica_heartbeat') {
+            const hb = data.data;
+            if (!hb || !hb.replicaId) return;
+            // Buffer: same replicaId collapses to the latest heartbeat only.
+            // Stamp browser-local receive time → liveness immune to clock skew
+            // between this machine and the crawler container (see lib/replicas).
+            pendingReplicasRef.current[hb.replicaId] = { ...hb, receivedAt: Date.now() };
+            if (!replicasFlushTimerRef.current) {
+              replicasFlushTimerRef.current = setTimeout(flushReplicas, 1000);
+            }
           }
+        } catch (e) {
+          console.error('WebSocket message error:', e);
         }
-      } catch (e) {
-        console.error('WebSocket message error:', e);
-      }
+      };
+
+      ws.onclose = () => {
+        setIsConnected(false);
+        // Fermeture volontaire (unmount / changement de token) : pas de reconnexion.
+        if (cancelled) return;
+        const delay = wsBackoffDelay(reconnectAttemptRef.current++);
+        console.log(`WebSocket disconnected — retry in ${delay}ms`);
+        reconnectTimerRef.current = setTimeout(() => {
+          reconnectTimerRef.current = null;
+          connect();
+        }, delay);
+      };
     };
 
-    wsRef.current.onclose = () => {
-      console.log('WebSocket disconnected');
-      setIsConnected(false);
-    };
+    connect();
 
     return () => {
+      cancelled = true;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
       if (wsRef.current) wsRef.current.close();
       // Drop any pending flush to avoid setState after unmount
       if (replicasFlushTimerRef.current) {
@@ -145,6 +169,18 @@ const App = () => {
       pendingReplicasRef.current = {};
     };
   }, [token, handleJobUpdate]);
+
+  // Fallback REST : si le WS est déconnecté, on rafraîchit les données clés
+  // toutes les 15s pour que le dashboard ne gèle pas silencieusement.
+  useEffect(() => {
+    if (!token || isConnected) return;
+    const interval = setInterval(() => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.capacity() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.callbacks() });
+    }, 15_000);
+    return () => clearInterval(interval);
+  }, [token, isConnected, queryClient]);
 
   // Clean up zombie replicas (older than 30s)
   useEffect(() => {
@@ -179,6 +215,7 @@ const App = () => {
   return (
     <CoherenceProvider token={token} replicas={replicas}>
       <AppShell
+        wsConnected={isConnected}
         badges={{ failedCallbacks: failedCallbackCount }}
         onLogout={handleLogout}
         onRefresh={handleManualRefresh}

--- a/apps-microservices/crawler-monitor-frontend/src/components/JobDetails.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/components/JobDetails.jsx
@@ -6,7 +6,6 @@ import {
   Play, Download, ExternalLink, MoreVertical,
   Settings, Layers, Mail,
   Cpu, RefreshCw,
-  ChevronDown, Search,
 } from 'lucide-react';
 import AdvancedLogViewer from './AdvancedLogViewer';
 import { Button } from './ui/button';
@@ -273,6 +272,21 @@ const JobDetails = ({ job, onToggleRaw, showRaw, onSelectJob, token, inline = fa
   const cbUrl = cb?.url ?? null;
   const cbOk = cbStatus === '200' || cbStatus === 200;
 
+  /*
+   * Visibilité des sections — une section est masquée tant que TOUTES ses
+   * valeurs sont absentes ; elle réapparaîtra dès que l'API les fournira.
+   */
+  const hasAnyKpi = [
+    stats?.requestsTotal,
+    stats?.requestsFinished,
+    stats?.requestsFailed,
+    formatDuration(stats?.crawlerRuntimeMillis),
+    throughput,
+    formatBytes(stats?.totalBytes),
+  ].some((v) => v != null);
+  const hasConfig = [cfg.strategy, cfg.depth, cfg.concurrency, cfg.user_agent ?? cfg.userAgent, cfg.respect_robots, cfg.timeout_ms ?? cfg.timeout, cfg.retries, cfg.cron ?? job.cron].some((v) => v != null);
+  const hasCallbackInfo = cbStatus != null || cbUrl != null || cbLatency != null;
+
   /* -- render --------------------------------------------------------------- */
   return (
     <div>
@@ -379,19 +393,21 @@ const JobDetails = ({ job, onToggleRaw, showRaw, onSelectJob, token, inline = fa
         </div>
       </div>
 
-      {/* KPI STRIP */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 border border-hairline rounded-lg mb-5">
-        <KpiCell label="URLs crawlées"  value={stats?.requestsTotal ?? null} />
-        <KpiCell label="Items extraits" value={stats?.requestsFinished ?? null} />
-        <KpiCell
-          label="Erreurs HTTP"
-          value={stats?.requestsFailed ?? null}
-          tone={stats?.requestsFailed > 0 ? 'warn' : undefined}
-        />
-        <KpiCell label="Durée totale"   value={formatDuration(stats?.crawlerRuntimeMillis)} />
-        <KpiCell label="Throughput"     value={throughput} />
-        <KpiCell label="Bandwidth"      value={formatBytes(stats?.totalBytes)} />
-      </div>
+      {/* KPI STRIP — masqué tant que l'API ne fournit aucune statistique */}
+      {hasAnyKpi && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 border border-hairline rounded-lg mb-5">
+          <KpiCell label="URLs crawlées"  value={stats?.requestsTotal ?? null} />
+          <KpiCell label="Items extraits" value={stats?.requestsFinished ?? null} />
+          <KpiCell
+            label="Erreurs HTTP"
+            value={stats?.requestsFailed ?? null}
+            tone={stats?.requestsFailed > 0 ? 'warn' : undefined}
+          />
+          <KpiCell label="Durée totale"   value={formatDuration(stats?.crawlerRuntimeMillis)} />
+          <KpiCell label="Throughput"     value={throughput} />
+          <KpiCell label="Bandwidth"      value={formatBytes(stats?.totalBytes)} />
+        </div>
+      )}
 
       {/* TABS + SIDEBAR */}
       <div className="grid gap-5 grid-cols-1 md:grid-cols-[1fr_360px]">
@@ -419,24 +435,6 @@ const JobDetails = ({ job, onToggleRaw, showRaw, onSelectJob, token, inline = fa
                 <AdvancedLogViewer content={job.rawContent || 'Contenu brut non disponible.'} jobId={job.id} />
               ) : (
                 <>
-                  {/* Fix 6: Logs toolbar */}
-                  <div className="flex items-center gap-2 mb-3">
-                    <button
-                      onClick={() => console.log('Filtre niveau')}
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[12px] text-ink-2 hover:text-ink-0 hover:bg-bg-2 border border-hairline transition-colors"
-                    >
-                      <ChevronDown size={12} />
-                      Niveau
-                    </button>
-                    <button
-                      onClick={() => console.log('Filtrer logs')}
-                      className="inline-flex items-center gap-1.5 flex-1 px-2.5 py-1.5 rounded-md text-[12px] text-ink-2 hover:text-ink-0 hover:bg-bg-2 border border-hairline transition-colors"
-                    >
-                      <Search size={12} />
-                      Filtrer
-                    </button>
-                  </div>
-
                   {!job.hasStats && !job.stats ? (
                     <div className="py-12 text-center text-ink-2">
                       <Clock className={`mx-auto mb-3 h-10 w-10 ${isRunning ? 'animate-spin' : 'text-ink-3'}`} />
@@ -530,67 +528,78 @@ const JobDetails = ({ job, onToggleRaw, showRaw, onSelectJob, token, inline = fa
         {/* Right: sidebar — Fix 8: 3 dedicated cards */}
         <div className="flex flex-col gap-4">
 
-          {/* Card A: Configuration */}
-          <SideCard icon={Settings} title="Configuration">
-            <KV k="Strategy"       v={cfg.strategy ?? null}            mono />
-            <KV k="Depth"          v={cfg.depth != null ? String(cfg.depth) : null} />
-            <KV k="Concurrency"    v={cfg.concurrency != null ? `${cfg.concurrency} parallel` : null} />
-            <KV k="User-agent"     v={cfg.user_agent ?? cfg.userAgent ?? null}  mono />
-            <KV k="Respect robots" v={cfg.respect_robots != null ? (cfg.respect_robots ? 'oui' : 'non') : null} tone={cfg.respect_robots ? 'ok' : undefined} />
-            <KV k="Timeout"        v={cfg.timeout_ms != null ? `${cfg.timeout_ms / 1000}s` : cfg.timeout ?? null} />
-            <KV k="Retries"        v={cfg.retries != null ? `${cfg.retries} max` : null} />
-            <KV k="Cron"           v={cfg.cron ?? job.cron ?? null}    mono />
-          </SideCard>
+          {/* Card A: Configuration — masquée tant que l'API ne fournit aucune valeur */}
+          {hasConfig && (
+            <SideCard icon={Settings} title="Configuration">
+              <KV k="Strategy"       v={cfg.strategy ?? null}            mono />
+              <KV k="Depth"          v={cfg.depth != null ? String(cfg.depth) : null} />
+              <KV k="Concurrency"    v={cfg.concurrency != null ? `${cfg.concurrency} parallel` : null} />
+              <KV k="User-agent"     v={cfg.user_agent ?? cfg.userAgent ?? null}  mono />
+              <KV k="Respect robots" v={cfg.respect_robots != null ? (cfg.respect_robots ? 'oui' : 'non') : null} tone={cfg.respect_robots ? 'ok' : undefined} />
+              <KV k="Timeout"        v={cfg.timeout_ms != null ? `${cfg.timeout_ms / 1000}s` : cfg.timeout ?? null} />
+              <KV k="Retries"        v={cfg.retries != null ? `${cfg.retries} max` : null} />
+              <KV k="Cron"           v={cfg.cron ?? job.cron ?? null}    mono />
+            </SideCard>
+          )}
 
-          {/* Card B: Pipeline */}
-          <SideCard icon={Layers} title="Pipeline">
-            {PIPELINE_STEPS.map((step) => {
-              const s = pipeline ? (pipeline[step] ?? {}) : {};
-              return (
-                <PipelineRow
-                  key={step}
-                  label={step}
-                  duration={s.duration ?? null}
-                  ratio={s.ratio ?? null}
-                />
-              );
-            })}
-          </SideCard>
+          {/* Card B: Pipeline — masquée tant que job.pipeline est absent de l'API */}
+          {pipeline && (
+            <SideCard icon={Layers} title="Pipeline">
+              {PIPELINE_STEPS.map((step) => {
+                const s = pipeline ? (pipeline[step] ?? {}) : {};
+                return (
+                  <PipelineRow
+                    key={step}
+                    label={step}
+                    duration={s.duration ?? null}
+                    ratio={s.ratio ?? null}
+                  />
+                );
+              })}
+            </SideCard>
+          )}
 
-          {/* Card C: Callback */}
-          <SideCard icon={Mail} title="Callback">
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center gap-2">
-                {cbStatus ? (
-                  <>
-                    <Pill tone={cbOk ? 'ok' : 'err'} dot>
-                      {cbOk ? '200 OK' : `Échec${cbStatus ? ` (${cbStatus})` : ''}`}
-                    </Pill>
-                    {cbLatency && (
-                      <span className="font-mono text-[11px] text-ink-2">{cbLatency}</span>
-                    )}
-                  </>
-                ) : (
-                  <span className="text-[12px] text-ink-3 font-mono">—</span>
-                )}
+          {/* Card C: Callback — masquée sans info callback (le bouton Rejouer est disabled sans cb, donc inutile seul) */}
+          {hasCallbackInfo && (
+            <SideCard icon={Mail} title="Callback">
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-2">
+                  {cbStatus ? (
+                    <>
+                      <Pill tone={cbOk ? 'ok' : 'err'} dot>
+                        {cbOk ? '200 OK' : `Échec${cbStatus ? ` (${cbStatus})` : ''}`}
+                      </Pill>
+                      {cbLatency && (
+                        <span className="font-mono text-[11px] text-ink-2">{cbLatency}</span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-[12px] text-ink-3 font-mono">—</span>
+                  )}
+                </div>
+
+                <div className="font-mono text-[11px] text-ink-1 p-2.5 bg-bg-1 rounded-md border border-hairline break-all min-h-[32px]">
+                  {cbUrl ?? '—'}
+                </div>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!cb}
+                  onClick={() => console.log('Rejouer callback', job.id)}
+                  className="w-full justify-center gap-1.5 text-[12px]"
+                >
+                  <RefreshCw size={12} />
+                  Rejouer le callback
+                </Button>
               </div>
+            </SideCard>
+          )}
 
-              <div className="font-mono text-[11px] text-ink-1 p-2.5 bg-bg-1 rounded-md border border-hairline break-all min-h-[32px]">
-                {cbUrl ?? '—'}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!cb}
-                onClick={() => console.log('Rejouer callback', job.id)}
-                className="w-full justify-center gap-1.5 text-[12px]"
-              >
-                <RefreshCw size={12} />
-                Rejouer le callback
-              </Button>
-            </div>
-          </SideCard>
+          {/* Fallback discret quand aucune métadonnée latérale n'est disponible */}
+          {!hasConfig && !pipeline && !hasCallbackInfo && (
+            <p className="text-[12px] text-ink-3 text-center py-4">Métadonnées de configuration non disponibles pour ce job.</p>
+          )}
 
         </div>
       </div>

--- a/apps-microservices/crawler-monitor-frontend/src/components/layout/AppShell.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/components/layout/AppShell.jsx
@@ -23,6 +23,7 @@ export function AppShell({
   onLogout,
   onRefresh,
   isRefreshing = false,
+  wsConnected = true,
 }) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -72,6 +73,7 @@ export function AppShell({
           onOpenCommandPalette={() => setPaletteOpen(true)}
           onRefresh={onRefresh}
           isRefreshing={isRefreshing}
+          wsConnected={wsConnected}
         />
         {/* pb-16 réserve la hauteur de la BottomTabBar sur mobile */}
         <main className="flex-1 overflow-y-auto p-5 pb-16 sm:pb-5">

--- a/apps-microservices/crawler-monitor-frontend/src/components/layout/Topbar.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/components/layout/Topbar.jsx
@@ -14,13 +14,14 @@ const isMac =
  *
  * Hauteur : 52px (alignée sur le brand de la Sidebar).
  * Layout (gauche → droite) :
- *   [burger mobile] · Breadcrumbs · (spacer) · Cmd+K · Refresh · ThemeToggle
+ *   [burger mobile] · Breadcrumbs · (spacer) · Badge Live · Cmd+K · Refresh · ThemeToggle
  */
 export function Topbar({
   onOpenMobileSidebar,
   onOpenCommandPalette,
   onRefresh,
   isRefreshing = false,
+  wsConnected = true,
 }) {
   return (
     <header className="h-[52px] flex-shrink-0 flex items-center px-5 border-b border-hairline bg-surface gap-4">
@@ -42,6 +43,20 @@ export function Topbar({
 
       {/* Actions à droite */}
       <div className="flex items-center gap-1 shrink-0">
+        {/* État de la liaison temps réel (WebSocket) */}
+        <span
+          className={cn(
+            'hidden sm:inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium',
+            wsConnected
+              ? 'border-ok/30 bg-ok-soft text-ok'
+              : 'border-err/30 bg-err-soft text-err',
+          )}
+          title={wsConnected ? 'Temps réel actif (WebSocket connecté)' : 'Temps réel interrompu — données rafraîchies toutes les 15s, reconnexion en cours'}
+        >
+          <span className={cn('h-1.5 w-1.5 rounded-full', wsConnected ? 'bg-ok animate-pulse' : 'bg-err')} />
+          {wsConnected ? 'Live' : 'Hors ligne'}
+        </span>
+
         {/* Bouton Cmd+K — desktop */}
         {onOpenCommandPalette && (
           <button

--- a/apps-microservices/crawler-monitor-frontend/src/hooks/queries.js
+++ b/apps-microservices/crawler-monitor-frontend/src/hooks/queries.js
@@ -262,7 +262,7 @@ export function useAlbumErrorsQuery(token, domain, options = {}) {
 export function useAlbumDeleteJobQuery(token, jobId, options = {}) {
   return useQuery({
     queryKey: queryKeys.albumDeleteJob(jobId),
-    queryFn: () => api.get(`/albums/delete-jobs/${jobId}`, token),
+    queryFn: () => api.get(`/albums/jobs/${jobId}`, token),
     enabled: !!token && !!jobId,
     refetchInterval: (q) => {
       const status = q.state.data?.status;

--- a/apps-microservices/crawler-monitor-frontend/src/lib/backoff.js
+++ b/apps-microservices/crawler-monitor-frontend/src/lib/backoff.js
@@ -1,0 +1,9 @@
+// Délai de reconnexion WebSocket : backoff exponentiel borné.
+// attempt 0 → 1s, 1 → 2s, 2 → 4s, ... plafonné à 30s.
+export const WS_BACKOFF_BASE_MS = 1000;
+export const WS_BACKOFF_MAX_MS = 30_000;
+
+export function wsBackoffDelay(attempt) {
+  const n = Math.max(0, Math.floor(attempt ?? 0));
+  return Math.min(WS_BACKOFF_BASE_MS * 2 ** n, WS_BACKOFF_MAX_MS);
+}

--- a/apps-microservices/crawler-monitor-frontend/src/lib/backoff.test.js
+++ b/apps-microservices/crawler-monitor-frontend/src/lib/backoff.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { wsBackoffDelay, WS_BACKOFF_BASE_MS, WS_BACKOFF_MAX_MS } from './backoff';
+
+describe('wsBackoffDelay', () => {
+  it('attempt 0 → 1s', () => {
+    expect(wsBackoffDelay(0)).toBe(1000);
+  });
+
+  it('attempt 1 → 2s', () => {
+    expect(wsBackoffDelay(1)).toBe(2000);
+  });
+
+  it('attempt 2 → 4s', () => {
+    expect(wsBackoffDelay(2)).toBe(4000);
+  });
+
+  it('attempt 4 → 16s', () => {
+    expect(wsBackoffDelay(4)).toBe(16000);
+  });
+
+  it('attempt 5 → plafonné à 30s', () => {
+    expect(wsBackoffDelay(5)).toBe(30000);
+  });
+
+  it('attempt 10 → toujours plafonné à 30s', () => {
+    expect(wsBackoffDelay(10)).toBe(30000);
+  });
+
+  it('attempt négatif → délai de base (1s)', () => {
+    expect(wsBackoffDelay(-3)).toBe(1000);
+  });
+
+  it('attempt undefined → délai de base (1s)', () => {
+    expect(wsBackoffDelay(undefined)).toBe(1000);
+  });
+
+  it('expose les constantes base/max', () => {
+    expect(WS_BACKOFF_BASE_MS).toBe(1000);
+    expect(WS_BACKOFF_MAX_MS).toBe(30000);
+  });
+});

--- a/apps-microservices/crawler-monitor-frontend/src/pages/Overview.jsx
+++ b/apps-microservices/crawler-monitor-frontend/src/pages/Overview.jsx
@@ -174,7 +174,7 @@ const Overview = ({ token, replicas }) => {
   }, [allJobs]);
 
   // Total slots from capacity or replica count
-  const totalSlots = capacity?.total ?? (replicas ? Object.keys(replicas).length : 0);
+  const totalSlots = capacity?.max_global_jobs ?? (replicas ? Object.keys(replicas).length : 0);
 
   // Build timeline data: aggregate jobs by hour (last 24 buckets)
   const timelineData = useMemo(() => {
@@ -397,11 +397,11 @@ const Overview = ({ token, replicas }) => {
         <SectionCard
           icon={Cpu}
           title="Capacité globale"
-          subtitle={`${capacity?.used ?? 0} / ${capacity?.total ?? totalSlots} slots utilisés`}
+          subtitle={`${capacity?.running_jobs ?? 0} / ${capacity?.max_global_jobs ?? totalSlots} slots utilisés`}
         >
           <CapacityRing
-            used={capacity?.used ?? 0}
-            total={capacity?.total ?? Math.max(1, totalSlots)}
+            used={capacity?.running_jobs ?? 0}
+            total={capacity?.max_global_jobs ?? Math.max(1, totalSlots)}
             format="count"
           />
           {/* Replica list with mini progress bars */}


### PR DESCRIPTION
…te album, panneaux vides

Quatre ameliorations UX/coherence sur le dashboard:

1. Capacite globale: l'anneau affichait 0/N alors que des jobs tournaient. Overview.jsx lisait des champs inexistants (capacity.used/total); il lit desormais running_jobs/max_global_jobs, les champs reels de GET /api/capacity.

2. Resilience WebSocket: onclose ne faisait que logger -> dashboard gele silencieusement en cas de coupure (redeploy, reseau). Ajout:
   - reconnexion automatique avec backoff exponentiel 1s->30s (helper teste src/lib/backoff.js), reset apres reconnexion reussie
   - badge Live / Hors ligne dans la Topbar (prop wsConnected via AppShell)
   - polling REST de secours 15s (jobs/capacite/callbacks) tant que deconnecte
   - garde par variable de closure par instance d'effet (pas de ref partage: evite une reconnexion fantome quand l'ancien onclose arrive apres le re-run de l'effet, StrictMode inclus)

3. Suppression d'album: le polling de progression appelait /albums/delete-jobs/{id} (404 en boucle); la route reelle du backend Go est /albums/jobs/{id} (forward vers image-download-service GET /jobs/{id}).

4. Detail job: la rangee de 6 KPI et les cartes Configuration/Pipeline/ Callback s'affichaient vides (sources job.config/pipeline/callback absentes de l'API). Rendu conditionnel: masquees tant que vides, reaffichees automatiquement des que l'API fournira les donnees; fallback discret si toute la colonne est vide. Suppression des deux boutons morts de la toolbar Logs (onClick = console.log).

Tests: 96/96 (87 existants + 9 nouveaux backoff). ESLint: 0 erreur nouvelle.