### PR TITLE
feat(account-service): bounce failed OAuth2 login to /login with error

### DIFF
--- a/apps-microservices/account-service-backend/internal/authserver/handler.go
+++ b/apps-microservices/account-service-backend/internal/authserver/handler.go
@@ -80,16 +80,7 @@ func (s *AuthServer) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Otherwise bounce to Vue login route, preserving every OAuth2 param
-		q := url.Values{}
-		q.Set("response_type", p.ResponseType)
-		q.Set("client_id", p.ClientID)
-		q.Set("redirect_uri", p.RedirectURI)
-		q.Set("code_challenge", p.CodeChallenge)
-		q.Set("code_challenge_method", p.CodeChallengeMethod)
-		if p.State != "" {
-			q.Set("state", p.State)
-		}
-		http.Redirect(w, r, s.deps.LoginPath+"?"+q.Encode(), http.StatusFound)
+		http.Redirect(w, r, s.deps.LoginPath+"?"+loginRedirectParams(p).Encode(), http.StatusFound)
 
 	case http.MethodPost:
 		if r.FormValue("action") != "login" {
@@ -103,11 +94,39 @@ func (s *AuthServer) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// loginRedirectParams rebuilds the OAuth2 query string the Vue login route
+// needs to re-render and re-submit the consent form. Shared by the GET bounce
+// (unauthenticated browser) and the POST failure bounce (redirectLoginErr).
+func loginRedirectParams(p *AuthorizeParams) url.Values {
+	q := url.Values{}
+	q.Set("response_type", p.ResponseType)
+	q.Set("client_id", p.ClientID)
+	q.Set("redirect_uri", p.RedirectURI)
+	q.Set("code_challenge", p.CodeChallenge)
+	q.Set("code_challenge_method", p.CodeChallengeMethod)
+	if p.State != "" {
+		q.Set("state", p.State)
+	}
+	return q
+}
+
+// redirectLoginErr bounces a failed login back to the Vue login page, keeping
+// every OAuth2 param plus a machine-readable error code (the frontend maps it
+// to a French message) and the typed username so only the password is re-entered.
+func (s *AuthServer) redirectLoginErr(w http.ResponseWriter, r *http.Request, p *AuthorizeParams, errCode string) {
+	q := loginRedirectParams(p)
+	if username := r.FormValue("username"); username != "" {
+		q.Set("username", username)
+	}
+	q.Set("error", errCode)
+	http.Redirect(w, r, s.deps.LoginPath+"?"+q.Encode(), http.StatusFound)
+}
+
 func (s *AuthServer) handleLogin(w http.ResponseWriter, r *http.Request, client *db.OAuth2Client, p *AuthorizeParams) {
 	username := r.FormValue("username")
 	password := r.FormValue("password")
 	if username == "" || password == "" {
-		writeOAuthErr(w, http.StatusBadRequest, "invalid_request", "missing credentials")
+		s.redirectLoginErr(w, r, p, "missing_credentials")
 		return
 	}
 	resp, err := auth.AuthenticateHellopro(s.deps.AuthURL, username, password)
@@ -121,7 +140,7 @@ func (s *AuthServer) handleLogin(w http.ResponseWriter, r *http.Request, client 
 		err = nil
 	}
 	if err != nil || !resp.Success {
-		writeOAuthErr(w, http.StatusUnauthorized, "invalid_grant", "invalid credentials")
+		s.redirectLoginErr(w, r, p, "credentials_error")
 		return
 	}
 	u, err := s.deps.UserUpserter.UpsertOnLogin(resp.Email, resp.DisplayName)
@@ -130,11 +149,11 @@ func (s *AuthServer) handleLogin(w http.ResponseWriter, r *http.Request, client 
 		return
 	}
 	if !u.IsAllowed {
-		writeOAuthErr(w, http.StatusForbidden, "access_denied", "user blocked")
+		s.redirectLoginErr(w, r, p, "user_blocked")
 		return
 	}
 	if !s.userMatchesAllowedRoles(u, client) {
-		writeOAuthErr(w, http.StatusForbidden, "access_denied", "role not allowed for this client")
+		s.redirectLoginErr(w, r, p, "role_not_allowed")
 		return
 	}
 	_ = auth.SetSession(w, s.deps.JWTSecret, auth.SessionData{

--- a/apps-microservices/account-service-backend/internal/authserver/handler_test.go
+++ b/apps-microservices/account-service-backend/internal/authserver/handler_test.go
@@ -1,0 +1,171 @@
+package authserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"account-service/internal/auth"
+	"account-service/internal/db"
+)
+
+// cfgUserSrc is a configurable UserUpserter for exercising the blocked /
+// role-not-allowed branches of handleLogin.
+type cfgUserSrc struct {
+	allowed bool
+	admin   bool
+}
+
+func (c cfgUserSrc) UpsertOnLogin(email, name string) (*auth.UpsertedUser, error) {
+	return &auth.UpsertedUser{Email: email, IsAllowed: c.allowed, IsAdmin: c.admin}, nil
+}
+
+func okHelloPro() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"email":"alice@example.com","display_name":"Alice"}`))
+	}))
+}
+
+func newTestServer(cli *db.OAuth2Client, helloURL string, users auth.UserUpserter) *AuthServer {
+	return NewAuthServer(AuthServerDeps{
+		ClientRepo:   &fakeClientRepo{c: cli},
+		AuthCodeRepo: &fakeAuthCodeRepo{},
+		UserUpserter: users,
+		AuthURL:      helloURL,
+		JWTSecret:    "s",
+		Issuer:       "https://account.test",
+		LoginPath:    "/login",
+		SecureCookie: false,
+	})
+}
+
+func loginClient() *db.OAuth2Client {
+	uris := `["https://x/cb"]`
+	return &db.OAuth2Client{ClientID: "x", RedirectURIs: &uris, IsActive: true}
+}
+
+func postLogin(srv *AuthServer, username, password string) *httptest.ResponseRecorder {
+	form := url.Values{
+		"action":                {"login"},
+		"response_type":         {"code"},
+		"client_id":             {"x"},
+		"redirect_uri":          {"https://x/cb"},
+		"code_challenge":        {"chal"},
+		"code_challenge_method": {"S256"},
+		"state":                 {"abc"},
+		"username":              {username},
+		"password":              {password},
+	}
+	r := httptest.NewRequest(http.MethodPost, "/authorize", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.HandleAuthorize(w, r)
+	return w
+}
+
+// assertLoginRedirect verifies a 302 back to /login carrying the given error
+// code and every OAuth2 param needed to re-render and re-submit the form.
+func assertLoginRedirect(t *testing.T, w *httptest.ResponseRecorder, wantErr string) url.Values {
+	t.Helper()
+	if w.Code != http.StatusFound {
+		t.Fatalf("Code=%d body=%s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/login?") {
+		t.Fatalf("Location=%q want /login? prefix", loc)
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse Location %q: %v", loc, err)
+	}
+	q := u.Query()
+	checks := map[string]string{
+		"error":                 wantErr,
+		"client_id":             "x",
+		"redirect_uri":          "https://x/cb",
+		"code_challenge":        "chal",
+		"code_challenge_method": "S256",
+		"response_type":         "code",
+		"state":                 "abc",
+	}
+	for k, want := range checks {
+		if q.Get(k) != want {
+			t.Fatalf("%s=%q want %q (loc=%s)", k, q.Get(k), want, loc)
+		}
+	}
+	return q
+}
+
+func TestAuthorizePOST_BadCredentials_RedirectsToLogin(t *testing.T) {
+	hp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false}`))
+	}))
+	defer hp.Close()
+
+	srv := newTestServer(loginClient(), hp.URL, cfgUserSrc{allowed: true})
+	w := postLogin(srv, "alice", "wrong")
+
+	q := assertLoginRedirect(t, w, "credentials_error")
+	if q.Get("username") != "alice" {
+		t.Fatalf("username=%q want alice (typed username should survive the bounce)", q.Get("username"))
+	}
+}
+
+func TestAuthorizePOST_MissingPassword_RedirectsToLogin(t *testing.T) {
+	// Missing fields short-circuit before AuthenticateHellopro, so AuthURL is unused.
+	srv := newTestServer(loginClient(), "", cfgUserSrc{allowed: true})
+	w := postLogin(srv, "alice", "")
+
+	q := assertLoginRedirect(t, w, "missing_credentials")
+	if q.Get("username") != "alice" {
+		t.Fatalf("username=%q want alice", q.Get("username"))
+	}
+}
+
+func TestAuthorizePOST_BlockedUser_RedirectsToLogin(t *testing.T) {
+	hp := okHelloPro()
+	defer hp.Close()
+
+	srv := newTestServer(loginClient(), hp.URL, cfgUserSrc{allowed: false})
+	w := postLogin(srv, "alice", "p")
+
+	assertLoginRedirect(t, w, "user_blocked")
+}
+
+func TestAuthorizePOST_RoleNotAllowed_RedirectsToLogin(t *testing.T) {
+	hp := okHelloPro()
+	defer hp.Close()
+
+	cli := loginClient()
+	roles := `["admin"]`
+	cli.AllowedRoles = &roles
+
+	srv := newTestServer(cli, hp.URL, cfgUserSrc{allowed: true, admin: false})
+	w := postLogin(srv, "alice", "p")
+
+	assertLoginRedirect(t, w, "role_not_allowed")
+}
+
+// A genuine server error (not a user-fixable login failure) must NOT bounce to
+// /login — it stays a JSON error so the problem is visible.
+func TestAuthorizePOST_ServerError_StaysJSON(t *testing.T) {
+	hp := okHelloPro()
+	defer hp.Close()
+
+	srv := newTestServer(loginClient(), hp.URL, errUserSrc{})
+	w := postLogin(srv, "alice", "p")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Code=%d want 500 (loc=%q)", w.Code, w.Header().Get("Location"))
+	}
+}
+
+type errUserSrc struct{}
+
+func (errUserSrc) UpsertOnLogin(_, _ string) (*auth.UpsertedUser, error) {
+	return nil, http.ErrAbortHandler
+}

