### PR TITLE
feat(nextjs-formulaire-hp): propagate GTM abtest1-5 slots from token

### DIFF
--- a/apps-microservices/nextjs-formulaire-hp/app/(flow)/questionnaire/questionnaire-client.tsx
+++ b/apps-microservices/nextjs-formulaire-hp/app/(flow)/questionnaire/questionnaire-client.tsx
@@ -13,7 +13,7 @@ import { useProcessMatching } from '@/hooks/api/useProcessMatching';
 import { usePriceEstimation } from '@/hooks/api/usePriceEstimation';
 import { hasDisplayablePriceEstimation } from '@/types/prix';
 import { setFunnelContext } from '@/lib/analytics';
-import type { CategoryTokenUrlData as UrlData } from '@/types/category-token';
+import { ABTEST_SLOTS, type CategoryTokenUrlData as UrlData } from '@/types/category-token';
 
 interface QuestionnaireClientProps {
   initialCategoryId?: string;
@@ -29,7 +29,7 @@ export default function QuestionnaireClient({
   initialDdc
 }: QuestionnaireClientProps) {
   const searchParams = useSearchParams();
-  const { setCategoryId, setDynamicAnswer, dynamicAnswers, addUserQuestionAnswer, setDdc, setMatchingTestParams, setAbtestUxLeadVersion, abtestUxLeadVersion, setAbtest2, setPageTemplateGtm, setFunnelContextValue, setPageLocationUri } = useFlowStore();
+  const { setCategoryId, setDynamicAnswer, dynamicAnswers, addUserQuestionAnswer, setDdc, setMatchingTestParams, setAbtestUxLeadVersion, abtestUxLeadVersion, setAbtest, setPageTemplateGtm, setFunnelContextValue, setPageLocationUri } = useFlowStore();
   const { goToSelection, goToSomethingToAdd, goToBudget } = useFlowNavigation();
   const { processMatching } = useProcessMatching();
   const { fetchPriceEstimation } = usePriceEstimation();
@@ -194,11 +194,15 @@ export default function QuestionnaireClient({
         setAbtestUxLeadVersion(urlData.abtest_UX_lead_version);
       }
 
-      // A/B test secondaire (token URL) : stocke dans le store + injecte dans le contexte GTM
-      // pour que tous les events devis_funnel_formulaire le portent.
-      if (typeof urlData.abtest2 === 'string' && urlData.abtest2.length > 0) {
-        setAbtest2(urlData.abtest2);
-        setFunnelContext({ abtest2: urlData.abtest2 });
+      // Slots A/B test GTM HelloPro abtest1..abtest5 (token URL) : stocke dans le
+      // store + injecte dans le contexte GTM pour que tous les events
+      // devis_funnel_formulaire les portent (omis si absents du token).
+      for (const slot of ABTEST_SLOTS) {
+        const slotValue = urlData[slot];
+        if (typeof slotValue === 'string' && slotValue.length > 0) {
+          setAbtest(slot, slotValue);
+          setFunnelContext({ [slot]: slotValue });
+        }
       }
 
       // 3 champs additionnels depuis le token chiffré : injectés dans le contexte GTM
@@ -254,7 +258,7 @@ export default function QuestionnaireClient({
 
     hasProcessedUrlData.current = true;
     setIsReady(true);
-  }, [isHydrated, initialUrlData, searchParams, dynamicAnswers, setDynamicAnswer, trackDbEvent, initialCategoryId, addUserQuestionAnswer, setAbtestUxLeadVersion, setAbtest2, setPageTemplateGtm, setFunnelContextValue, setPageLocationUri]);
+  }, [isHydrated, initialUrlData, searchParams, dynamicAnswers, setDynamicAnswer, trackDbEvent, initialCategoryId, addUserQuestionAnswer, setAbtestUxLeadVersion, setAbtest, setPageTemplateGtm, setFunnelContextValue, setPageLocationUri]);
 
   // Fin du questionnaire : lancer matching + prix en parallèle et afficher
   // l'étape transparence (email) — le loader ne s'affiche qu'au CTA.

--- a/apps-microservices/nextjs-formulaire-hp/app/api/category-token/route.ts
+++ b/apps-microservices/nextjs-formulaire-hp/app/api/category-token/route.ts
@@ -5,13 +5,15 @@ import { generateCategoryToken, validateCategoryToken } from '@/lib/category-tok
  * POST /api/category-token
  * Génère un token sécurisé pour une catégorie
  *
- * Body: { categoryId: number }
+ * Body: { categoryId: number, data?: object }
+ *   data (optionnel) : bloc `data` du payload chiffré, même contrat que le PHP
+ *   (Q1 pré-remplie, slots abtest1..5, page_template_gtm, funnel_context…)
  * Response: { token: string, url: string }
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { categoryId } = body;
+    const { categoryId, data } = body;
 
     if (!categoryId || typeof categoryId !== 'number' || categoryId <= 0) {
       return NextResponse.json(
@@ -20,7 +22,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const token = generateCategoryToken(categoryId);
+    if (data !== undefined && (typeof data !== 'object' || data === null || Array.isArray(data))) {
+      return NextResponse.json(
+        { error: 'data doit être un objet si fourni' },
+        { status: 400 }
+      );
+    }
+
+    const token = generateCategoryToken(categoryId, data);
     const baseUrl = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
     return NextResponse.json({

--- a/apps-microservices/nextjs-formulaire-hp/docs/GTM_EVENTS.md
+++ b/apps-microservices/nextjs-formulaire-hp/docs/GTM_EVENTS.md
@@ -56,7 +56,15 @@ Le funnel GTM repose sur **un événement principal** (`devis_funnel_formulaire`
   // Contexte funnel — setFunnelContext(...)
   rubrique_id: number,
   'product.category5': string,
-  abtest2?: string,           // optionnel — provient du token URL, omis si absent
+
+  // Slots A/B test GTM HelloPro (dimensions custom GA4) — depuis le bloc `data`
+  // du token URL chiffré, chaque slot présent est poussé tel quel, omis si absent
+  abtest1?: string,
+  abtest2?: string,
+  abtest3?: string,
+  abtest4?: string,
+  abtest5?: string,
+
   page_template?: string,     // optionnel — template GTM de la page d'entrée, depuis le token URL (champ `page_template_gtm` côté token, remappé en `page_template` pour le push)
   funnel_context?: string,    // optionnel — contexte funnel, depuis le token URL
   page_location_uri?: string, // optionnel — URI de la page d'entrée, depuis le token URL
@@ -71,6 +79,19 @@ Le funnel GTM repose sur **un événement principal** (`devis_funnel_formulaire`
   // + champs additionnels selon l'étape (cf. tableau ci-dessous)
 }
 ```
+
+**Contrat émetteur des slots A/B** : côté PHP, `generateCategoryToken($idCategorie, ['abtestN' => 'label_bras', ...])`
+(`FRONT/fonctions/fonctions_generales.php`) ; tout `abtest1`..`abtest5` présent dans le bloc `data` du token chiffré est
+propagé dans chaque event du funnel (source de vérité : `ABTEST_SLOTS` dans [types/category-token.ts](../types/category-token.ts)).
+Pour fabriquer un token de test côté Next : `POST /api/category-token` avec `{ categoryId, data: { abtest1: '...' } }`.
+
+**Réhydratation après full page load** : le contexte funnel (`funnelContext`) est une variable de module — perdue à
+chaque full page load. Le cas réel est le **back/forward navigateur** (le store persisté est conservé mais le re-parse
+du token est sauté quand Q1 est déjà répondue) ; le F5, lui, vide le store et redirige vers le token d'origine
+(comportement voulu de `flow-store`). Au premier event suivant, `trackQuoteFunnel` réhydrate le contexte depuis le
+store Zustand persisté (slots abtest1..5, `page_template`, `funnel_context`, `page_location_uri`, `rubrique_id`,
+`product.category5`) via `ensureFunnelContextFromStore()` ; les valeurs déjà posées dans le contexte priment sur
+celles du store.
 
 ### Types d'étapes (`step_type`)
 
@@ -388,7 +409,8 @@ Le composant `<Hotjar />` ([components/analytics/](../components/analytics)) cha
 ### Data Layer Variables
 
 - `step_name`, `step_type`, `step_index`, `step_number`
-- `flow_type`, `rubrique_id`, `product.category5`, `abtest2`
+- `flow_type`, `rubrique_id`, `product.category5`
+- `abtest1`, `abtest2`, `abtest3`, `abtest4`, `abtest5` (slots A/B partagés HelloPro, depuis le bloc `data` du token URL)
 - `page_template`, `funnel_context`, `page_location_uri` (depuis le token URL — `page_template` correspond au champ `page_template_gtm` du payload chiffré)
 - `conversion`, `profile_type`, `user_known_status`
 - `user_id`, `session_id`

--- a/apps-microservices/nextjs-formulaire-hp/lib/analytics/gtm.ts
+++ b/apps-microservices/nextjs-formulaire-hp/lib/analytics/gtm.ts
@@ -1,5 +1,8 @@
 // Global types are declared in types/global.d.ts
 
+import { ABTEST_SLOTS, type AbtestSlot } from '@/types/category-token';
+import { useFlowStore } from '@/lib/stores/flow-store';
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -8,10 +11,9 @@ type StepType = 'init' | 'question' | 'localisation' | 'choix-propart' | 'select
 
 type FlowType = 'principal' | 'pas_assez_produits' | 'pas_trouve_recherchez' | 'budget_ne_correspond_pas' | null;
 
-interface FunnelContext {
+interface FunnelContext extends Partial<Record<AbtestSlot, string>> {
   rubrique_id?: number;
   'product.category5'?: string;
-  abtest2?: string;
   page_template_gtm?: string;
   funnel_context?: string;
   page_location_uri?: string;
@@ -111,6 +113,7 @@ export function resetTrackingState(): void {
   funnelContext = {};
   currentStepIndex = 0;
   currentFlowType = null;
+  contextHydratedFromStore = false;
 }
 
 /**
@@ -153,11 +156,45 @@ function getDeviceInfo() {
 let funnelContext: FunnelContext = {};
 let currentFlowType: FlowType = null;
 
+// Garde one-shot de la réhydratation du contexte depuis le store persisté
+let contextHydratedFromStore = false;
+
 /**
  * Initialiser le contexte du funnel (à appeler au début)
  */
 export function setFunnelContext(context: FunnelContext) {
   funnelContext = { ...funnelContext, ...context };
+}
+
+/**
+ * Réhydrate le contexte funnel depuis le store Zustand persisté (sessionStorage).
+ * funnelContext est une variable de module : tout full page load la vide. Le cas
+ * réel est le back/forward navigateur (le store est conservé mais le re-parse du
+ * token est sauté quand Q1 est déjà répondue) — le F5, lui, vide le store et
+ * redirige vers le token d'origine (cf. flow-store). Appelé en lazy au premier
+ * event pour couvrir tous les points d'entrée — les valeurs déjà posées (token
+ * frais) priment sur celles du store.
+ */
+function ensureFunnelContextFromStore(): void {
+  if (contextHydratedFromStore || typeof window === 'undefined') return;
+  contextHydratedFromStore = true;
+
+  try {
+    const { abtests, pageTemplateGtm, funnelContextValue, pageLocationUri, categoryId, categoryName } =
+      useFlowStore.getState();
+
+    funnelContext = {
+      ...abtests,
+      ...(pageTemplateGtm && { page_template_gtm: pageTemplateGtm }),
+      ...(funnelContextValue && { funnel_context: funnelContextValue }),
+      ...(pageLocationUri && { page_location_uri: pageLocationUri }),
+      ...(categoryId && { rubrique_id: categoryId }),
+      ...(categoryName && { 'product.category5': categoryName }),
+      ...funnelContext,
+    };
+  } catch {
+    // Store indisponible : contexte inchangé
+  }
 }
 
 /**
@@ -195,6 +232,8 @@ export function trackQuoteFunnel(
   stepType: StepType,
   additionalData?: Record<string, unknown>
 ) {
+  ensureFunnelContextFromStore();
+
   const userId = getUserId();
   const sessionId = getSessionId();
 
@@ -208,8 +247,10 @@ export function trackQuoteFunnel(
     rubrique_id: funnelContext.rubrique_id,
     'product.category5': funnelContext['product.category5'],
 
-    // A/B test secondaire (token URL) — omis si absent
-    ...(funnelContext.abtest2 && { abtest2: funnelContext.abtest2 }),
+    // Slots A/B test GTM HelloPro abtest1..abtest5 (token URL) — omis si absents
+    ...Object.fromEntries(
+      ABTEST_SLOTS.filter((slot) => funnelContext[slot]).map((slot) => [slot, funnelContext[slot]])
+    ),
 
     // Champs additionnels token URL — omis si absent.
     // Note : `page_template_gtm` du token est pousse sous la cle `page_template` dans le dataLayer.

--- a/apps-microservices/nextjs-formulaire-hp/lib/category-token.ts
+++ b/apps-microservices/nextjs-formulaire-hp/lib/category-token.ts
@@ -14,6 +14,7 @@ interface TokenPayload {
   c: number;    // id_categorie
   d: string;    // date (YYYY-MM-DD)
   t: number;    // timestamp (pour unicité supplémentaire)
+  data?: Record<string, unknown>; // bloc data optionnel (Q1 pré-remplie, abtest1..5, page_template_gtm…)
 }
 
 interface TokenValidationResult {
@@ -96,17 +97,22 @@ function isDateValid(dateStr: string): boolean {
  * Le token est différent à chaque génération grâce à l'IV aléatoire
  *
  * @param categoryId - L'ID de la catégorie à encoder
+ * @param data - Bloc `data` optionnel, même contrat que le PHP generateCategoryToken()
+ *               (fonctions_generales.php) : Q1 pré-remplie, slots abtest1..5,
+ *               page_template_gtm, funnel_context, page_location_uri…
  * @returns Le token URL-safe (complètement différent à chaque appel)
  *
  * @example
  * const token = generateCategoryToken(123);
+ * const tokenAb = generateCategoryToken(123, { abtest4: 'mon-bras-B' });
  * // → "xYz...différent à chaque appel"
  */
-export function generateCategoryToken(categoryId: number): string {
+export function generateCategoryToken(categoryId: number, data?: Record<string, unknown>): string {
   const payload: TokenPayload = {
     c: categoryId,
     d: getTodayDate(),
     t: Date.now(),
+    ...(data && Object.keys(data).length > 0 && { data }),
   };
 
   if (!TOKEN_SECRET) {

--- a/apps-microservices/nextjs-formulaire-hp/lib/stores/flow-store.ts
+++ b/apps-microservices/nextjs-formulaire-hp/lib/stores/flow-store.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import type { ContactFormData, ProfileData, UserAnswers, Supplier } from '@/types';
 import type { CharacteristicsMap } from '@/types/characteristics';
 import type { PriceEstimationState } from '@/types/prix';
+import type { AbtestSlot } from '@/types/category-token';
 
 // =============================================================================
 // STORAGE WRAPPER - Gère le reset sur reload (F5) et changement manuel d'URL
@@ -198,9 +199,10 @@ export interface FlowState {
   // Version A/B test piloté par le token URL (champ abtest_UX_lead_version du payload décrypté)
   abtestUxLeadVersion: number | null;
 
-  // A/B test secondaire piloté par le token URL (champ abtest2 du payload décrypté).
-  // String libre injecté dans tous les events GTM devis_funnel_formulaire.
-  abtest2: string | null;
+  // Slots A/B test GTM HelloPro pilotés par le token URL (champs abtest1..abtest5
+  // du payload décrypté). Strings libres injectés dans tous les events GTM
+  // devis_funnel_formulaire (omis si absents).
+  abtests: Partial<Record<AbtestSlot, string>>;
 
   // 3 champs additionnels piloté par le token URL, injectés dans tous les events
   // GTM devis_funnel_formulaire (omis si absent). Naming côté token et GTM en
@@ -326,7 +328,7 @@ export interface FlowState {
   // Actions
   setCategoryId: (id: number) => void;
   setAbtestUxLeadVersion: (value: number | null) => void;
-  setAbtest2: (value: string | null) => void;
+  setAbtest: (slot: AbtestSlot, value: string) => void;
   setPageTemplateGtm: (value: string | null) => void;
   setFunnelContextValue: (value: string | null) => void;
   setPageLocationUri: (value: string | null) => void;
@@ -369,7 +371,7 @@ export interface FlowState {
 const initialState = {
   categoryId: null,
   abtestUxLeadVersion: null as number | null,
-  abtest2: null as string | null,
+  abtests: {} as Partial<Record<AbtestSlot, string>>,
   pageTemplateGtm: null as string | null,
   funnelContextValue: null as string | null,
   pageLocationUri: null as string | null,
@@ -416,7 +418,7 @@ export const useFlowStore = create<FlowState>()(
 
       setAbtestUxLeadVersion: (value) => set({ abtestUxLeadVersion: value }),
 
-      setAbtest2: (value) => set({ abtest2: value }),
+      setAbtest: (slot, value) => set((state) => ({ abtests: { ...state.abtests, [slot]: value } })),
 
       setPageTemplateGtm: (value) => set({ pageTemplateGtm: value }),
 

--- a/apps-microservices/nextjs-formulaire-hp/types/category-token.ts
+++ b/apps-microservices/nextjs-formulaire-hp/types/category-token.ts
@@ -1,15 +1,22 @@
 /**
+ * Slots A/B test GTM partagés HelloPro (dimensions custom GA4 abtest1..abtest5).
+ * Tout slot présent dans le bloc `data` du token chiffré est propagé dans chaque
+ * event GTM devis_funnel_formulaire du funnel (omis si absent).
+ */
+export const ABTEST_SLOTS = ['abtest1', 'abtest2', 'abtest3', 'abtest4', 'abtest5'] as const;
+export type AbtestSlot = (typeof ABTEST_SLOTS)[number];
+
+/**
  * Données URL injectées dans le payload chiffré du token catégorie.
  * Source de vérité unique partagée entre :
  *  - le middleware Edge (déchiffrement AES-256-CBC)
  *  - le client React (parsing du query param urlData)
  */
-export interface CategoryTokenUrlData {
+export interface CategoryTokenUrlData extends Partial<Record<AbtestSlot, string>> {
   id_question: number;
   id_reponse: number;
   equivalence: unknown[];
   abtest_UX_lead_version?: number;
-  abtest2?: string;
   page_template_gtm?: string;
   funnel_context?: string;
   page_location_uri?: string;


### PR DESCRIPTION
EN: any abtest1..abtest5 slot present in the encrypted token's data block is now stored (Zustand) and pushed on every devis_funnel_formulaire GTM event (omitted when absent). Funnel context is lazily rehydrated from the persisted store on full page loads (browser back/forward), and the Node token generator + POST /api/category-token accept an optional data block (PHP parity) to forge test tokens. GTM_EVENTS.md updated accordingly.

FR: tout slot abtest1..abtest5 present dans le bloc data du token chiffre est stocke (Zustand) et pousse sur chaque event GTM devis_funnel_formulaire (omis si absent). Le contexte funnel est rehydrate en lazy depuis le store persiste apres un full page load (back/forward navigateur), et le generateur de token Node + POST /api/category-token acceptent un bloc data optionnel (parite PHP) pour fabriquer des tokens de test. Doc GTM_EVENTS.md mise a jour.