--- a/apps-microservices/account-service-frontend/src/views/LoginView.vue
+++ b/apps-microservices/account-service-frontend/src/views/LoginView.vue
@@ -9,9 +9,26 @@ const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 
-const username = ref('')
+// French messages for the error codes the backend appends when it bounces a
+// failed OAuth2 login back to /login (see redirectLoginErr in the auth server).
+const ERROR_MESSAGES: Record<string, string> = {
+  credentials_error: "Nom d'utilisateur ou mot de passe incorrect.",
+  missing_credentials: 'Tous les champs sont obligatoires.',
+  user_blocked: 'Votre compte est bloqué. Contactez un administrateur.',
+  role_not_allowed: "Vous n'êtes pas autorisé à accéder à ce service.",
+}
+
+function queryParam(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+const username = ref(queryParam(route.query.username))
 const password = ref('')
-const errorMessage = ref('')
+const errorMessage = ref(
+  route.query.error
+    ? (ERROR_MESSAGES[queryParam(route.query.error)] ?? 'Erreur de connexion')
+    : '',
+)
 
 const oauthMode = computed(() =>
   Boolean(route.query.client_id && route.query.redirect_uri && route.query.code_challenge),


### PR DESCRIPTION
EN: On OAuth2 login failure, redirect back to the Vue /login page with all OAuth2 params and the typed username preserved, plus a machine-readable error code that the frontend maps to a French message. Covers bad credentials, missing fields, blocked user, and role-not-allowed. Genuine server errors and OAuth protocol errors stay as JSON. Native form POST means only the backend can issue the redirect, so the auth server builds it (shared loginRedirectParams helper) and LoginView reads route.query.error/username.

FR: En cas d'echec de connexion OAuth2, redirige vers la page /login Vue en conservant tous les parametres OAuth2 et le nom d'utilisateur saisi, avec un code d'erreur que le frontend traduit en message francais. Couvre identifiants invalides, champs manquants, utilisateur bloque et role non autorise. Les erreurs serveur et protocole OAuth restent en JSON.